### PR TITLE
fix: avoid window reference in checkout session

### DIFF
--- a/client/src/pages/api/create-checkout-session/route.ts
+++ b/client/src/pages/api/create-checkout-session/route.ts
@@ -17,6 +17,12 @@ export default async function handler(req: Request, res: Response) {
 
     const stripe = new Stripe(stripeSecretKey);
 
+    // Determine the base URL for redirects. `window.location.origin` isn't
+    // available in a server environment, so fall back to the request's origin
+    // header or a sensible default.
+    const baseUrl =
+      process.env.NEXT_PUBLIC_BASE_URL ?? req.headers.origin ?? "http://localhost:3000";
+
     // Create Stripe checkout session
     const session = await stripe.checkout.sessions.create({
       payment_method_types: ["card"],
@@ -39,8 +45,8 @@ export default async function handler(req: Request, res: Response) {
         hours: hours.toString(),
         costPerHour: costPerHour.toString(),
       },
-      success_url: `${process.env.NEXT_PUBLIC_BASE_URL || window.location.origin}/pricing?success=true&session_id={CHECKOUT_SESSION_ID}`,
-      cancel_url: `${process.env.NEXT_PUBLIC_BASE_URL || window.location.origin}/pricing?canceled=true`,
+      success_url: `${baseUrl}/pricing?success=true&session_id={CHECKOUT_SESSION_ID}`,
+      cancel_url: `${baseUrl}/pricing?canceled=true`,
     });
 
     return res.json({ sessionId: session.id });


### PR DESCRIPTION
## Summary
- use request origin when constructing Stripe redirect URLs to avoid server-side window reference

## Testing
- `npm test`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_688fe0c8dcc483238bf1d516b41a567b