### PR TITLE
feat: add Lindy support chat across pages

### DIFF
--- a/client/src/components/LindyChat.tsx
+++ b/client/src/components/LindyChat.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import React, { useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { MessageCircle, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+const LINDY_EMBED_ID = "9620fed7-bdfb-4329-ada0-b60963170c59";
+const LINDY_IFRAME_URL = `https://chat.lindy.ai/embedded/lindyEmbed/${LINDY_EMBED_ID}`;
+
+// If you really want to allow an override from env in Next.js builds,
+// this guard avoids touching `process` at runtime in the browser.
+const LINDY_EMBED_URL =
+  (typeof process !== "undefined" &&
+    (process as any)?.env?.NEXT_PUBLIC_LINDY_EMBED_URL) ||
+  LINDY_IFRAME_URL;
+
+export default function LindyChat() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <Button
+        onClick={() => setOpen(true)}
+        className="fixed bottom-6 right-6 rounded-full w-14 h-14 p-0 bg-gradient-to-r from-emerald-500 to-cyan-600 text-white shadow-lg hover:from-emerald-400 hover:to-cyan-500 z-40"
+        aria-label="Open chat"
+      >
+        <MessageCircle className="w-6 h-6" />
+      </Button>
+
+      <AnimatePresence>
+        {open && (
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 20 }}
+            // Responsive size; feels like a proper chat dock
+            className="fixed bottom-6 right-6 w-[min(28rem,92vw)] h-[min(70vh,80vh)] bg-slate-900/95 text-slate-100 border border-white/10 rounded-xl shadow-2xl overflow-hidden z-50"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Lindy Support Chat"
+          >
+            {/* Header */}
+            <div className="bg-gradient-to-r from-emerald-500 to-cyan-600 text-white p-3 flex justify-between items-center">
+              <div className="flex items-center">
+                <MessageCircle className="w-5 h-5 mr-2" />
+                <h3 className="font-semibold">Blueprint × Lindy</h3>
+              </div>
+              <button
+                onClick={() => setOpen(false)}
+                className="text-white hover:text-white/80 transition-colors"
+                aria-label="Close chat"
+              >
+                <X className="w-5 h-5" />
+              </button>
+            </div>
+
+            {/* Lindy iFrame */}
+            <div className="w-full h-[calc(100%-48px)] bg-slate-900">
+              <iframe
+                src={LINDY_EMBED_URL}
+                title="Lindy Support Chat"
+                className="w-full h-full"
+                // allow microphone/camera if your embed uses them
+                allow="clipboard-write; microphone; camera; autoplay"
+                // keeping sandbox relaxed; tighten if your flow allows
+                sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-downloads"
+              />
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </>
+  );
+}
+

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -75,6 +75,7 @@ import {
 import { Link } from "wouter";
 import Nav from "@/components/Nav";
 import Footer from "@/components/Footer";
+import LindyChat from "@/components/LindyChat";
 import { useAuth } from "@/contexts/AuthContext";
 import { db } from "@/lib/firebase";
 import {
@@ -2357,6 +2358,7 @@ export default function Dashboard() {
           </div>
         )}
         <Footer />
+        <LindyChat />
       </div>
 
       {/* Onboarding Components */}

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -26,6 +26,7 @@ const LocationShowcase = lazy(
 );
 const ContactForm = lazy(() => import("@/components/sections/ContactForm"));
 import Footer from "@/components/Footer";
+import LindyChat from "@/components/LindyChat";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import {
@@ -515,6 +516,7 @@ export default function Home() {
       )}
 
       <Footer />
+      <LindyChat />
     </div>
   );
 }

--- a/client/src/pages/PilotProgram.jsx
+++ b/client/src/pages/PilotProgram.jsx
@@ -17,6 +17,7 @@ import Nav from "@/components/Nav";
 import { toast, Toaster } from "sonner";
 import ContactForm from "@/components/sections/ContactForm";
 import Footer from "@/components/Footer";
+import LindyChat from "@/components/LindyChat";
 import {
   Rocket,
   MapPin,
@@ -1788,6 +1789,7 @@ export default function PilotProgram() {
       </section>
 
       <Footer />
+      <LindyChat />
     </div>
   );
 }

--- a/client/src/pages/Pricing.tsx
+++ b/client/src/pages/Pricing.tsx
@@ -28,6 +28,7 @@ import { Label } from "@/components/ui/label";
 import { Slider } from "@/components/ui/slider";
 import Nav from "@/components/Nav";
 import Footer from "@/components/Footer";
+import LindyChat from "@/components/LindyChat";
 import Stripe from "stripe";
 // Import the new modal components
 import { TeamSeatSelectorModal } from "@/components/TeamSeatSelectorModal";
@@ -1325,6 +1326,7 @@ export default function PricingPage() {
       </motion.div>
       {/* End Main Content Container */}
       <Footer />
+      <LindyChat />
       <WorkspaceNameModal
         isOpen={isWorkspaceNameOpen}
         onClose={() => setIsWorkspaceNameOpen(false)}

--- a/client/src/pages/ScannerPortal.tsx
+++ b/client/src/pages/ScannerPortal.tsx
@@ -33,6 +33,7 @@ import { ref, uploadBytesResumable, getDownloadURL } from "firebase/storage";
 import { db, storage } from "@/lib/firebase";
 import Nav from "@/components/Nav";
 import Footer from "@/components/Footer";
+import LindyChat from "@/components/LindyChat";
 import ThreeViewer from "@/components/ThreeViewer"; // Add this import
 
 import {
@@ -1840,6 +1841,7 @@ export default function ScannerPortal() {
         </Dialog>
       )}
       <Footer />
+      <LindyChat />
 
       {/* Distance Dialog */}
       {showDistanceDialog && (


### PR DESCRIPTION
## Summary
- add reusable LindyChat component with floating chat dock
- enable LindyChat on Home, Pilot Program, Dashboard, Scanner Portal, and Pricing pages

## Testing
- `npm test` *(fails: Missing script)*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689e233a6d28832392d5f2d444226bce