### PR TITLE
Register toast listener once

### DIFF
--- a/client/src/hooks/use-toast.ts
+++ b/client/src/hooks/use-toast.ts
@@ -177,7 +177,7 @@ function useToast() {
         listeners.splice(index, 1);
       }
     };
-  }, [state]);
+  }, []);
 
   return {
     ...state,

--- a/client/tests/hooks/use-toast.test.tsx
+++ b/client/tests/hooks/use-toast.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { useToast, toast } from '@/hooks/use-toast';
+
+function TestComponent() {
+  const { toasts } = useToast();
+  return <div data-testid="count">{toasts.length}</div>;
+}
+
+describe('useToast hook', () => {
+  it('propagates toast updates to subscribers', () => {
+    render(<TestComponent />);
+    expect(screen.getByTestId('count').textContent).toBe('0');
+
+    act(() => {
+      toast({ description: 'Hello' });
+    });
+
+    expect(screen.getByTestId('count').textContent).toBe('1');
+  });
+});


### PR DESCRIPTION
## Summary
- Avoid redundant toast listener registrations by running useToast effect once.
- Add regression test to ensure toast updates propagate to subscribers.

## Testing
- `npx vitest run` *(fails: invalid hook call in ContactForm.test.tsx, Nav.test.jsx)*
- `npx vitest run client/tests/hooks/use-toast.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_688f8149d6308323a3af23c7387c1696