### PR TITLE
Trigger Lindy webhooks after blueprint activation and scale update

### DIFF
--- a/client/src/pages/BlueprintEditor.tsx
+++ b/client/src/pages/BlueprintEditor.tsx
@@ -3227,6 +3227,26 @@ export default function BlueprintEditor() {
           });
         }
 
+        try {
+          await fetch(
+            "https://public.lindy.ai/api/v1/webhooks/lindy/eadb6b53-64c0-450d-85c1-71cf4d2ce749",
+            {
+              method: "POST",
+              headers: {
+                Authorization:
+                  "Bearer 1b1338d68dff4f009bbfaee1166cb9fc48b5fefa6dddbea797264674e2ee0150",
+                "Content-Type": "application/json",
+              },
+              body: JSON.stringify({
+                blueprint_id: blueprintId,
+                status: "active",
+              }),
+            },
+          );
+        } catch (err) {
+          console.error("Error triggering Lindy webhook:", err);
+        }
+
         // Update local state
         setBlueprintStatus("active");
       }

--- a/client/src/pages/ScannerPortal.tsx
+++ b/client/src/pages/ScannerPortal.tsx
@@ -467,6 +467,43 @@ export default function ScannerPortal() {
         await updateDoc(doc(db, "blueprints", selectedBooking.blueprintId), {
           scale: scaleFactor,
         });
+        let companyName = selectedBooking.businessName || "";
+        try {
+          const blueprintSnap = await getDoc(
+            doc(db, "blueprints", selectedBooking.blueprintId),
+          );
+          if (blueprintSnap.exists()) {
+            const data = blueprintSnap.data();
+            companyName =
+              data.locationName ||
+              data.businessName ||
+              data.name ||
+              companyName;
+          }
+        } catch (err) {
+          console.error("Error fetching blueprint info for webhook:", err);
+        }
+        try {
+          await fetch(
+            "https://public.lindy.ai/api/v1/webhooks/lindy/0a0433bc-9930-4a1e-9734-5912316f4a6c",
+            {
+              method: "POST",
+              headers: {
+                Authorization:
+                  "Bearer 1b1338d68dff4f009bbfaee1166cb9fc48b5fefa6dddbea797264674e2ee0150",
+                "Content-Type": "application/json",
+              },
+              body: JSON.stringify({
+                blueprint_id: selectedBooking.blueprintId,
+                scale: scaleFactor,
+                company_name: companyName,
+                location_name: companyName,
+              }),
+            },
+          );
+        } catch (err) {
+          console.error("Error triggering Lindy webhook:", err);
+        }
         console.log("Scale factor saved to Firestore:", scaleFactor);
       }
 


### PR DESCRIPTION
## Summary
- call Lindy webhook when a blueprint is activated in the editor
- call Lindy webhook when scale value is saved in the Scanner Portal and include the blueprint's company/location name

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx vitest` *(fails: ContactForm/Nav tests and network errors)*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_688f861788f08323aaecad41983f0188