### PR TITLE
Use Blueprint logo across navigation and editor

### DIFF
--- a/client/src/components/Footer.jsx
+++ b/client/src/components/Footer.jsx
@@ -101,18 +101,11 @@ export default function Footer() {
           {/* Brand/Company */}
           <motion.div variants={itemVariants} className="md:col-span-4">
             <div className="flex items-center gap-3 mb-4">
-              <div className="w-10 h-10 rounded-lg bg-gradient-to-br from-indigo-600 to-violet-600 flex items-center justify-center">
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  viewBox="0 0 24 24"
-                  fill="currentColor"
-                  className="w-6 h-6"
-                >
-                  <path d="M11.7 2.805a.75.75 0 01.6 0A60.65 60.65 0 0122.83 8.72a.75.75 0 01-.231 1.337 49.949 49.949 0 00-9.902 3.912l-.003.002-.34.18a.75.75 0 01-.707 0A50.009 50.009 0 007.5 12.174v-.224c0-.131.067-.248.172-.311a54.614 54.614 0 014.653-2.52.75.75 0 00-.65-1.352 56.129 56.129 0 00-4.78 2.589 1.858 1.858 0 00-.859 1.228 49.803 49.803 0 00-4.634-1.527.75.75 0 01-.231-1.337A60.653 60.653 0 0111.7 2.805z" />
-                  <path d="M13.06 15.473a48.45 48.45 0 017.666-3.282c.134 1.414.22 2.843.255 4.285a.75.75 0 01-.46.71 47.878 47.878 0 00-8.105 4.342.75.75 0 01-.832 0 47.877 47.877 0 00-8.104-4.342.75.75 0 01-.461-.71c.035-1.442.121-2.87.255-4.286A48.4 48.4 0 016 13.18v1.27a1.5 1.5 0 00-.14 2.508c-.09.38-.222.753-.397 1.11.452.213.901.434 1.346.661a6.729 6.729 0 00.551-1.608 1.5 1.5 0 00.14-2.67v-.645a48.549 48.549 0 013.44 1.668 2.25 2.25 0 002.12 0z" />
-                  <path d="M4.462 19.462c.42-.419.753-.89 1-1.394.453.213.902.434 1.347.661a6.743 6.743 0 01-1.286 1.794.75.75 0 11-1.06-1.06z" />
-                </svg>
-              </div>
+                <img
+                  src="/gradientBPLogo.ico"
+                  alt="Blueprint logo"
+                  className="w-10 h-10 rounded-lg"
+                />
               <h3 className="text-2xl font-bold bg-gradient-to-r from-blue-300 to-indigo-300 inline-block text-transparent bg-clip-text">
                 Blueprint
               </h3>

--- a/client/src/components/Nav.jsx
+++ b/client/src/components/Nav.jsx
@@ -112,23 +112,15 @@ export default function Nav({
       <div className="flex items-center justify-between h-full w-full px-6 md:px-8 lg:px-12">
         {/* Enhanced brand logo */}
         <div className="flex items-center">
-          <Link href="/" className="flex items-center space-x-3 group">
-            <div
-              className={`w-11 h-11 rounded-xl bg-gradient-to-br from-indigo-600 via-violet-600 to-fuchsia-600 flex items-center justify-center transition-all duration-300 shadow-lg group-hover:shadow-indigo-300/50 ${
-                isScrolled ? "scale-95" : ""
-              }`}
-            >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 24 24"
-                fill="white"
-                className="w-6 h-6"
-              >
-                <path d="M11.7 2.805a.75.75 0 01.6 0A60.65 60.65 0 0122.83 8.72a.75.75 0 01-.231 1.337 49.949 49.949 0 00-9.902 3.912l-.003.002-.34.18a.75.75 0 01-.707 0A50.009 50.009 0 007.5 12.174v-.224c0-.131.067-.248.172-.311a54.614 54.614 0 014.653-2.52.75.75 0 00-.65-1.352 56.129 56.129 0 00-4.78 2.589 1.858 1.858 0 00-.859 1.228 49.803 49.803 0 00-4.634-1.527.75.75 0 01-.231-1.337A60.653 60.653 0 0111.7 2.805z" />
-                <path d="M13.06 15.473a48.45 48.45 0 017.666-3.282c.134 1.414.22 2.843.255 4.285a.75.75 0 01-.46.71 47.878 47.878 0 00-8.105 4.342.75.75 0 01-.832 0 47.877 47.877 0 00-8.104-4.342.75.75 0 01-.461-.71c.035-1.442.121-2.87.255-4.286A48.4 48.4 0 016 13.18v1.27a1.5 1.5 0 00-.14 2.508c-.09.38-.222.753-.397 1.11.452.213.901.434 1.346.661a6.729 6.729 0 00.551-1.608 1.5 1.5 0 00.14-2.67v-.645a48.549 48.549 0 013.44 1.668 2.25 2.25 0 002.12 0z" />
-              </svg>
-            </div>
-            <span
+            <Link href="/" className="flex items-center space-x-3 group">
+              <img
+                src="/gradientBPLogo.ico"
+                alt="Blueprint logo"
+                className={`w-11 h-11 rounded-xl transition-all duration-300 shadow-lg group-hover:shadow-indigo-300/50 ${
+                  isScrolled ? "scale-95" : ""
+                }`}
+              />
+              <span
               className={`text-2xl font-black transition-all duration-300 ${
                 isScrolled
                   ? "bg-gradient-to-r from-slate-800 to-slate-600 bg-clip-text text-transparent"

--- a/client/src/pages/BlueprintEditor.tsx
+++ b/client/src/pages/BlueprintEditor.tsx
@@ -197,7 +197,6 @@ import {
   Square,
   Palette,
   Library,
-  Landmark,
   ChevronsUpDown,
   MoreHorizontal,
   UserPlus,
@@ -1625,10 +1624,14 @@ export default function BlueprintEditor() {
       <div className="fixed inset-0 bg-white z-50 flex flex-col">
         {/* Header */}
         <div className="border-b py-4 px-6 flex justify-between items-center bg-white">
-          <div className="flex items-center">
-            <Landmark className="h-6 w-6 text-indigo-500 mr-2" />
-            <span className="font-semibold text-xl">Blueprint</span>
-          </div>
+            <div className="flex items-center">
+              <img
+                src="/gradientBPLogo.ico"
+                alt="Blueprint logo"
+                className="h-6 w-6 mr-2"
+              />
+              <span className="font-semibold text-xl">Blueprint</span>
+            </div>
           <Badge className="bg-indigo-100 text-indigo-800">
             Feature Setup {currentFeatureIndex + 1} of {selectedFeatures.length}
           </Badge>
@@ -2338,7 +2341,11 @@ export default function BlueprintEditor() {
             {/* Header */}
             <div className="sticky top-0 z-10 border-b py-3 px-4 bg-white flex justify-between items-center">
               <div className="flex items-center">
-                <Landmark className="h-5 w-5 text-indigo-500 mr-1.5" />
+                <img
+                  src="/gradientBPLogo.ico"
+                  alt="Blueprint logo"
+                  className="h-5 w-5 mr-1.5"
+                />
                 <span className="font-semibold">Blueprint Setup</span>
               </div>
               <Badge className="bg-indigo-100 text-indigo-800">
@@ -2852,10 +2859,14 @@ export default function BlueprintEditor() {
           <div className="fixed inset-0 bg-white z-50 flex flex-col">
             {/* Header */}
             <div className="border-b py-4 px-6 flex justify-between items-center bg-white">
-              <div className="flex items-center">
-                <Landmark className="h-6 w-6 text-indigo-500 mr-2" />
-                <span className="font-semibold text-xl">Blueprint</span>
-              </div>
+                <div className="flex items-center">
+                  <img
+                    src="/gradientBPLogo.ico"
+                    alt="Blueprint logo"
+                    className="h-6 w-6 mr-2"
+                  />
+                  <span className="font-semibold text-xl">Blueprint</span>
+                </div>
               <Badge className="bg-indigo-100 text-indigo-800">
                 Step {onboardingStep} of 5
               </Badge>
@@ -5750,7 +5761,11 @@ export default function BlueprintEditor() {
               if (e.key === "Enter" || e.key === " ") navigateToDashboard();
             }} // Added keyboard handler
           >
-            <Landmark className="h-5 w-5 text-indigo-500 group-hover:text-indigo-600 transition-colors" />{" "}
+            <img
+              src="/gradientBPLogo.ico"
+              alt="Blueprint logo"
+              className="h-5 w-5"
+            />{" "}
             {/* Added hover effect */}
             <span className="font-semibold text-lg group-hover:text-indigo-700 transition-colors">
               Blueprint


### PR DESCRIPTION
## Summary
- replace nav and footer icons with Blueprint logo
- swap landmark icons in Blueprint Editor headers with Blueprint logo for consistent branding

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_688fb24f6a1083239dd259525c87dc63