### PR TITLE
style: refresh help page ui

### DIFF
--- a/client/src/pages/Help.tsx
+++ b/client/src/pages/Help.tsx
@@ -256,15 +256,15 @@ export default function Help() {
 
   return (
     <>
-      <div className="min-h-screen bg-gradient-to-b from-blue-50 to-indigo-50">
+      <div className="min-h-screen flex flex-col bg-[#0B1220] text-slate-100">
         <Nav />
 
         {/* Hero Section */}
         <div className="relative pt-24 pb-12 overflow-hidden">
           {/* Animated background blobs */}
-          <div className="absolute top-32 left-10 w-96 h-96 bg-purple-200 rounded-full mix-blend-multiply filter blur-3xl opacity-20 animate-blob"></div>
-          <div className="absolute top-40 right-10 w-96 h-96 bg-blue-300 rounded-full mix-blend-multiply filter blur-3xl opacity-20 animate-blob animation-delay-2000"></div>
-          <div className="absolute -bottom-8 left-1/2 w-96 h-96 bg-indigo-200 rounded-full mix-blend-multiply filter blur-3xl opacity-20 animate-blob animation-delay-4000"></div>
+          <div className="absolute top-32 left-10 w-96 h-96 rounded-full blur-3xl opacity-30 bg-gradient-to-br from-emerald-500/30 via-cyan-500/25 to-sky-500/10 animate-blob"></div>
+          <div className="absolute top-40 right-10 w-96 h-96 rounded-full blur-3xl opacity-20 bg-gradient-to-tr from-cyan-500/20 via-emerald-500/20 to-sky-500/10 animate-blob animation-delay-2000"></div>
+          <div className="absolute -bottom-8 left-1/2 w-96 h-96 rounded-full blur-3xl opacity-20 bg-gradient-to-tr from-sky-500/20 via-emerald-500/15 to-amber-400/10 animate-blob animation-delay-4000"></div>
 
           <div className="container mx-auto px-6 relative z-10">
             <motion.div
@@ -273,10 +273,12 @@ export default function Help() {
               transition={{ duration: 0.8 }}
               className="text-center max-w-3xl mx-auto"
             >
-              <h1 className="text-4xl md:text-5xl font-extrabold text-transparent bg-clip-text bg-gradient-to-r from-blue-600 to-indigo-700 mb-4">
-                We're Here To Help
+              <h1 className="text-4xl md:text-5xl font-extrabold mb-4">
+                <span className="bg-gradient-to-r from-emerald-400 via-cyan-300 to-emerald-200 bg-clip-text text-transparent">
+                  We're Here To Help
+                </span>
               </h1>
-              <p className="text-lg md:text-xl text-gray-700 mb-8">
+              <p className="text-lg md:text-xl text-slate-300 mb-8">
                 Need to reschedule your mapping session or have questions about
                 Blueprint? Our team is ready to assist you every step of the
                 way.
@@ -290,27 +292,27 @@ export default function Help() {
               className="grid grid-cols-1 md:grid-cols-3 gap-6 mt-12"
             >
               <motion.div variants={item}>
-                <Card className="bg-white/80 backdrop-blur-sm border-0 shadow-lg hover:shadow-xl transition-all duration-300 hover:-translate-y-1">
+                <Card className="bg-white/5 backdrop-blur border border-white/10 shadow-xl hover:border-white/20 transition-all duration-300 hover:-translate-y-1">
                   <CardHeader className="pb-2">
-                    <div className="w-12 h-12 rounded-full bg-blue-100 flex items-center justify-center mb-4">
-                      <CalendarIcon2 className="w-6 h-6 text-blue-600" />
+                    <div className="w-12 h-12 rounded-full bg-emerald-500/10 flex items-center justify-center mb-4">
+                      <CalendarIcon2 className="w-6 h-6 text-emerald-300" />
                     </div>
-                    <CardTitle className="text-xl font-bold">
+                    <CardTitle className="text-xl font-bold text-white">
                       Reschedule
                     </CardTitle>
-                    <CardDescription>
+                    <CardDescription className="text-slate-400">
                       Change your mapping session date and time
                     </CardDescription>
                   </CardHeader>
                   <CardContent>
-                    <p className="text-gray-600">
+                    <p className="text-slate-300">
                       Need a different time? No problem. Reschedule your 3D
                       mapping session to a more convenient time.
                     </p>
                   </CardContent>
                   <CardFooter>
                     <Button
-                      className="bg-blue-600 hover:bg-blue-700 text-white w-full"
+                      className="w-full bg-gradient-to-r from-emerald-500 to-cyan-600 text-white border-0 hover:from-emerald-400 hover:to-cyan-500"
                       onClick={() => setActiveTab("reschedule")}
                     >
                       Reschedule Now
@@ -320,25 +322,25 @@ export default function Help() {
               </motion.div>
 
               <motion.div variants={item}>
-                <Card className="bg-white/80 backdrop-blur-sm border-0 shadow-lg hover:shadow-xl transition-all duration-300 hover:-translate-y-1">
+                <Card className="bg-white/5 backdrop-blur border border-white/10 shadow-xl hover:border-white/20 transition-all duration-300 hover:-translate-y-1">
                   <CardHeader className="pb-2">
-                    <div className="w-12 h-12 rounded-full bg-purple-100 flex items-center justify-center mb-4">
-                      <HelpCircle className="w-6 h-6 text-purple-600" />
+                    <div className="w-12 h-12 rounded-full bg-cyan-500/10 flex items-center justify-center mb-4">
+                      <HelpCircle className="w-6 h-6 text-cyan-300" />
                     </div>
-                    <CardTitle className="text-xl font-bold">FAQ</CardTitle>
-                    <CardDescription>
+                    <CardTitle className="text-xl font-bold text-white">FAQ</CardTitle>
+                    <CardDescription className="text-slate-400">
                       Find answers to common questions
                     </CardDescription>
                   </CardHeader>
                   <CardContent>
-                    <p className="text-gray-600">
+                    <p className="text-slate-300">
                       Browse our comprehensive FAQ section for quick answers to
                       your Blueprint questions.
                     </p>
                   </CardContent>
                   <CardFooter>
                     <Button
-                      className="bg-purple-600 hover:bg-purple-700 text-white w-full"
+                      className="w-full bg-gradient-to-r from-emerald-500 to-cyan-600 text-white border-0 hover:from-emerald-400 hover:to-cyan-500"
                       onClick={() => setActiveTab("faq")}
                     >
                       View FAQs
@@ -348,27 +350,27 @@ export default function Help() {
               </motion.div>
 
               <motion.div variants={item}>
-                <Card className="bg-white/80 backdrop-blur-sm border-0 shadow-lg hover:shadow-xl transition-all duration-300 hover:-translate-y-1">
+                <Card className="bg-white/5 backdrop-blur border border-white/10 shadow-xl hover:border-white/20 transition-all duration-300 hover:-translate-y-1">
                   <CardHeader className="pb-2">
-                    <div className="w-12 h-12 rounded-full bg-green-100 flex items-center justify-center mb-4">
-                      <MessageCircle className="w-6 h-6 text-green-600" />
+                    <div className="w-12 h-12 rounded-full bg-purple-500/10 flex items-center justify-center mb-4">
+                      <MessageCircle className="w-6 h-6 text-purple-300" />
                     </div>
-                    <CardTitle className="text-xl font-bold">
+                    <CardTitle className="text-xl font-bold text-white">
                       Contact Us
                     </CardTitle>
-                    <CardDescription>
+                    <CardDescription className="text-slate-400">
                       Reach out to our support team
                     </CardDescription>
                   </CardHeader>
                   <CardContent>
-                    <p className="text-gray-600">
+                    <p className="text-slate-300">
                       Have a specific question? Our dedicated support team is
                       ready to help you.
                     </p>
                   </CardContent>
                   <CardFooter>
                     <Button
-                      className="bg-green-600 hover:bg-green-700 text-white w-full"
+                      className="w-full bg-gradient-to-r from-emerald-500 to-cyan-600 text-white border-0 hover:from-emerald-400 hover:to-cyan-500"
                       onClick={() => setActiveTab("contact")}
                     >
                       Contact Support
@@ -387,36 +389,45 @@ export default function Help() {
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.5, delay: 0.3 }}
           >
-            <Tabs
-              value={activeTab}
-              onValueChange={setActiveTab}
-              className="w-full"
-            >
-              <TabsList className="grid w-full grid-cols-3 mb-8">
-                <TabsTrigger value="reschedule" className="text-base">
-                  Reschedule
-                </TabsTrigger>
-                <TabsTrigger value="faq" className="text-base">
-                  FAQ
-                </TabsTrigger>
-                <TabsTrigger value="contact" className="text-base">
-                  Contact Us
-                </TabsTrigger>
-              </TabsList>
+              <Tabs
+                value={activeTab}
+                onValueChange={setActiveTab}
+                className="w-full"
+              >
+                <TabsList className="grid w-full grid-cols-3 mb-8 bg-white/5 p-1 rounded-lg">
+                  <TabsTrigger
+                    value="reschedule"
+                    className="text-base text-slate-300 data-[state=active]:bg-gradient-to-r data-[state=active]:from-emerald-500 data-[state=active]:to-cyan-600 data-[state=active]:text-white rounded-md"
+                  >
+                    Reschedule
+                  </TabsTrigger>
+                  <TabsTrigger
+                    value="faq"
+                    className="text-base text-slate-300 data-[state=active]:bg-gradient-to-r data-[state=active]:from-emerald-500 data-[state=active]:to-cyan-600 data-[state=active]:text-white rounded-md"
+                  >
+                    FAQ
+                  </TabsTrigger>
+                  <TabsTrigger
+                    value="contact"
+                    className="text-base text-slate-300 data-[state=active]:bg-gradient-to-r data-[state=active]:from-emerald-500 data-[state=active]:to-cyan-600 data-[state=active]:text-white rounded-md"
+                  >
+                    Contact Us
+                  </TabsTrigger>
+                </TabsList>
 
-              <TabsContent value="reschedule">
-                <motion.div
-                  initial={{ opacity: 0 }}
-                  animate={{ opacity: 1 }}
-                  exit={{ opacity: 0 }}
-                  transition={{ duration: 0.4 }}
-                  className="bg-white rounded-lg shadow-xl p-6 md:p-8"
-                >
-                  <h2 className="text-2xl font-bold text-gray-800 mb-6">
-                    Reschedule Your 3D Mapping Session
-                  </h2>
-                  <Form {...rescheduleForm}>
-                    <form
+                <TabsContent value="reschedule">
+                  <motion.div
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    exit={{ opacity: 0 }}
+                    transition={{ duration: 0.4 }}
+                    className="bg-white/5 backdrop-blur border border-white/10 rounded-lg p-6 md:p-8"
+                  >
+                    <h2 className="text-2xl font-bold text-white mb-6">
+                      Reschedule Your 3D Mapping Session
+                    </h2>
+                    <Form {...rescheduleForm}>
+                      <form
                       onSubmit={rescheduleForm.handleSubmit(onRescheduleSubmit)}
                       className="space-y-6"
                     >
@@ -427,12 +438,12 @@ export default function Help() {
                             name="reason"
                             render={({ field }) => (
                               <FormItem>
-                                <FormLabel className="text-gray-700 font-medium">
+                                <FormLabel className="text-slate-200 font-medium">
                                   Reason for rescheduling
                                 </FormLabel>
                                 <FormControl>
                                   <Select onValueChange={field.onChange}>
-                                    <SelectTrigger>
+                                    <SelectTrigger className="bg-slate-900/60 border-slate-700 text-slate-100">
                                       <SelectValue placeholder="Select a reason" />
                                     </SelectTrigger>
                                     <SelectContent>
@@ -464,7 +475,7 @@ export default function Help() {
                             name="date"
                             render={({ field }) => (
                               <FormItem className="flex flex-col">
-                                <FormLabel className="text-gray-700 font-medium">
+                                <FormLabel className="text-slate-200 font-medium">
                                   Select a new date
                                 </FormLabel>
                                 <Popover>
@@ -473,9 +484,9 @@ export default function Help() {
                                       <Button
                                         variant="outline"
                                         className={cn(
-                                          "pl-3 text-left font-normal",
+                                          "pl-3 text-left font-normal bg-slate-900/60 border-slate-700 text-slate-100",
                                           !field.value &&
-                                            "text-muted-foreground",
+                                            "text-slate-400",
                                         )}
                                       >
                                         {field.value ? (
@@ -521,7 +532,7 @@ export default function Help() {
                             name="time"
                             render={({ field }) => (
                               <FormItem>
-                                <FormLabel className="text-gray-700 font-medium">
+                                <FormLabel className="text-slate-200 font-medium">
                                   Select a new time
                                 </FormLabel>
                                 <FormControl>
@@ -538,7 +549,7 @@ export default function Help() {
                                         />
                                         <label
                                           htmlFor={`time-${time}`}
-                                          className="flex items-center justify-center px-3 py-2 text-sm border rounded-md peer-checked:bg-blue-50 peer-checked:border-blue-600 peer-checked:text-blue-600 cursor-pointer transition-all duration-200 hover:bg-gray-50"
+                                          className="flex items-center justify-center px-3 py-2 text-sm border border-slate-700 rounded-md text-slate-300 peer-checked:bg-emerald-500/20 peer-checked:border-emerald-500 peer-checked:text-emerald-300 cursor-pointer transition-all duration-200 hover:bg-slate-800"
                                         >
                                           {time}
                                         </label>
@@ -558,13 +569,13 @@ export default function Help() {
                             name="notes"
                             render={({ field }) => (
                               <FormItem>
-                                <FormLabel className="text-gray-700 font-medium">
+                                <FormLabel className="text-slate-200 font-medium">
                                   Additional notes (optional)
                                 </FormLabel>
                                 <FormControl>
                                   <Textarea
                                     placeholder="Any specific requirements or information for our team"
-                                    className="min-h-[200px]"
+                                    className="min-h-[200px] bg-slate-900/60 border-slate-700 text-slate-100"
                                     {...field}
                                   />
                                 </FormControl>
@@ -573,42 +584,42 @@ export default function Help() {
                             )}
                           />
 
-                          <div className="border-t border-gray-200 pt-4">
-                            <p className="text-sm text-gray-500 mb-4">
-                              By submitting this request, you agree to our
-                              rescheduling policy. We'll confirm your new
-                              appointment as soon as possible.
-                            </p>
-                            <Button
-                              type="submit"
-                              className="bg-blue-600 hover:bg-blue-700 text-white w-full"
-                            >
-                              Submit Rescheduling Request
-                            </Button>
+                            <div className="border-t border-white/10 pt-4">
+                              <p className="text-sm text-slate-400 mb-4">
+                                By submitting this request, you agree to our
+                                rescheduling policy. We'll confirm your new
+                                appointment as soon as possible.
+                              </p>
+                              <Button
+                                type="submit"
+                                className="w-full bg-gradient-to-r from-emerald-500 to-cyan-600 text-white border-0 hover:from-emerald-400 hover:to-cyan-500"
+                              >
+                                Submit Rescheduling Request
+                              </Button>
+                            </div>
                           </div>
                         </div>
-                      </div>
-                    </form>
-                  </Form>
-                </motion.div>
-              </TabsContent>
+                      </form>
+                    </Form>
+                  </motion.div>
+                </TabsContent>
 
-              <TabsContent value="faq">
-                <motion.div
-                  initial={{ opacity: 0 }}
-                  animate={{ opacity: 1 }}
-                  exit={{ opacity: 0 }}
-                  transition={{ duration: 0.4 }}
-                  className="bg-white rounded-lg shadow-xl p-6 md:p-8"
-                >
-                  <div className="flex items-center mb-8">
-                    <div className="w-10 h-10 rounded-full bg-purple-100 flex items-center justify-center mr-4">
-                      <BookOpen className="w-5 h-5 text-purple-600" />
+                <TabsContent value="faq">
+                  <motion.div
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    exit={{ opacity: 0 }}
+                    transition={{ duration: 0.4 }}
+                    className="bg-white/5 backdrop-blur border border-white/10 rounded-lg p-6 md:p-8"
+                  >
+                    <div className="flex items-center mb-8">
+                      <div className="w-10 h-10 rounded-full bg-emerald-500/10 flex items-center justify-center mr-4">
+                        <BookOpen className="w-5 h-5 text-emerald-300" />
+                      </div>
+                      <h2 className="text-2xl font-bold text-white">
+                        Frequently Asked Questions
+                      </h2>
                     </div>
-                    <h2 className="text-2xl font-bold text-gray-800">
-                      Frequently Asked Questions
-                    </h2>
-                  </div>
 
                   <div className="space-y-6">
                     {faqItems.map((item, index) => (
@@ -621,55 +632,56 @@ export default function Help() {
                     ))}
                   </div>
 
-                  <div className="mt-12 bg-purple-50 rounded-lg p-6 border border-purple-100">
-                    <h3 className="font-semibold text-purple-900 mb-2">
-                      Didn't find what you're looking for?
-                    </h3>
-                    <p className="text-purple-800 mb-4">
-                      Our support team is ready to help with any other questions
-                      you might have.
-                    </p>
-                    <Button
-                      onClick={() => setActiveTab("contact")}
-                      className="bg-purple-600 hover:bg-purple-700 text-white"
-                    >
-                      Contact Support
-                      <ArrowRight className="w-4 h-4 ml-2" />
-                    </Button>
-                  </div>
-                </motion.div>
-              </TabsContent>
+                    <div className="mt-12 bg-white/5 rounded-lg p-6 border border-white/10">
+                      <h3 className="font-semibold text-white mb-2">
+                        Didn't find what you're looking for?
+                      </h3>
+                      <p className="text-slate-300 mb-4">
+                        Our support team is ready to help with any other questions
+                        you might have.
+                      </p>
+                      <Button
+                        onClick={() => setActiveTab("contact")}
+                        className="bg-gradient-to-r from-emerald-500 to-cyan-600 text-white border-0 hover:from-emerald-400 hover:to-cyan-500"
+                      >
+                        Contact Support
+                        <ArrowRight className="w-4 h-4 ml-2" />
+                      </Button>
+                    </div>
+                  </motion.div>
+                </TabsContent>
 
               <TabsContent value="contact">
-                <motion.div
-                  initial={{ opacity: 0 }}
-                  animate={{ opacity: 1 }}
-                  exit={{ opacity: 0 }}
-                  transition={{ duration: 0.4 }}
-                >
-                  <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-                    <div className="md:col-span-2">
-                      <div className="bg-white rounded-lg shadow-xl p-6 md:p-8">
-                        <h2 className="text-2xl font-bold text-gray-800 mb-6">
-                          Contact Our Support Team
-                        </h2>
-                        <Form {...contactForm}>
-                          <form
-                            onSubmit={contactForm.handleSubmit(onContactSubmit)}
-                            className="space-y-6"
-                          >
+                  <motion.div
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    exit={{ opacity: 0 }}
+                    transition={{ duration: 0.4 }}
+                  >
+                    <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+                      <div className="md:col-span-2">
+                        <div className="bg-white/5 backdrop-blur border border-white/10 rounded-lg p-6 md:p-8">
+                          <h2 className="text-2xl font-bold text-white mb-6">
+                            Contact Our Support Team
+                          </h2>
+                          <Form {...contactForm}>
+                            <form
+                              onSubmit={contactForm.handleSubmit(onContactSubmit)}
+                              className="space-y-6"
+                            >
                             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                               <FormField
                                 control={contactForm.control}
                                 name="name"
                                 render={({ field }) => (
                                   <FormItem>
-                                    <FormLabel className="text-gray-700 font-medium">
+                                    <FormLabel className="text-slate-200 font-medium">
                                       Your Name
                                     </FormLabel>
                                     <FormControl>
                                       <Input
                                         placeholder="John Doe"
+                                        className="bg-slate-900/60 border-slate-700 text-slate-100 placeholder:text-slate-400"
                                         {...field}
                                       />
                                     </FormControl>
@@ -683,12 +695,13 @@ export default function Help() {
                                 name="email"
                                 render={({ field }) => (
                                   <FormItem>
-                                    <FormLabel className="text-gray-700 font-medium">
+                                    <FormLabel className="text-slate-200 font-medium">
                                       Email Address
                                     </FormLabel>
                                     <FormControl>
                                       <Input
                                         placeholder="your@email.com"
+                                        className="bg-slate-900/60 border-slate-700 text-slate-100 placeholder:text-slate-400"
                                         {...field}
                                       />
                                     </FormControl>
@@ -701,20 +714,20 @@ export default function Help() {
                             <FormField
                               control={contactForm.control}
                               name="issue"
-                              render={({ field }) => (
-                                <FormItem>
-                                  <FormLabel className="text-gray-700 font-medium">
-                                    Issue Type
-                                  </FormLabel>
-                                  <FormControl>
-                                    <Select onValueChange={field.onChange}>
-                                      <SelectTrigger>
-                                        <SelectValue placeholder="Select an issue type" />
-                                      </SelectTrigger>
-                                      <SelectContent>
-                                        <SelectItem value="technical">
-                                          Technical Support
-                                        </SelectItem>
+                                render={({ field }) => (
+                                  <FormItem>
+                                    <FormLabel className="text-slate-200 font-medium">
+                                      Issue Type
+                                    </FormLabel>
+                                    <FormControl>
+                                      <Select onValueChange={field.onChange}>
+                                        <SelectTrigger className="bg-slate-900/60 border-slate-700 text-slate-100">
+                                          <SelectValue placeholder="Select an issue type" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                          <SelectItem value="technical">
+                                            Technical Support
+                                          </SelectItem>
                                         <SelectItem value="billing">
                                           Billing Question
                                         </SelectItem>
@@ -740,13 +753,13 @@ export default function Help() {
                               name="message"
                               render={({ field }) => (
                                 <FormItem>
-                                  <FormLabel className="text-gray-700 font-medium">
+                                  <FormLabel className="text-slate-200 font-medium">
                                     Message
                                   </FormLabel>
                                   <FormControl>
                                     <Textarea
                                       placeholder="Please describe your issue or question in detail"
-                                      className="min-h-[150px]"
+                                      className="min-h-[150px] bg-slate-900/60 border-slate-700 text-slate-100"
                                       {...field}
                                     />
                                   </FormControl>
@@ -768,88 +781,88 @@ export default function Help() {
                               </div>
                             </div>
 
+                              <Button
+                                type="submit"
+                                className="bg-gradient-to-r from-emerald-500 to-cyan-600 text-white border-0 hover:from-emerald-400 hover:to-cyan-500"
+                              >
+                                Send Message
+                                <SendHorizontal className="w-4 h-4 ml-2" />
+                              </Button>
+                            </form>
+                          </Form>
+                        </div>
+                      </div>
+
+                      <div className="space-y-6">
+                        <Card className="bg-white/5 backdrop-blur border border-white/10">
+                          <CardHeader>
+                            <CardTitle className="text-lg font-semibold">
+                              Contact Information
+                            </CardTitle>
+                          </CardHeader>
+                          <CardContent className="space-y-4">
+                            <div className="flex items-center">
+                              <div className="w-8 h-8 rounded-full bg-emerald-500/10 flex items-center justify-center mr-3">
+                                <Mail className="w-4 h-4 text-emerald-300" />
+                              </div>
+                              <div>
+                                <p className="text-sm text-slate-400">Email</p>
+                                <p className="font-medium text-slate-200">
+                                  nijel@tryblueprint.io
+                                </p>
+                              </div>
+                            </div>
+
+                            <div className="flex items-center">
+                              <div className="w-8 h-8 rounded-full bg-cyan-500/10 flex items-center justify-center mr-3">
+                                <Phone className="w-4 h-4 text-cyan-300" />
+                              </div>
+                              <div>
+                                <p className="text-sm text-slate-400">Phone</p>
+                                <p className="font-medium text-slate-200">(800) 123-4567</p>
+                              </div>
+                            </div>
+
+                            <div className="flex items-center">
+                              <div className="w-8 h-8 rounded-full bg-purple-500/10 flex items-center justify-center mr-3">
+                                <Clock className="w-4 h-4 text-purple-300" />
+                              </div>
+                              <div>
+                                <p className="text-sm text-slate-400">
+                                  Support Hours
+                                </p>
+                                <p className="font-medium text-slate-200">
+                                  Monday - Friday: 9AM - 6PM EST
+                                </p>
+                              </div>
+                            </div>
+                          </CardContent>
+                        </Card>
+
+                        <Card className="bg-gradient-to-br from-emerald-500 to-cyan-600 text-white">
+                          <CardHeader>
+                            <CardTitle className="text-lg font-semibold">
+                              Start a Live Chat
+                            </CardTitle>
+                          </CardHeader>
+                          <CardContent>
+                            <p className="mb-4 text-slate-100/80">
+                              Get immediate assistance from our support agents via
+                              live chat.
+                            </p>
                             <Button
-                              type="submit"
-                              className="bg-green-600 hover:bg-green-700 text-white"
+                              variant="secondary"
+                              className="w-full bg-gradient-to-r from-emerald-500 to-cyan-600 text-white border-0 hover:from-emerald-400 hover:to-cyan-500"
+                              onClick={() => setLiveChat(true)}
                             >
-                              Send Message
-                              <SendHorizontal className="w-4 h-4 ml-2" />
+                              <MessageSquare className="w-4 h-4 mr-2" />
+                              Start Chat
                             </Button>
-                          </form>
-                        </Form>
+                          </CardContent>
+                        </Card>
                       </div>
                     </div>
-
-                    <div className="space-y-6">
-                      <Card className="bg-white shadow-lg border-0">
-                        <CardHeader>
-                          <CardTitle className="text-lg font-semibold">
-                            Contact Information
-                          </CardTitle>
-                        </CardHeader>
-                        <CardContent className="space-y-4">
-                          <div className="flex items-center">
-                            <div className="w-8 h-8 rounded-full bg-blue-100 flex items-center justify-center mr-3">
-                              <Mail className="w-4 h-4 text-blue-600" />
-                            </div>
-                            <div>
-                              <p className="text-sm text-gray-500">Email</p>
-                              <p className="font-medium">
-                                nijel@tryblueprint.io
-                              </p>
-                            </div>
-                          </div>
-
-                          <div className="flex items-center">
-                            <div className="w-8 h-8 rounded-full bg-green-100 flex items-center justify-center mr-3">
-                              <Phone className="w-4 h-4 text-green-600" />
-                            </div>
-                            <div>
-                              <p className="text-sm text-gray-500">Phone</p>
-                              <p className="font-medium">(800) 123-4567</p>
-                            </div>
-                          </div>
-
-                          <div className="flex items-center">
-                            <div className="w-8 h-8 rounded-full bg-purple-100 flex items-center justify-center mr-3">
-                              <Clock className="w-4 h-4 text-purple-600" />
-                            </div>
-                            <div>
-                              <p className="text-sm text-gray-500">
-                                Support Hours
-                              </p>
-                              <p className="font-medium">
-                                Monday - Friday: 9AM - 6PM EST
-                              </p>
-                            </div>
-                          </div>
-                        </CardContent>
-                      </Card>
-
-                      <Card className="bg-gradient-to-br from-indigo-500 to-blue-600 text-white shadow-lg border-0">
-                        <CardHeader>
-                          <CardTitle className="text-lg font-semibold">
-                            Start a Live Chat
-                          </CardTitle>
-                        </CardHeader>
-                        <CardContent>
-                          <p className="mb-4 text-blue-100">
-                            Get immediate assistance from our support agents via
-                            live chat.
-                          </p>
-                          <Button
-                            variant="secondary"
-                            className="w-full bg-white text-blue-600 hover:bg-blue-50"
-                            onClick={() => setLiveChat(true)}
-                          >
-                            <MessageSquare className="w-4 h-4 mr-2" />
-                            Start Chat
-                          </Button>
-                        </CardContent>
-                      </Card>
-                    </div>
-                  </div>
-                </motion.div>
+                  </motion.div>
               </TabsContent>
             </Tabs>
           </motion.div>
@@ -862,16 +875,16 @@ export default function Help() {
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: 20 }}
-              className="fixed bottom-6 right-6 w-96 bg-white rounded-lg shadow-2xl overflow-hidden z-50"
+              className="fixed bottom-6 right-6 w-96 bg-slate-900/90 text-slate-100 border border-white/10 rounded-lg shadow-2xl overflow-hidden z-50"
             >
-              <div className="bg-blue-600 text-white p-4 flex justify-between items-center">
+              <div className="bg-gradient-to-r from-emerald-500 to-cyan-600 text-white p-4 flex justify-between items-center">
                 <div className="flex items-center">
                   <MessageCircle className="w-5 h-5 mr-2" />
                   <h3 className="font-semibold">Blueprint Support</h3>
                 </div>
                 <button
                   onClick={() => setLiveChat(false)}
-                  className="text-white hover:text-blue-200 transition-colors"
+                  className="text-white hover:text-white/80 transition-colors"
                 >
                   <X className="w-5 h-5" />
                 </button>
@@ -888,10 +901,10 @@ export default function Help() {
                     <div
                       className={`inline-block rounded-lg px-4 py-2 max-w-xs ${
                         msg.sender === "user"
-                          ? "bg-blue-500 text-white"
+                          ? "bg-emerald-500 text-white"
                           : msg.sender === "agent"
-                            ? "bg-green-500 text-white"
-                            : "bg-gray-100 text-gray-800"
+                            ? "bg-cyan-500 text-white"
+                            : "bg-slate-800 text-slate-200"
                       }`}
                     >
                       {msg.message}
@@ -901,14 +914,14 @@ export default function Help() {
                 <div ref={chatEndRef} />
               </div>
 
-              <form onSubmit={handleSendMessage} className="border-t p-4 flex">
+              <form onSubmit={handleSendMessage} className="border-t border-white/10 p-4 flex bg-slate-900/95">
                 <Input
                   value={chatInput}
                   onChange={(e) => setChatInput(e.target.value)}
                   placeholder="Type your message..."
-                  className="flex-grow mr-2"
+                  className="flex-grow mr-2 bg-slate-800 border-slate-700 text-slate-100 placeholder:text-slate-400"
                 />
-                <Button type="submit" className="bg-blue-600 text-white">
+                <Button type="submit" className="bg-gradient-to-r from-emerald-500 to-cyan-600 text-white border-0 hover:from-emerald-400 hover:to-cyan-500">
                   <SendHorizontal className="w-4 h-4" />
                 </Button>
               </form>
@@ -927,24 +940,24 @@ function FaqItem({ question, answer, index }) {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
-    <motion.div
-      initial={{ opacity: 0, y: 10 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ delay: index * 0.1 }}
-      className="border-b border-gray-200 pb-4"
-    >
-      <button
-        onClick={() => setIsOpen(!isOpen)}
-        className="flex justify-between items-center w-full text-left py-2 focus:outline-none"
+      <motion.div
+        initial={{ opacity: 0, y: 10 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: index * 0.1 }}
+        className="border-b border-white/10 pb-4"
       >
-        <h3 className="text-lg font-medium text-gray-800">{question}</h3>
-        <motion.div
-          animate={{ rotate: isOpen ? 180 : 0 }}
-          transition={{ duration: 0.3 }}
+        <button
+          onClick={() => setIsOpen(!isOpen)}
+          className="flex justify-between items-center w-full text-left py-2 focus:outline-none"
         >
-          <ChevronDown className="w-5 h-5 text-gray-500" />
-        </motion.div>
-      </button>
+          <h3 className="text-lg font-medium text-white">{question}</h3>
+          <motion.div
+            animate={{ rotate: isOpen ? 180 : 0 }}
+            transition={{ duration: 0.3 }}
+          >
+            <ChevronDown className="w-5 h-5 text-slate-400" />
+          </motion.div>
+        </button>
       <AnimatePresence>
         {isOpen && (
           <motion.div
@@ -954,10 +967,10 @@ function FaqItem({ question, answer, index }) {
             transition={{ duration: 0.3 }}
             className="overflow-hidden"
           >
-            <p className="text-gray-600 pt-2 pb-2 pl-1">{answer}</p>
-          </motion.div>
-        )}
-      </AnimatePresence>
-    </motion.div>
+              <p className="text-slate-300 pt-2 pb-2 pl-1">{answer}</p>
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </motion.div>
   );
 }


### PR DESCRIPTION
## Summary
- restyle Help page with dark aurora theme and gradient accents
- align cards, tabs, and chat with emerald/cyan color scheme

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689dfbf3a86083239b0802f81edf257f