### PR TITLE
Restrict Google sign-in to existing accounts

### DIFF
--- a/Blueprint-WebApp/client/src/contexts/AuthContext.tsx
+++ b/Blueprint-WebApp/client/src/contexts/AuthContext.tsx
@@ -153,6 +153,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       const user = await firebaseSignInWithGoogle();
       console.log("User signed in with Google successfully:", user.uid);
       const userData = await getUserData(user.uid);
+      if (!userData) {
+        await logOut();
+        const error: any = new Error("No account found with this email");
+        error.code = "auth/user-not-found";
+        throw error;
+      }
       setUserData(userData);
     } catch (error: any) {
       console.error("Google sign in error:", {

--- a/Blueprint-WebApp/client/src/lib/firebase.ts
+++ b/Blueprint-WebApp/client/src/lib/firebase.ts
@@ -248,7 +248,6 @@ export const signInWithGoogle = async () => {
 
   try {
     const result = await signInWithPopup(auth, googleProvider);
-    await createUserDocument(result.user);
     console.log("Google sign in successful:", result.user.uid);
     return result.user;
   } catch (error: any) {

--- a/client/src/contexts/AuthContext.tsx
+++ b/client/src/contexts/AuthContext.tsx
@@ -153,6 +153,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       const user = await firebaseSignInWithGoogle();
       console.log("User signed in with Google successfully:", user.uid);
       const userData = await getUserData(user.uid);
+      if (!userData) {
+        await logOut();
+        const error: any = new Error("No account found with this email");
+        error.code = "auth/user-not-found";
+        throw error;
+      }
       setUserData(userData);
     } catch (error: any) {
       console.error("Google sign in error:", {

--- a/client/src/lib/firebase.ts
+++ b/client/src/lib/firebase.ts
@@ -248,7 +248,6 @@ export const signInWithGoogle = async () => {
 
   try {
     const result = await signInWithPopup(auth, googleProvider);
-    await createUserDocument(result.user);
     console.log("Google sign in successful:", result.user.uid);
     return result.user;
   } catch (error: any) {


### PR DESCRIPTION
## Summary
- Only allow Google sign-in for emails already in the user database
- Prompt unregistered users to join the pilot program from the sign-in page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689915945e5c832388231f415dafafec