### PR TITLE
Ensure buttons and inputs use black text

### DIFF
--- a/client/src/components/CloudUpload.tsx
+++ b/client/src/components/CloudUpload.tsx
@@ -207,10 +207,20 @@ const CloudUpload: React.FC<CloudUploadProps> = ({ onFileSelect }) => {
 
   return (
     <div className="flex gap-2 mt-2 flex-wrap">
-      <Button variant="outline" size="sm" onClick={handleGoogleDrive}>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={handleGoogleDrive}
+        className="text-black"
+      >
         Connect Google Drive
       </Button>
-      <Button variant="outline" size="sm" onClick={handleOneDrive}>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={handleOneDrive}
+        className="text-black"
+      >
         Connect OneDrive
       </Button>
     </div>

--- a/client/src/components/ui/button.tsx
+++ b/client/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium text-black ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {

--- a/client/src/components/ui/input.tsx
+++ b/client/src/components/ui/input.tsx
@@ -11,7 +11,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-black ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         ref={ref}

--- a/client/src/components/ui/textarea.tsx
+++ b/client/src/components/ui/textarea.tsx
@@ -10,7 +10,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     return (
       <textarea
         className={cn(
-          "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-black ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         ref={ref}

--- a/client/src/pages/BlueprintEditor.tsx
+++ b/client/src/pages/BlueprintEditor.tsx
@@ -6126,7 +6126,7 @@ export default function BlueprintEditor() {
                             </h2>
                             <div className="flex items-center gap-2 mb-3">
                               <div className="relative flex-1">
-                                <Search className="h-4 w-4 absolute left-2.5 top-2.5 text-muted-foreground" />
+                                <Search className="h-4 w-4 absolute left-2.5 top-2.5 text-black" />
                                 <Input
                                   placeholder="Search models..."
                                   className="pl-9"
@@ -6142,8 +6142,9 @@ export default function BlueprintEditor() {
                                 onClick={() =>
                                   modelFileInputRef.current?.click()
                                 }
+                                className="text-black"
                               >
-                                <Upload className="h-4 w-4" />
+                                <Upload className="h-4 w-4 text-black" />
                               </Button>
                               <input
                                 type="file"
@@ -7581,7 +7582,7 @@ export default function BlueprintEditor() {
                   threeViewerRef.current?.enterWalkMode();
                 }
               }}
-              className="gap-2 bg-background/80 backdrop-blur-sm hover:bg-muted/90 px-3 py-2 h-auto rounded-md shadow"
+              className="gap-2 bg-background/80 backdrop-blur-sm hover:bg-muted/90 px-3 py-2 h-auto rounded-md shadow text-black"
               title={isWalkMode ? "Exit Walk Mode" : "Enter Walk Mode"}
             >
               <PersonStanding className="h-6 w-6" />
@@ -7592,7 +7593,7 @@ export default function BlueprintEditor() {
               variant="ghost"
               size="sm"
               onClick={() => setShowTextAnchors(!showTextAnchors)}
-              className="gap-2 bg-background/80 backdrop-blur-sm hover:bg-muted/90 px-3 py-2 h-auto rounded-md shadow"
+              className="gap-2 bg-background/80 backdrop-blur-sm hover:bg-muted/90 px-3 py-2 h-auto rounded-md shadow text-black"
               title={
                 showTextAnchors ? "Hide Text Anchors" : "Show Text Anchors"
               }
@@ -7610,7 +7611,7 @@ export default function BlueprintEditor() {
               variant="ghost"
               size="sm"
               onClick={() => setShowFileAnchors(!showFileAnchors)}
-              className="gap-2 bg-background/80 backdrop-blur-sm hover:bg-muted/90 px-3 py-2 h-auto rounded-md shadow"
+              className="gap-2 bg-background/80 backdrop-blur-sm hover:bg-muted/90 px-3 py-2 h-auto rounded-md shadow text-black"
               title={
                 showFileAnchors ? "Hide File Anchors" : "Show File Anchors"
               }
@@ -7628,7 +7629,7 @@ export default function BlueprintEditor() {
               variant="ghost"
               size="sm"
               onClick={() => setShowWebpageAnchors(!showWebpageAnchors)}
-              className="gap-1.5 bg-background/80 backdrop-blur-sm hover:bg-muted/90 px-2 py-1 h-auto rounded-md shadow"
+              className="gap-1.5 bg-background/80 backdrop-blur-sm hover:bg-muted/90 px-2 py-1 h-auto rounded-md shadow text-black"
               title={
                 showWebpageAnchors
                   ? "Hide Webpage Anchors"
@@ -7648,7 +7649,7 @@ export default function BlueprintEditor() {
               variant="ghost"
               size="sm"
               onClick={() => setShowModelAnchors(!showModelAnchors)}
-              className="gap-2 bg-background/80 backdrop-blur-sm hover:bg-muted/90 px-3 py-2 h-auto rounded-md shadow"
+              className="gap-2 bg-background/80 backdrop-blur-sm hover:bg-muted/90 px-3 py-2 h-auto rounded-md shadow text-black"
               title={
                 showModelAnchors
                   ? "Hide 3D Model Anchors"
@@ -7668,7 +7669,7 @@ export default function BlueprintEditor() {
               variant="ghost"
               size="sm"
               onClick={() => setShowQrCodes(!showQrCodes)}
-              className="gap-2 bg-background/80 backdrop-blur-sm hover:bg-muted/90 px-3 py-2 h-auto rounded-md shadow"
+              className="gap-2 bg-background/80 backdrop-blur-sm hover:bg-muted/90 px-3 py-2 h-auto rounded-md shadow text-black"
               title={
                 showQrCodes ? "Hide QR Code Anchors" : "Show QR Code Anchors"
               }


### PR DESCRIPTION
## Summary
- Default buttons and form fields now render black text for better contrast
- Search bar and upload controls use black icons and text
- Bottom-right editor controls explicitly style text and icons as black

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6898baacbe2483238423eda6d8d72b80