### PR TITLE
Align legal pages with dark theme

### DIFF
--- a/client/src/pages/PrivacyPolicy.tsx
+++ b/client/src/pages/PrivacyPolicy.tsx
@@ -64,30 +64,32 @@ export default function PrivacyPolicy() {
         <meta name="robots" content="index, follow" />
       </Helmet>
 
-      <div className="min-h-screen bg-gray-50 py-12">
-        <motion.div
-          className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8"
-          initial="initial"
-          animate="animate"
-          variants={fadeInUp}
-        >
+      <div className="min-h-screen flex flex-col bg-[#0B1220] text-slate-100">
+        <Nav />
+        <main className="flex-grow py-12">
+          <motion.div
+            className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8"
+            initial="initial"
+            animate="animate"
+            variants={fadeInUp}
+          >
           {/* Header */}
           <div className="text-center mb-12">
-            <h1 className="text-4xl font-bold text-gray-900 mb-4">
+            <h1 className="text-4xl font-bold text-white mb-4">
               Privacy Policy
             </h1>
-            <p className="text-lg text-gray-600">
+            <p className="text-lg text-slate-400">
               Effective Date: July 1, 2025 | Last Updated: July 1, 2025
             </p>
           </div>
 
           {/* Content */}
-          <div className="bg-white rounded-lg shadow-lg p-8 prose prose-lg max-w-none">
+          <div className="rounded-lg border border-white/10 bg-white/5 p-8 prose prose-invert prose-lg max-w-none">
             <section className="mb-8">
-              <h2 className="text-2xl font-semibold text-gray-900 mb-4">
+              <h2 className="text-2xl font-semibold text-white mb-4">
                 1. Introduction
               </h2>
-              <p className="text-gray-700 leading-relaxed">
+              <p className="text-slate-300 leading-relaxed">
                 Welcome to Blueprint ("Blueprint," "we," "us," or "our").
                 Blueprint provides an AI-powered augmented reality platform that
                 creates custom AR experiences for physical spaces ("Services").
@@ -95,7 +97,7 @@ export default function PrivacyPolicy() {
                 safeguard your information when you use our website, mobile
                 application, and Services.
               </p>
-              <p className="text-gray-700 leading-relaxed">
+              <p className="text-slate-300 leading-relaxed">
                 Please read this Privacy Policy carefully. By using our
                 Services, you agree to the collection and use of information in
                 accordance with this policy. If you do not agree with the terms
@@ -104,18 +106,18 @@ export default function PrivacyPolicy() {
             </section>
 
             <section className="mb-8">
-              <h2 className="text-2xl font-semibold text-gray-900 mb-4">
+              <h2 className="text-2xl font-semibold text-white mb-4">
                 2. Information We Collect
               </h2>
-              <p className="text-gray-700 leading-relaxed mb-4">
+              <p className="text-slate-300 leading-relaxed mb-4">
                 We collect information from and about users of our Services,
                 including:
               </p>
 
-              <h3 className="text-xl font-medium text-gray-800 mb-3">
+              <h3 className="text-xl font-medium text-slate-200 mb-3">
                 A. Personal Information
               </h3>
-              <ul className="list-disc pl-6 text-gray-700 space-y-2 mb-6">
+              <ul className="list-disc pl-6 text-slate-300 space-y-2 mb-6">
                 <li>
                   <strong>Account Information:</strong> Name, email address,
                   phone number, username, password, and profile information
@@ -141,15 +143,15 @@ export default function PrivacyPolicy() {
 
             {/* Add all other sections from your privacy policy document */}
 
-            <section className="mb-8 bg-blue-50 p-6 rounded-lg">
-              <h2 className="text-2xl font-semibold text-gray-900 mb-4">
+            <section className="mb-8 bg-white/5 p-6 rounded-lg border border-white/10">
+              <h2 className="text-2xl font-semibold text-white mb-4">
                 Contact Us
               </h2>
-              <p className="text-gray-700 mb-4">
+              <p className="text-slate-300 mb-4">
                 For questions about this Privacy Policy or our privacy
                 practices:
               </p>
-              <div className="text-gray-700">
+              <div className="text-slate-300">
                 <p>
                   <strong>Blueprint Privacy Team</strong>
                 </p>
@@ -157,7 +159,7 @@ export default function PrivacyPolicy() {
                   Email:{" "}
                   <a
                     href="mailto:nijel@tryblueprint.io"
-                    className="text-blue-600 hover:text-blue-800"
+                    className="text-emerald-400 hover:text-emerald-300"
                   >
                     nijel@tryblueprint.io
                   </a>
@@ -167,7 +169,7 @@ export default function PrivacyPolicy() {
                   Phone:{" "}
                   <a
                     href="tel:9196389913"
-                    className="text-blue-600 hover:text-blue-800"
+                    className="text-emerald-400 hover:text-emerald-300"
                   >
                     (919) 638-9913
                   </a>
@@ -176,6 +178,8 @@ export default function PrivacyPolicy() {
             </section>
           </div>
         </motion.div>
+      </main>
+      <Footer />
       </div>
     </>
   );

--- a/client/src/pages/Terms.tsx
+++ b/client/src/pages/Terms.tsx
@@ -65,110 +65,112 @@ export default function TermsOfService() {
         <meta name="robots" content="index, follow" />
       </Helmet>
 
-      <div className="min-h-screen bg-gray-50 py-12">
-        <motion.div
-          className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8"
-          initial="initial"
-          animate="animate"
-          variants={fadeInUp}
-        >
+      <div className="min-h-screen flex flex-col bg-[#0B1220] text-slate-100">
+        <Nav />
+        <main className="flex-grow py-12">
+          <motion.div
+            className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8"
+            initial="initial"
+            animate="animate"
+            variants={fadeInUp}
+          >
           {/* Header */}
           <div className="text-center mb-12">
-            <h1 className="text-4xl font-bold text-gray-900 mb-4">
+            <h1 className="text-4xl font-bold text-white mb-4">
               Terms of Service
             </h1>
-            <p className="text-lg text-gray-600">
+            <p className="text-lg text-slate-400">
               Effective Date: July 1, 2025 | Last Updated: July 1, 2025
             </p>
           </div>
 
           {/* Table of Contents */}
-          <div className="bg-white rounded-lg shadow-lg p-6 mb-8">
-            <h3 className="text-lg font-semibold mb-4 text-gray-900">
+          <div className="rounded-lg border border-white/10 bg-white/5 p-6 mb-8">
+            <h3 className="text-lg font-semibold mb-4 text-white">
               Table of Contents
             </h3>
             <nav className="grid grid-cols-1 md:grid-cols-2 gap-2 text-sm">
               <a
                 href="#acceptance"
-                className="text-blue-600 hover:text-blue-800 transition-colors"
+                className="text-emerald-400 hover:text-emerald-300 transition-colors"
               >
                 1. Acceptance of Terms
               </a>
               <a
                 href="#services"
-                className="text-blue-600 hover:text-blue-800 transition-colors"
+                className="text-emerald-400 hover:text-emerald-300 transition-colors"
               >
                 2. Description of Services
               </a>
               <a
                 href="#accounts"
-                className="text-blue-600 hover:text-blue-800 transition-colors"
+                className="text-emerald-400 hover:text-emerald-300 transition-colors"
               >
                 3. User Accounts
               </a>
               <a
                 href="#acceptable-use"
-                className="text-blue-600 hover:text-blue-800 transition-colors"
+                className="text-emerald-400 hover:text-emerald-300 transition-colors"
               >
                 4. Acceptable Use Policy
               </a>
               <a
                 href="#intellectual-property"
-                className="text-blue-600 hover:text-blue-800 transition-colors"
+                className="text-emerald-400 hover:text-emerald-300 transition-colors"
               >
                 5. Intellectual Property
               </a>
               <a
                 href="#payment"
-                className="text-blue-600 hover:text-blue-800 transition-colors"
+                className="text-emerald-400 hover:text-emerald-300 transition-colors"
               >
                 6. Payment Terms
               </a>
               <a
                 href="#privacy"
-                className="text-blue-600 hover:text-blue-800 transition-colors"
+                className="text-emerald-400 hover:text-emerald-300 transition-colors"
               >
                 7. Privacy and Data
               </a>
               <a
                 href="#disclaimers"
-                className="text-blue-600 hover:text-blue-800 transition-colors"
+                className="text-emerald-400 hover:text-emerald-300 transition-colors"
               >
                 8. Disclaimers
               </a>
               <a
                 href="#limitation"
-                className="text-blue-600 hover:text-blue-800 transition-colors"
+                className="text-emerald-400 hover:text-emerald-300 transition-colors"
               >
                 9. Limitation of Liability
               </a>
               <a
                 href="#indemnification"
-                className="text-blue-600 hover:text-blue-800 transition-colors"
+                className="text-emerald-400 hover:text-emerald-300 transition-colors"
               >
                 10. Indemnification
               </a>
               <a
                 href="#termination"
-                className="text-blue-600 hover:text-blue-800 transition-colors"
+                className="text-emerald-400 hover:text-emerald-300 transition-colors"
               >
                 11. Termination
               </a>
               <a
                 href="#governing-law"
-                className="text-blue-600 hover:text-blue-800 transition-colors"
+                className="text-emerald-400 hover:text-emerald-300 transition-colors"
               >
                 12. Governing Law
               </a>
               <a
                 href="#changes"
-                className="text-blue-600 hover:text-blue-800 transition-colors"
+                className="text-emerald-400 hover:text-emerald-300 transition-colors"
               >
                 13. Changes to Terms
               </a>
               <a
                 href="#contact"
-                className="text-blue-600 hover:text-blue-800 transition-colors"
+                className="text-emerald-400 hover:text-emerald-300 transition-colors"
               >
                 14. Contact Information
               </a>
@@ -176,24 +178,24 @@ export default function TermsOfService() {
           </div>
 
           {/* Content */}
-          <div className="bg-white rounded-lg shadow-lg p-8 prose prose-lg max-w-none">
+          <div className="rounded-lg border border-white/10 bg-white/5 p-8 prose prose-invert prose-lg max-w-none">
             <section id="acceptance" className="mb-8">
-              <h2 className="text-2xl font-semibold text-gray-900 mb-4">
+              <h2 className="text-2xl font-semibold text-white mb-4">
                 1. Acceptance of Terms
               </h2>
-              <p className="text-gray-700 leading-relaxed mb-4">
+              <p className="text-slate-300 leading-relaxed mb-4">
                 Welcome to Blueprint ("Blueprint," "Company," "we," "us," or
                 "our"). These Terms of Service ("Terms") govern your use of
                 Blueprint's AI-powered augmented reality platform, website,
                 mobile applications, and related services (collectively, the
                 "Services").
               </p>
-              <p className="text-gray-700 leading-relaxed mb-4">
+              <p className="text-slate-300 leading-relaxed mb-4">
                 By accessing or using our Services, you agree to be bound by
                 these Terms. If you disagree with any part of these Terms, you
                 may not access or use our Services.
               </p>
-              <p className="text-gray-700 leading-relaxed">
+              <p className="text-slate-300 leading-relaxed">
                 These Terms apply to all visitors, users, and others who access
                 or use our Services, including venue partners, content creators,
                 and end users.
@@ -201,15 +203,15 @@ export default function TermsOfService() {
             </section>
 
             <section id="services" className="mb-8">
-              <h2 className="text-2xl font-semibold text-gray-900 mb-4">
+              <h2 className="text-2xl font-semibold text-white mb-4">
                 2. Description of Services
               </h2>
-              <p className="text-gray-700 leading-relaxed mb-4">
+              <p className="text-slate-300 leading-relaxed mb-4">
                 Blueprint provides an AI-powered augmented reality platform that
                 creates custom AR experiences for physical spaces. Our Services
                 include:
               </p>
-              <ul className="list-disc pl-6 text-gray-700 space-y-2 mb-4">
+              <ul className="list-disc pl-6 text-slate-300 space-y-2 mb-4">
                 <li>
                   Web and mobile applications for AR content creation and
                   management
@@ -222,30 +224,30 @@ export default function TermsOfService() {
                 <li>Analytics and performance monitoring</li>
                 <li>Integration with venue partner systems</li>
               </ul>
-              <p className="text-gray-700 leading-relaxed">
+              <p className="text-slate-300 leading-relaxed">
                 We reserve the right to modify, suspend, or discontinue any
                 aspect of our Services at any time with reasonable notice.
               </p>
             </section>
 
             <section id="accounts" className="mb-8">
-              <h2 className="text-2xl font-semibold text-gray-900 mb-4">
+              <h2 className="text-2xl font-semibold text-white mb-4">
                 3. User Accounts and Responsibilities
               </h2>
 
-              <h3 className="text-xl font-medium text-gray-800 mb-3">
+              <h3 className="text-xl font-medium text-slate-200 mb-3">
                 Account Creation
               </h3>
-              <p className="text-gray-700 leading-relaxed mb-4">
+              <p className="text-slate-300 leading-relaxed mb-4">
                 To access certain features, you must create an account. You
                 agree to provide accurate, current, and complete information and
                 to update such information as necessary.
               </p>
 
-              <h3 className="text-xl font-medium text-gray-800 mb-3">
+              <h3 className="text-xl font-medium text-slate-200 mb-3">
                 Account Security
               </h3>
-              <ul className="list-disc pl-6 text-gray-700 space-y-2 mb-4">
+              <ul className="list-disc pl-6 text-slate-300 space-y-2 mb-4">
                 <li>
                   You are responsible for maintaining the confidentiality of
                   your account credentials
@@ -264,35 +266,35 @@ export default function TermsOfService() {
                 </li>
               </ul>
 
-              <h3 className="text-xl font-medium text-gray-800 mb-3">
+              <h3 className="text-xl font-medium text-slate-200 mb-3">
                 Business Accounts
               </h3>
-              <p className="text-gray-700 leading-relaxed">
+              <p className="text-slate-300 leading-relaxed">
                 Venue partners and business users may have additional terms and
                 responsibilities as outlined in separate agreements.
               </p>
             </section>
 
             <section id="acceptable-use" className="mb-8">
-              <h2 className="text-2xl font-semibold text-gray-900 mb-4">
+              <h2 className="text-2xl font-semibold text-white mb-4">
                 4. Acceptable Use Policy
               </h2>
 
-              <h3 className="text-xl font-medium text-gray-800 mb-3">
+              <h3 className="text-xl font-medium text-slate-200 mb-3">
                 Permitted Uses
               </h3>
-              <p className="text-gray-700 leading-relaxed mb-4">
+              <p className="text-slate-300 leading-relaxed mb-4">
                 You may use our Services for lawful purposes consistent with
                 these Terms and applicable laws.
               </p>
 
-              <h3 className="text-xl font-medium text-gray-800 mb-3">
+              <h3 className="text-xl font-medium text-slate-200 mb-3">
                 Prohibited Uses
               </h3>
-              <p className="text-gray-700 leading-relaxed mb-4">
+              <p className="text-slate-300 leading-relaxed mb-4">
                 You agree not to:
               </p>
-              <ul className="list-disc pl-6 text-gray-700 space-y-2 mb-4">
+              <ul className="list-disc pl-6 text-slate-300 space-y-2 mb-4">
                 <li>Violate any applicable laws or regulations</li>
                 <li>Infringe upon intellectual property rights of others</li>
                 <li>Upload malicious code, viruses, or harmful content</li>
@@ -318,14 +320,14 @@ export default function TermsOfService() {
             </section>
 
             <section id="intellectual-property" className="mb-8">
-              <h2 className="text-2xl font-semibold text-gray-900 mb-4">
+              <h2 className="text-2xl font-semibold text-white mb-4">
                 5. Intellectual Property Rights
               </h2>
 
-              <h3 className="text-xl font-medium text-gray-800 mb-3">
+              <h3 className="text-xl font-medium text-slate-200 mb-3">
                 Our Property
               </h3>
-              <p className="text-gray-700 leading-relaxed mb-4">
+              <p className="text-slate-300 leading-relaxed mb-4">
                 Blueprint retains all rights, title, and interest in our
                 Services, including software, algorithms, AI models, trademarks,
                 and proprietary technology. Our Services are protected by
@@ -333,20 +335,20 @@ export default function TermsOfService() {
                 laws.
               </p>
 
-              <h3 className="text-xl font-medium text-gray-800 mb-3">
+              <h3 className="text-xl font-medium text-slate-200 mb-3">
                 Your Content
               </h3>
-              <p className="text-gray-700 leading-relaxed mb-4">
+              <p className="text-slate-300 leading-relaxed mb-4">
                 You retain ownership of content you create or upload. By using
                 our Services, you grant Blueprint a worldwide, non-exclusive,
                 royalty-free license to use, reproduce, and display your content
                 solely for providing and improving our Services.
               </p>
 
-              <h3 className="text-xl font-medium text-gray-800 mb-3">
+              <h3 className="text-xl font-medium text-slate-200 mb-3">
                 AI-Generated Content
               </h3>
-              <p className="text-gray-700 leading-relaxed mb-4">
+              <p className="text-slate-300 leading-relaxed mb-4">
                 Content generated by our AI systems based on your inputs may be
                 used by Blueprint to improve our Services. You have the right to
                 use AI-generated content created specifically for your account.
@@ -354,22 +356,22 @@ export default function TermsOfService() {
             </section>
 
             <section id="payment" className="mb-8">
-              <h2 className="text-2xl font-semibold text-gray-900 mb-4">
+              <h2 className="text-2xl font-semibold text-white mb-4">
                 6. Payment Terms
               </h2>
 
-              <h3 className="text-xl font-medium text-gray-800 mb-3">
+              <h3 className="text-xl font-medium text-slate-200 mb-3">
                 Subscription Fees
               </h3>
-              <p className="text-gray-700 leading-relaxed mb-4">
+              <p className="text-slate-300 leading-relaxed mb-4">
                 Certain features require paid subscriptions. Fees are charged in
                 advance and are non-refundable except as required by law.
               </p>
 
-              <h3 className="text-xl font-medium text-gray-800 mb-3">
+              <h3 className="text-xl font-medium text-slate-200 mb-3">
                 Payment Processing
               </h3>
-              <ul className="list-disc pl-6 text-gray-700 space-y-2 mb-4">
+              <ul className="list-disc pl-6 text-slate-300 space-y-2 mb-4">
                 <li>
                   Payments are processed through secure third-party providers
                 </li>
@@ -383,10 +385,10 @@ export default function TermsOfService() {
                 </li>
               </ul>
 
-              <h3 className="text-xl font-medium text-gray-800 mb-3">
+              <h3 className="text-xl font-medium text-slate-200 mb-3">
                 Refunds
               </h3>
-              <p className="text-gray-700 leading-relaxed">
+              <p className="text-slate-300 leading-relaxed">
                 Refunds are provided at our discretion and in accordance with
                 applicable laws. Contact us at nijel@tryblueprint.io for refund
                 requests.
@@ -394,20 +396,20 @@ export default function TermsOfService() {
             </section>
 
             <section id="privacy" className="mb-8">
-              <h2 className="text-2xl font-semibold text-gray-900 mb-4">
+              <h2 className="text-2xl font-semibold text-white mb-4">
                 7. Privacy and Data
               </h2>
-              <p className="text-gray-700 leading-relaxed mb-4">
+              <p className="text-slate-300 leading-relaxed mb-4">
                 Your privacy is important to us. Our Privacy Policy explains how
                 we collect, use, and protect your information when you use our
                 Services.
               </p>
-              <p className="text-gray-700 leading-relaxed">
+              <p className="text-slate-300 leading-relaxed">
                 By using our Services, you consent to the collection and use of
                 information as described in our{" "}
                 <a
                   href="/privacy"
-                  className="text-blue-600 hover:text-blue-800"
+                  className="text-emerald-400 hover:text-emerald-300"
                 >
                   Privacy Policy
                 </a>
@@ -416,63 +418,63 @@ export default function TermsOfService() {
             </section>
 
             <section id="disclaimers" className="mb-8">
-              <h2 className="text-2xl font-semibold text-gray-900 mb-4">
+              <h2 className="text-2xl font-semibold text-white mb-4">
                 8. Disclaimers
               </h2>
               <div className="bg-yellow-50 border-l-4 border-yellow-400 p-4 mb-4">
-                <p className="text-gray-700 leading-relaxed font-medium">
+                <p className="text-slate-300 leading-relaxed font-medium">
                   OUR SERVICES ARE PROVIDED "AS IS" AND "AS AVAILABLE" WITHOUT
                   WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED.
                 </p>
               </div>
-              <p className="text-gray-700 leading-relaxed mb-4">
+              <p className="text-slate-300 leading-relaxed mb-4">
                 We disclaim all warranties, including but not limited to:
               </p>
-              <ul className="list-disc pl-6 text-gray-700 space-y-2 mb-4">
+              <ul className="list-disc pl-6 text-slate-300 space-y-2 mb-4">
                 <li>Merchantability and fitness for a particular purpose</li>
                 <li>Non-infringement of third-party rights</li>
                 <li>Accuracy, completeness, or timeliness of content</li>
                 <li>Uninterrupted or error-free operation</li>
                 <li>Security or virus-free operation</li>
               </ul>
-              <p className="text-gray-700 leading-relaxed">
+              <p className="text-slate-300 leading-relaxed">
                 AR experiences may vary based on device capabilities,
                 environmental conditions, and other factors beyond our control.
               </p>
             </section>
 
             <section id="limitation" className="mb-8">
-              <h2 className="text-2xl font-semibold text-gray-900 mb-4">
+              <h2 className="text-2xl font-semibold text-white mb-4">
                 9. Limitation of Liability
               </h2>
               <div className="bg-red-50 border-l-4 border-red-400 p-4 mb-4">
-                <p className="text-gray-700 leading-relaxed font-medium">
+                <p className="text-slate-300 leading-relaxed font-medium">
                   TO THE MAXIMUM EXTENT PERMITTED BY LAW, BLUEPRINT SHALL NOT BE
                   LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL,
                   OR PUNITIVE DAMAGES.
                 </p>
               </div>
-              <p className="text-gray-700 leading-relaxed mb-4">
+              <p className="text-slate-300 leading-relaxed mb-4">
                 Our total liability for any claims arising from these Terms or
                 your use of our Services shall not exceed the amount you paid us
                 in the twelve months preceding the claim.
               </p>
-              <p className="text-gray-700 leading-relaxed">
+              <p className="text-slate-300 leading-relaxed">
                 Some jurisdictions do not allow limitations on liability, so
                 these limitations may not apply to you.
               </p>
             </section>
 
             <section id="indemnification" className="mb-8">
-              <h2 className="text-2xl font-semibold text-gray-900 mb-4">
+              <h2 className="text-2xl font-semibold text-white mb-4">
                 10. Indemnification
               </h2>
-              <p className="text-gray-700 leading-relaxed mb-4">
+              <p className="text-slate-300 leading-relaxed mb-4">
                 You agree to indemnify and hold Blueprint harmless from any
                 claims, damages, losses, and expenses (including reasonable
                 attorney fees) arising from:
               </p>
-              <ul className="list-disc pl-6 text-gray-700 space-y-2 mb-4">
+              <ul className="list-disc pl-6 text-slate-300 space-y-2 mb-4">
                 <li>Your use of our Services</li>
                 <li>Your violation of these Terms</li>
                 <li>Your violation of any rights of another party</li>
@@ -481,26 +483,26 @@ export default function TermsOfService() {
             </section>
 
             <section id="termination" className="mb-8">
-              <h2 className="text-2xl font-semibold text-gray-900 mb-4">
+              <h2 className="text-2xl font-semibold text-white mb-4">
                 11. Termination
               </h2>
 
-              <h3 className="text-xl font-medium text-gray-800 mb-3">By You</h3>
-              <p className="text-gray-700 leading-relaxed mb-4">
+              <h3 className="text-xl font-medium text-slate-200 mb-3">By You</h3>
+              <p className="text-slate-300 leading-relaxed mb-4">
                 You may terminate your account at any time by contacting us or
                 using account settings.
               </p>
 
-              <h3 className="text-xl font-medium text-gray-800 mb-3">By Us</h3>
-              <p className="text-gray-700 leading-relaxed mb-4">
+              <h3 className="text-xl font-medium text-slate-200 mb-3">By Us</h3>
+              <p className="text-slate-300 leading-relaxed mb-4">
                 We may suspend or terminate your access for violations of these
                 Terms, non-payment, or other reasons with appropriate notice.
               </p>
 
-              <h3 className="text-xl font-medium text-gray-800 mb-3">
+              <h3 className="text-xl font-medium text-slate-200 mb-3">
                 Effect of Termination
               </h3>
-              <p className="text-gray-700 leading-relaxed">
+              <p className="text-slate-300 leading-relaxed">
                 Upon termination, your right to use our Services ceases
                 immediately. We may delete your account and content, though some
                 data may be retained as required by law or legitimate business
@@ -509,77 +511,77 @@ export default function TermsOfService() {
             </section>
 
             <section id="governing-law" className="mb-8">
-              <h2 className="text-2xl font-semibold text-gray-900 mb-4">
+              <h2 className="text-2xl font-semibold text-white mb-4">
                 12. Governing Law and Disputes
               </h2>
-              <p className="text-gray-700 leading-relaxed mb-4">
+              <p className="text-slate-300 leading-relaxed mb-4">
                 These Terms are governed by the laws of North Carolina, United
                 States, without regard to conflict of law principles.
               </p>
-              <p className="text-gray-700 leading-relaxed mb-4">
+              <p className="text-slate-300 leading-relaxed mb-4">
                 Any disputes arising from these Terms or your use of our
                 Services shall be resolved through binding arbitration in
                 Durham, North Carolina, except for claims that may be brought in
                 small claims court.
               </p>
-              <p className="text-gray-700 leading-relaxed">
+              <p className="text-slate-300 leading-relaxed">
                 You waive any right to participate in class action lawsuits or
                 class-wide arbitration.
               </p>
             </section>
 
             <section id="changes" className="mb-8">
-              <h2 className="text-2xl font-semibold text-gray-900 mb-4">
+              <h2 className="text-2xl font-semibold text-white mb-4">
                 13. Changes to Terms
               </h2>
-              <p className="text-gray-700 leading-relaxed mb-4">
+              <p className="text-slate-300 leading-relaxed mb-4">
                 We may update these Terms periodically. We will notify you of
                 material changes via email or through our Services at least 30
                 days before they take effect.
               </p>
-              <p className="text-gray-700 leading-relaxed">
+              <p className="text-slate-300 leading-relaxed">
                 Your continued use of our Services after changes take effect
                 constitutes acceptance of the new Terms.
               </p>
             </section>
 
             <section id="miscellaneous" className="mb-8">
-              <h2 className="text-2xl font-semibold text-gray-900 mb-4">
+              <h2 className="text-2xl font-semibold text-white mb-4">
                 14. Miscellaneous
               </h2>
 
-              <h3 className="text-xl font-medium text-gray-800 mb-3">
+              <h3 className="text-xl font-medium text-slate-200 mb-3">
                 Entire Agreement
               </h3>
-              <p className="text-gray-700 leading-relaxed mb-4">
+              <p className="text-slate-300 leading-relaxed mb-4">
                 These Terms constitute the entire agreement between you and
                 Blueprint regarding our Services.
               </p>
 
-              <h3 className="text-xl font-medium text-gray-800 mb-3">
+              <h3 className="text-xl font-medium text-slate-200 mb-3">
                 Severability
               </h3>
-              <p className="text-gray-700 leading-relaxed mb-4">
+              <p className="text-slate-300 leading-relaxed mb-4">
                 If any provision of these Terms is found unenforceable, the
                 remaining provisions will remain in full force and effect.
               </p>
 
-              <h3 className="text-xl font-medium text-gray-800 mb-3">Waiver</h3>
-              <p className="text-gray-700 leading-relaxed">
+              <h3 className="text-xl font-medium text-slate-200 mb-3">Waiver</h3>
+              <p className="text-slate-300 leading-relaxed">
                 No waiver of any term or condition shall be deemed a further or
                 continuing waiver of such term or any other term.
               </p>
             </section>
 
-            <section id="contact" className="mb-8 bg-blue-50 p-6 rounded-lg">
-              <h2 className="text-2xl font-semibold text-gray-900 mb-4">
+            <section id="contact" className="mb-8 bg-white/5 p-6 rounded-lg border border-white/10">
+              <h2 className="text-2xl font-semibold text-white mb-4">
                 15. Contact Information
               </h2>
-              <p className="text-gray-700 mb-4">
+              <p className="text-slate-300 mb-4">
                 If you have questions about these Terms of Service, please
                 contact us:
               </p>
-              <div className="text-gray-700">
+              <div className="text-slate-300">
                 <p>
                   <strong>Blueprint Legal Team</strong>
                 </p>
@@ -587,7 +589,7 @@ export default function TermsOfService() {
                   Email:{" "}
                   <a
                     href="mailto:nijel@tryblueprint.io"
-                    className="text-blue-600 hover:text-blue-800"
+                    className="text-emerald-400 hover:text-emerald-300"
                   >
                     nijel@tryblueprint.io
                   </a>
@@ -597,7 +599,7 @@ export default function TermsOfService() {
                   Phone:{" "}
                   <a
                     href="tel:9196389913"
-                    className="text-blue-600 hover:text-blue-800"
+                    className="text-emerald-400 hover:text-emerald-300"
                   >
                     (919) 638-9913
                   </a>
@@ -609,7 +611,7 @@ export default function TermsOfService() {
           {/* Back to Top Button */}
           <motion.button
             onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
-            className="fixed bottom-8 right-8 bg-blue-600 text-white p-3 rounded-full shadow-lg hover:bg-blue-700 transition-colors z-50"
+            className="fixed bottom-8 right-8 bg-emerald-500 text-white p-3 rounded-full shadow-lg hover:bg-emerald-600 transition-colors z-50"
             whileHover={{ scale: 1.1 }}
             whileTap={{ scale: 0.9 }}
           >
@@ -627,7 +629,9 @@ export default function TermsOfService() {
               />
             </svg>
           </motion.button>
-        </motion.div>
+          </motion.div>
+        </main>
+        <Footer />
       </div>
     </>
   );


### PR DESCRIPTION
## Summary
- Restyle Terms of Service to use dark palette and emerald accents consistent with rest of site
- Apply same dark theme, nav/footer layout, and contact card styling to Privacy Policy

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689e166013f48323a2cd40156382ca03