### PR TITLE
Clarify Nav test helper usage

### DIFF
--- a/client/tests/components/sections/Nav.test.jsx
+++ b/client/tests/components/sections/Nav.test.jsx
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 
-// Import the actual Nav component and the getInitials function
-import Nav, { getInitials as getInitialsInternal } from '@/components/Nav'; // Assuming getInitials is exported or accessible
+// Import the Nav component. It doesn't export getInitials, so we define a helper below for tests.
+import Nav from '@/components/Nav';
 
 // Mock dependencies used by Nav component
 vi.mock('@/hooks/use-toast', () => ({
@@ -25,12 +25,7 @@ vi.mock('wouter', () => ({
 }));
 
 
-// If getInitials is not directly exported, copy its logic here for testing
-// For this exercise, we'll assume it's exported or we test it via component rendering if needed.
-// If it was a named export from Nav.jsx:
-// import { getInitials } from '@/components/Nav';
-
-// If getInitials is NOT exported, we copy the function here for unit testing:
+// Nav doesn't export getInitials, so copy its logic here for unit testing.
 const getInitials = (name) => {
   if (!name) return "";
   return name
@@ -44,12 +39,12 @@ const getInitials = (name) => {
 
 
 describe('Nav Component', () => {
-  // Placeholder for Nav component rendering tests
+  // Basic Nav component rendering test
   it('should render login/signup buttons if no currentUser', () => {
     render(<Nav />);
     expect(screen.getByText('Sign In')).toBeInTheDocument();
   });
-  // Add more Nav component specific tests here later if needed
+  // Additional Nav component tests can be added here later if needed
 
   describe('getInitials() utility function', () => {
     it('should return correct initials for a two-word name', () => {


### PR DESCRIPTION
## Summary
- clarify Nav test comment to note local getInitials helper
- remove unused internal getInitials import
- tidy comments in Nav component test suite

## Testing
- `npx vitest run client/tests/components/sections/Nav.test.jsx` *(fails: Cannot read properties of null (reading 'useState'))*

------
https://chatgpt.com/codex/tasks/task_e_688f815668dc8323af898debc58d03ab