### PR TITLE
Add styled legal pages and update footer links

### DIFF
--- a/Blueprint-WebApp/client/src/components/Footer.jsx
+++ b/Blueprint-WebApp/client/src/components/Footer.jsx
@@ -199,7 +199,7 @@ export default function Footer() {
               </li>
               <li>
                 <a
-                  href="#"
+                  href="/privacy"
                   className="text-gray-400 hover:text-white transition-colors duration-300 flex items-center"
                 >
                   <span className="w-1.5 h-1.5 rounded-full bg-indigo-400 mr-2"></span>
@@ -208,7 +208,7 @@ export default function Footer() {
               </li>
               <li>
                 <a
-                  href="#"
+                  href="/terms"
                   className="text-gray-400 hover:text-white transition-colors duration-300 flex items-center"
                 >
                   <span className="w-1.5 h-1.5 rounded-full bg-indigo-400 mr-2"></span>
@@ -349,13 +349,13 @@ export default function Footer() {
           </p>
           <div className="mt-4 md:mt-0 flex justify-center md:justify-end space-x-6">
             <a
-              href="#"
+              href="/privacy"
               className="text-sm text-gray-500 hover:text-gray-300 transition-colors duration-300"
             >
               Privacy Policy
             </a>
             <a
-              href="#"
+              href="/terms"
               className="text-sm text-gray-500 hover:text-gray-300 transition-colors duration-300"
             >
               Terms of Service

--- a/Blueprint-WebApp/client/src/main.tsx
+++ b/Blueprint-WebApp/client/src/main.tsx
@@ -31,6 +31,8 @@ import Settings from "./pages/Settings";
 import ScannerPortal from "./pages/ScannerPortal";
 import AcceptInvite from "./pages/AcceptInvite";
 import PilotProgram from "./pages/PilotProgram";
+import Privacy from "./pages/Privacy";
+import Terms from "./pages/Terms";
 
 function Router() {
   return (
@@ -51,6 +53,8 @@ function Router() {
       <Route path="/scanner-portal" component={ScannerPortal} />
       <Route path="/accept-invite" component={AcceptInvite} />
       <Route path="/pilot-program" component={PilotProgram} />
+      <Route path="/privacy" component={Privacy} />
+      <Route path="/terms" component={Terms} />
 
       {/* Protected Routes */}
       <Route path="/create-blueprint">

--- a/Blueprint-WebApp/client/src/pages/Privacy.tsx
+++ b/Blueprint-WebApp/client/src/pages/Privacy.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import Nav from "@/components/Nav";
+import Footer from "@/components/Footer";
+
+export default function Privacy() {
+  return (
+    <div className="min-h-screen flex flex-col bg-gradient-to-b from-white to-indigo-50">
+      <Nav />
+      <main className="flex-1 w-full max-w-3xl mx-auto px-6 py-24 text-slate-700">
+        <h1 className="text-4xl font-bold text-center mb-8 bg-gradient-to-r from-indigo-600 to-blue-600 bg-clip-text text-transparent">
+          Privacy Policy
+        </h1>
+        <section className="prose prose-slate max-w-none space-y-6">
+          <p>
+            Your privacy is important to us. This policy outlines how Blueprint
+            collects, uses, and protects your information when you use our
+            services.
+          </p>
+          <p>
+            We only collect data necessary to deliver and improve the Blueprint
+            experience. We never sell your data and we strive to use industry
+            best practices to safeguard the information you share with us.
+          </p>
+          <p>
+            If you have any questions about this policy, please contact us at
+            <a href="mailto:support@blueprint.com"> support@blueprint.com </a>.
+          </p>
+        </section>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/Blueprint-WebApp/client/src/pages/Terms.tsx
+++ b/Blueprint-WebApp/client/src/pages/Terms.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import Nav from "@/components/Nav";
+import Footer from "@/components/Footer";
+
+export default function Terms() {
+  return (
+    <div className="min-h-screen flex flex-col bg-gradient-to-b from-white to-indigo-50">
+      <Nav />
+      <main className="flex-1 w-full max-w-3xl mx-auto px-6 py-24 text-slate-700">
+        <h1 className="text-4xl font-bold text-center mb-8 bg-gradient-to-r from-indigo-600 to-blue-600 bg-clip-text text-transparent">
+          Terms & Conditions
+        </h1>
+        <section className="prose prose-slate max-w-none space-y-6">
+          <p>
+            By using Blueprint's services, you agree to the following terms and
+            conditions. Please read them carefully.
+          </p>
+          <p>
+            We provide our platform on an "as is" basis and may update these terms
+            from time to time. Continued use of the service constitutes acceptance
+            of any changes.
+          </p>
+          <p>
+            If you have questions about these terms, please contact
+            <a href="mailto:support@blueprint.com"> support@blueprint.com </a>.
+          </p>
+        </section>
+      </main>
+      <Footer />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add new Privacy Policy and Terms & Conditions pages styled to match the latest UI.
- Link privacy and terms pages in the footer and router.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: openai not defined, mapping-confirmation errors)*
- `npx vitest run` *(fails: missing setup.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68955146d60c8323961c2498c190b550