### PR TITLE
Remove pricing mentions from website, focus on free pilot

### DIFF
--- a/client/src/components/sections/ContactForm.tsx
+++ b/client/src/components/sections/ContactForm.tsx
@@ -85,7 +85,7 @@ export default function ContactForm() {
     },
     {
       icon: <TrendingUp className="w-5 h-5" />,
-      title: "Proven ROI",
+      title: "Proven Impact",
       description: "200%+ engagement increase",
     },
   ];
@@ -413,11 +413,10 @@ export default function ContactForm() {
                       </div>
                       <div>
                         <h4 className="font-bold text-lg">
-                          Industry Leader Pricing
+                          Exclusive Early Access
                         </h4>
                         <p className="text-sm opacity-80 leading-relaxed">
-                          Lock in exclusive early adopter rates before our
-                          public launch
+                          Get exclusive access and benefits as an early participant in our free pilot program.
                         </p>
                       </div>
                     </div>
@@ -529,7 +528,6 @@ export default function ContactForm() {
                     <div className="text-sm text-slate-500 mb-8">
                       <p>• Check your email for confirmation</p>
                       <p>• Priority access secured</p>
-                      <p>• Early adopter pricing locked in</p>
                     </div>
                     <Button
                       className="bg-gradient-to-r from-indigo-600 to-violet-600 hover:from-indigo-700 hover:to-violet-700 px-8 py-3 font-semibold"

--- a/client/src/pages/Discover.tsx
+++ b/client/src/pages/Discover.tsx
@@ -541,7 +541,7 @@ const steps = [
     description:
       "Reserve your spot for priority access to Blueprint's AR platform",
     benefits: [
-      "50% early adopter discount",
+      "Free 14-day pilot access",
       "Priority support",
       "Custom onboarding",
     ],
@@ -726,7 +726,7 @@ export default function Discover() {
                 </div>
                 <div className="flex items-center gap-2">
                   <CheckCircle2 className="w-5 h-5 text-green-500" />
-                  <span>ROI guaranteed</span>
+                  <span>Impact Guaranteed</span>
                 </div>
               </motion.div>
             </motion.div>

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -46,10 +46,10 @@ export default function Home() {
       icon: <Users className="w-6 h-6 md:w-8 md:h-8" />,
       title: "Join Waitlist",
       description:
-        "Secure your spot in our exclusive early access program. Priority onboarding and special pricing available.",
+        "Secure your spot in our exclusive early access program. Priority onboarding for our free pilot program available.",
       benefits: [
         "Priority access",
-        "Early adopter pricing",
+        "Free 14-day pilot",
         "Dedicated support",
       ],
       color: "from-emerald-500 to-teal-600",
@@ -376,7 +376,7 @@ export default function Home() {
                 className="text-lg px-10 py-6 font-semibold border-2 border-slate-300 text-slate-700 hover:bg-slate-50 hover:border-slate-400 transition-all duration-300"
                 onClick={handleScrollToContactForm}
               >
-                See Pricing & Get Started
+                Learn More & Get Started
                 <ArrowDown className="w-5 h-5 ml-2" />
               </Button>
             </motion.div>

--- a/client/src/pages/PilotProgram.jsx
+++ b/client/src/pages/PilotProgram.jsx
@@ -277,7 +277,7 @@ export default function PilotProgram() {
     },
     {
       q: "What happens after the 14-day pilot?",
-      a: "You'll have three options: 1) Continue with a full deployment (monthly plans start at $599), 2) Take a break and come back when ready, or 3) Simply say thanks but no thanks. There's absolutely no pressure. We'll also provide a complete analytics report showing the impact on your business metrics.",
+      a: "You'll have three options: 1) Discuss future options with our team, 2) Take a break and come back when ready, or 3) Simply say thanks but no thanks. There's absolutely no pressure. We'll also provide a complete analytics report showing the impact on your business metrics.",
     },
     {
       q: "How do customers access the AR experience?",


### PR DESCRIPTION
This commit updates the Home, PilotProgram, Discover, and ContactForm components to remove any language related to pricing, payments, or specific discounts. The messaging has been changed to emphasize the current offering of a 14-day free pilot program where there is no option to pay afterwards.

Key changes:
- Replaced 'special pricing', 'early adopter pricing/discount/rates' with 'free pilot program' or similar.
- Changed 'See Pricing & Get Started' to 'Learn More & Get Started'.
- Removed mention of 'monthly plans start at $599' in PilotProgram FAQ.
- Changed 'ROI guaranteed' and 'Proven ROI' to 'Impact Guaranteed' and 'Proven Impact' respectively to reduce financial implications.
- Updated ContactForm sidebar and success message to remove pricing references.