### PR TITLE
feat: Implement lazy loading and provide optimization guidance

### DIFF
--- a/client/src/components/BlueprintImage.jsx
+++ b/client/src/components/BlueprintImage.jsx
@@ -57,6 +57,7 @@ const BlueprintImage = ({ blueprint }) => {
         onError={handleImageError}
         onLoad={handleImageLoad}
         style={{ display: isLoading ? "none" : "block" }}
+        loading="lazy"
       />
 
       {/* Fallback content when no image is available */}

--- a/client/src/components/sections/LocationShowcase.jsx
+++ b/client/src/components/sections/LocationShowcase.jsx
@@ -251,6 +251,7 @@ export default function LocationShowcase() {
                   }
                   alt={currentLocation.name}
                   className="w-full h-full object-cover"
+                  loading="lazy"
                 />
                 <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/20 to-transparent">
                   <div className="absolute bottom-6 left-6 text-white">
@@ -281,6 +282,7 @@ export default function LocationShowcase() {
                   }
                   alt={`AR-enhanced ${currentLocation.name}`}
                   className="w-full h-full object-cover"
+                  loading="lazy"
                 />
                 <div className="absolute inset-0 bg-gradient-to-t from-indigo-900/80 via-indigo-900/30 to-transparent">
                   <div className="absolute bottom-6 left-6 text-white">

--- a/client/src/pages/Discover.tsx
+++ b/client/src/pages/Discover.tsx
@@ -478,6 +478,7 @@ const ImageCarousel = () => {
               animate={{ opacity: 1, scale: 1 }}
               exit={{ opacity: 0, scale: 0.95 }}
               transition={{ duration: 0.7 }}
+              loading="lazy"
             />
           </AnimatePresence>
 


### PR DESCRIPTION
I've implemented lazy loading for images to improve initial page load performance and reduce upfront data transfer.

Key changes:
- I added the `loading="lazy"` attribute to `<img>` tags in:
    - `client/src/components/BlueprintImage.jsx`
    - The `ImageCarousel` component within `client/src/pages/Discover.tsx`
    - `client/src/components/sections/LocationShowcase.jsx`

This change defers the loading of off-screen images until they are about to enter the viewport.

Additionally, I:
- Investigated browser caching mechanisms and have provided recommendations for server-side `Cache-Control` header configuration to further reduce redundant image downloads.
- Offered guidance on image optimization techniques (compression, modern formats like WebP, responsive images) to reduce asset sizes.
- Reviewed Framer Motion animations, confirming standard practices and their synergy with lazy loading.