### PR TITLE
feat: show cost per hour for blueprint content

### DIFF
--- a/client/src/components/CostPanel.tsx
+++ b/client/src/components/CostPanel.tsx
@@ -1,0 +1,74 @@
+import React, { useMemo } from "react";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
+
+interface CostPanelProps {
+  imageCount: number;
+  videoCount: number;
+  modelCount: number;
+  webpageCount: number;
+  textCount: number;
+}
+
+const BASE_RATE = 0.5;
+const IMAGE_RATE = 0.01;
+const VIDEO_RATE = 0.03;
+const MODEL_RATE = 0.03;
+const WEBPAGE_RATE = 0.02;
+const TEXT_RATE = 0.01;
+
+export default function CostPanel({
+  imageCount,
+  videoCount,
+  modelCount,
+  webpageCount,
+  textCount,
+}: CostPanelProps) {
+  const total = useMemo(() => {
+    return (
+      BASE_RATE +
+      imageCount * IMAGE_RATE +
+      videoCount * VIDEO_RATE +
+      modelCount * MODEL_RATE +
+      webpageCount * WEBPAGE_RATE +
+      textCount * TEXT_RATE
+    );
+  }, [imageCount, videoCount, modelCount, webpageCount, textCount]);
+
+  const items = [
+    { label: "Images", count: imageCount, rate: IMAGE_RATE },
+    { label: "Videos", count: videoCount, rate: VIDEO_RATE },
+    { label: "3D Models", count: modelCount, rate: MODEL_RATE },
+    { label: "Webpages", count: webpageCount, rate: WEBPAGE_RATE },
+    { label: "Text", count: textCount, rate: TEXT_RATE },
+  ];
+
+  return (
+    <Card className="w-56 text-sm">
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base">Cost per Hour</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <div className="text-2xl font-bold">${total.toFixed(2)}/hr</div>
+        <Separator />
+        <div className="flex justify-between text-xs text-muted-foreground">
+          <span>Base rate</span>
+          <span>${BASE_RATE.toFixed(2)}/hr</span>
+        </div>
+        <Separator />
+        <div className="space-y-1">
+          {items.map((item) => (
+            <div key={item.label} className="flex justify-between items-center">
+              <span>
+                {item.label} ({item.count})
+              </span>
+              <Badge variant="secondary">+${(item.count * item.rate).toFixed(2)}</Badge>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+

--- a/client/src/pages/BlueprintEditor.tsx
+++ b/client/src/pages/BlueprintEditor.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useState, useEffect, useRef, useCallback } from "react";
+import React, { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import * as THREE from "three";
 import ThreeViewer from "@/components/ThreeViewer";
@@ -16,6 +16,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import FeatureConfigHub from "@/components/FeatureConfigScreens";
 import { Switch } from "@/components/ui/switch";
+import CostPanel from "@/components/CostPanel";
 
 // Define interfaces for onboarding data
 interface AreaItem {
@@ -638,6 +639,22 @@ export default function BlueprintEditor() {
   const [searchQuery, setSearchQuery] = useState("");
   const [uploadedFiles, setUploadedFiles] = useState<any[]>([]);
   const [externalUrl, setExternalUrl] = useState("");
+
+  // Cost panel counts
+  const imageCount = useMemo(
+    () => fileAnchors.filter((a) => a.fileType === "image").length,
+    [fileAnchors],
+  );
+  const videoCount = useMemo(
+    () => fileAnchors.filter((a) => a.fileType === "video").length,
+    [fileAnchors],
+  );
+  const modelCount = useMemo(() => modelAnchors.length, [modelAnchors]);
+  const webpageCount = useMemo(
+    () => webpageAnchors.length,
+    [webpageAnchors],
+  );
+  const textCount = useMemo(() => textAnchors.length, [textAnchors]);
 
   useEffect(() => {
     if (activeSection !== "create") {
@@ -7342,7 +7359,8 @@ export default function BlueprintEditor() {
                 )}
               </div>
             ) : (
-              <ThreeViewer
+              <div className="w-full h-full relative">
+                <ThreeViewer
                 //modelPath={model3DPath}
                 modelPath={blueprintModelUrl}
                 ref={threeViewerRef}
@@ -7506,6 +7524,16 @@ export default function BlueprintEditor() {
                 onBackgroundClick={handleViewerBackgroundClick}
                 onFileAnchorClick={handleFileAnchorClicked}
               />
+                <div className="absolute bottom-4 right-4 z-40">
+                  <CostPanel
+                    imageCount={imageCount}
+                    videoCount={videoCount}
+                    modelCount={modelCount}
+                    webpageCount={webpageCount}
+                    textCount={textCount}
+                  />
+                </div>
+              </div>
             )}
 
             {/* Action bar - bottom center */}


### PR DESCRIPTION
## Summary
- add CostPanel component to show pricing by content type
- integrate panel into Blueprint editor with dynamic counts

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68ac891967f083238ff411ad5175f084