### PR TITLE
Open pilot program call links in a new tab

### DIFF
--- a/Blueprint-WebApp/client/src/pages/PilotProgram.jsx
+++ b/Blueprint-WebApp/client/src/pages/PilotProgram.jsx
@@ -1150,7 +1150,11 @@ export default function PilotProgram() {
                 className="bg-gradient-to-r from-indigo-600 to-violet-600 text-white hover:from-indigo-700 hover:to-violet-700"
                 asChild
               >
-                <a href="https://calendly.com/blueprintar/30min">
+                <a
+                  href="https://calendly.com/blueprintar/30min"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
                   Schedule a Call
                   <ArrowRight className="ml-2 w-5 h-5" />
                 </a>

--- a/client/src/pages/PilotProgram.jsx
+++ b/client/src/pages/PilotProgram.jsx
@@ -1726,6 +1726,8 @@ export default function PilotProgram() {
                   <a
                     href="https://calendly.com/blueprintar/30min"
                     aria-label="Schedule a call with Blueprint"
+                    target="_blank"
+                    rel="noopener noreferrer"
                   >
                     Schedule a Call
                     <ArrowRight className="ml-2 w-5 h-5" />


### PR DESCRIPTION
## Summary
- Open "Schedule a Call" links in Pilot Program pages in a new browser tab using `target="_blank"` and `rel="noopener noreferrer"`.

## Testing
- `npm test` (fails: Missing script "test")
- `npx vitest run` (fails: Invalid hook call / google is not defined)
- `npx vitest run client/tests/pages/PilotProgram.test.jsx Blueprint-WebApp/client/tests/pages/PilotProgram.test.jsx`


------
https://chatgpt.com/codex/tasks/task_e_6899236c4b988323b8612e9469b7365d