### PR TITLE
feat: add editor tour and simplify onboarding

### DIFF
--- a/client/src/components/onboarding/BlueprintEditorTour.tsx
+++ b/client/src/components/onboarding/BlueprintEditorTour.tsx
@@ -1,0 +1,64 @@
+import React, { useState } from "react";
+import { BlueprintTooltip } from "@/components/onboarding/BlueprintTooltip";
+
+interface TourProps {
+  onFinish: () => void;
+}
+
+const steps = [
+  {
+    title: "Welcome to the Editor",
+    description:
+      "This is the Blueprint Editor. Here you can navigate your 3D space and add interactive elements.",
+  },
+  {
+    title: "Mark Areas",
+    description:
+      "Use the Mark Areas tool to highlight important locations within your space.",
+  },
+  {
+    title: "Elements Panel",
+    description:
+      "Add text, media and links using the elements panel on the left side.",
+  },
+  {
+    title: "Activation",
+    description:
+      "When you're ready, activate your Blueprint to make it live.",
+  },
+];
+
+export const BlueprintEditorTour: React.FC<TourProps> = ({ onFinish }) => {
+  const [step, setStep] = useState(0);
+
+  const next = () => {
+    if (step < steps.length - 1) {
+      setStep(step + 1);
+    } else {
+      onFinish();
+    }
+  };
+
+  const skip = () => {
+    onFinish();
+  };
+
+  const current = steps[step];
+
+  return (
+    <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/40">
+      <BlueprintTooltip
+        title={current.title}
+        description={current.description}
+        onNext={next}
+        onSkip={skip}
+        currentStep={step}
+        totalSteps={steps.length}
+        isFirstStep={step === 0}
+        isLastStep={step === steps.length - 1}
+      />
+    </div>
+  );
+};
+
+export default BlueprintEditorTour;

--- a/client/src/pages/BlueprintEditor.tsx
+++ b/client/src/pages/BlueprintEditor.tsx
@@ -9,6 +9,7 @@ import { useAuth } from "@/contexts/AuthContext";
 import { useToast } from "@/hooks/use-toast";
 import { ToastAction } from "@/components/ui/toast";
 import ViewModeToggle from "@/components/ViewModeToggle";
+import { BlueprintEditorTour } from "@/components/onboarding/BlueprintEditorTour";
 //import WorkflowEditor from "@/components/WorkflowEditor";cl
 import { QRCodeCanvas } from "qrcode.react";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -395,9 +396,15 @@ export default function BlueprintEditor() {
   const { toast } = useToast();
 
   const [blueprintScale, setBlueprintScale] = useState<number>(34.85);
-  // Onboarding states - ADD THESE
-  const [showOnboarding, setShowOnboarding] = useState(true);
-  const [onboardingStep, setOnboardingStep] = useState(1);
+  // Legacy onboarding disabled; use simple tour instead
+  const [showOnboarding, setShowOnboarding] = useState(false);
+  const [onboardingStep, setOnboardingStep] = useState(0);
+  const [showTour, setShowTour] = useState<boolean>(() => {
+    if (typeof window !== "undefined") {
+      return !localStorage.getItem("blueprint_editor_tour_completed");
+    }
+    return true;
+  });
   // Define interfaces for onboarding data
   interface AreaItem {
     id: string;
@@ -8724,7 +8731,16 @@ export default function BlueprintEditor() {
             </DialogFooter>
           </DialogContent>
         </Dialog>
-        {showOnboarding && <InteractiveOnboarding />}
+        {showTour && (
+          <BlueprintEditorTour
+            onFinish={() => {
+              if (typeof window !== "undefined") {
+                localStorage.setItem("blueprint_editor_tour_completed", "true");
+              }
+              setShowTour(false);
+            }}
+          />
+        )}
         <Dialog open={showShareDialog} onOpenChange={setShowShareDialog}>
           <DialogContent>
             <DialogHeader>


### PR DESCRIPTION
## Summary
- disable legacy blueprint onboarding and launch viewer with a lightweight tour
- add BlueprintEditorTour component for a skippable UI walkthrough

## Testing
- `npm test` (fails: Missing script)
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68990b219aa083238e12aa298e73eed6