### PR TITLE
Add embeddable metrics dashboard

### DIFF
--- a/Blueprint-WebApp/client/src/main.tsx
+++ b/Blueprint-WebApp/client/src/main.tsx
@@ -34,6 +34,7 @@ import PilotProgram from "./pages/PilotProgram";
 import Privacy from "./pages/Privacy";
 import Terms from "./pages/Terms";
 import EmbedCalendar from "./pages/EmbedCalendar";
+import EmbedDashboard from "./pages/EmbedDashboard";
 
 function Router() {
   return (
@@ -57,6 +58,7 @@ function Router() {
       <Route path="/privacy" component={Privacy} />
       <Route path="/terms" component={Terms} />
       <Route path="/embed/calendar" component={EmbedCalendar} />
+      <Route path="/embed/dashboard" component={EmbedDashboard} />
 
       {/* Protected Routes */}
       <Route path="/create-blueprint">

--- a/Blueprint-WebApp/client/src/pages/EmbedDashboard.tsx
+++ b/Blueprint-WebApp/client/src/pages/EmbedDashboard.tsx
@@ -1,0 +1,170 @@
+type Metric = {
+  label: string;
+  value: string;
+};
+
+type Section = {
+  title: string;
+  metrics: Metric[];
+};
+
+const sections: Section[] = [
+  {
+    title: "Daily Pulse",
+    metrics: [
+      { label: "CAC", value: "$420" },
+      { label: "Retention / Churn", value: "92% / 8%" },
+      {
+        label: "Avg Onboarding Time / Cost",
+        value: "3 days / $250",
+      },
+      {
+        label: "Ops Throughput (venues/day)",
+        value: "5",
+      },
+      {
+        label: "Users / Sessions (total)",
+        value: "1,200 / 4,300",
+      },
+      {
+        label: "Onboarded (today / last week)",
+        value: "3 / 21",
+      },
+      {
+        label: "Planned Onboardings (today / next week)",
+        value: "5 / 35",
+      },
+    ],
+  },
+  {
+    title: "Unit Economics",
+    metrics: [
+      { label: "Gross Margin", value: "78%" },
+      { label: "CAC per Venue", value: "$400" },
+      { label: "CAC Payback", value: "14 mo" },
+      { label: "LTV", value: "$9,500" },
+      { label: "LTV : CAC", value: "3.2x" },
+      { label: "Burn Multiple", value: "1.9" },
+      {
+        label: "Price/hr realized vs list",
+        value: "$95 / $100",
+      },
+      {
+        label: "Hours/venue/month (p50/p75/p90)",
+        value: "42 / 60 / 80",
+      },
+      {
+        label: "COGS/hr (storage/CDN/inference/obs)",
+        value: "$0.20 / $0.05 / $0.15 / $0.10",
+      },
+      {
+        label: "Contribution margin/venue",
+        value: "$1,800",
+      },
+    ],
+  },
+  {
+    title: "Retention & Expansion",
+    metrics: [
+      { label: "GRR", value: "91%" },
+      { label: "NRR", value: "108%" },
+      { label: "Logo Retention", value: "89%" },
+      { label: "Cohort Retention (6 mo)", value: "85%" },
+      { label: "Quick Ratio", value: "4.2" },
+      { label: "Magic Number", value: "0.9" },
+    ],
+  },
+  {
+    title: "Onboarding & Ops",
+    metrics: [
+      {
+        label: "Time to go-live (median/p90)",
+        value: "7d / 12d",
+      },
+      {
+        label: "Cost to onboard/venue",
+        value: "$350",
+      },
+      {
+        label: "Onboarding capacity (actual/plan)",
+        value: "5 / 6 per day",
+      },
+      { label: "Install success rate", value: "96%" },
+      {
+        label: "Support minutes per venue/month",
+        value: "35",
+      },
+      { label: "AE ramp time", value: "5.5 mo" },
+    ],
+  },
+  {
+    title: "Usage & Engagement",
+    metrics: [
+      {
+        label: "Sessions / Users per venue (monthly)",
+        value: "320 / 140",
+      },
+      { label: "Minutes per session", value: "12" },
+      { label: "Hours/venue/month", value: "64" },
+      { label: "QR funnel completion", value: "45%" },
+      { label: "Wearer participation", value: "70%" },
+      { label: "Staff-triggered activation", value: "55%" },
+    ],
+  },
+  {
+    title: "Pipeline & Forecasting",
+    metrics: [
+      {
+        label: "Lead → Demo → Pilot → Paid",
+        value: "30% → 60% → 50% → 40%",
+      },
+      {
+        label: "Avg venues per closed-won",
+        value: "3",
+      },
+      {
+        label: "Bookings per pod/month",
+        value: "12",
+      },
+      { label: "Forecast accuracy (60d)", value: "85%" },
+    ],
+  },
+  {
+    title: "Board Metrics",
+    metrics: [
+      { label: "Rule of 40", value: "45%" },
+      { label: "MRR / ARR", value: "$75k / $900k" },
+      { label: "GM%", value: "78%" },
+      { label: "CAC Payback", value: "14 mo" },
+      { label: "Burn Multiple", value: "1.9" },
+      { label: "Magic Number", value: "0.9" },
+    ],
+  },
+];
+
+export default function EmbedDashboard() {
+  return (
+    <div className="min-h-screen bg-white p-4 md:p-8 text-slate-800">
+      <h1 className="text-2xl font-bold mb-6 text-center">
+        Blueprint Metrics Dashboard
+      </h1>
+      {sections.map((section) => (
+        <div key={section.title} className="mb-8">
+          <h2 className="text-xl font-semibold mb-4">{section.title}</h2>
+          <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+            {section.metrics.map((m) => (
+              <div
+                key={m.label}
+                className="rounded-lg border bg-slate-50 p-4 shadow-sm"
+              >
+                <div className="text-sm text-slate-500">{m.label}</div>
+                <div className="text-2xl font-semibold">{m.value}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -39,6 +39,7 @@ const PrivacyPolicy = lazy(() => import("./pages/PrivacyPolicy"));
 const Terms = lazy(() => import("./pages/Terms"));
 const FAQ = lazy(() => import("./pages/FAQ"));
 const EmbedCalendar = lazy(() => import("./pages/EmbedCalendar"));
+const EmbedDashboard = lazy(() => import("./pages/EmbedDashboard"));
 
 function Router() {
   return (
@@ -64,6 +65,7 @@ function Router() {
       <Route path="/terms" component={Terms} />
       <Route path="/faq" component={FAQ} />
       <Route path="/embed/calendar" component={EmbedCalendar} />
+      <Route path="/embed/dashboard" component={EmbedDashboard} />
 
       {/* Protected */}
       <Route path="/create-blueprint">

--- a/client/src/pages/EmbedDashboard.tsx
+++ b/client/src/pages/EmbedDashboard.tsx
@@ -1,0 +1,170 @@
+type Metric = {
+  label: string;
+  value: string;
+};
+
+type Section = {
+  title: string;
+  metrics: Metric[];
+};
+
+const sections: Section[] = [
+  {
+    title: "Daily Pulse",
+    metrics: [
+      { label: "CAC", value: "$420" },
+      { label: "Retention / Churn", value: "92% / 8%" },
+      {
+        label: "Avg Onboarding Time / Cost",
+        value: "3 days / $250",
+      },
+      {
+        label: "Ops Throughput (venues/day)",
+        value: "5",
+      },
+      {
+        label: "Users / Sessions (total)",
+        value: "1,200 / 4,300",
+      },
+      {
+        label: "Onboarded (today / last week)",
+        value: "3 / 21",
+      },
+      {
+        label: "Planned Onboardings (today / next week)",
+        value: "5 / 35",
+      },
+    ],
+  },
+  {
+    title: "Unit Economics",
+    metrics: [
+      { label: "Gross Margin", value: "78%" },
+      { label: "CAC per Venue", value: "$400" },
+      { label: "CAC Payback", value: "14 mo" },
+      { label: "LTV", value: "$9,500" },
+      { label: "LTV : CAC", value: "3.2x" },
+      { label: "Burn Multiple", value: "1.9" },
+      {
+        label: "Price/hr realized vs list",
+        value: "$95 / $100",
+      },
+      {
+        label: "Hours/venue/month (p50/p75/p90)",
+        value: "42 / 60 / 80",
+      },
+      {
+        label: "COGS/hr (storage/CDN/inference/obs)",
+        value: "$0.20 / $0.05 / $0.15 / $0.10",
+      },
+      {
+        label: "Contribution margin/venue",
+        value: "$1,800",
+      },
+    ],
+  },
+  {
+    title: "Retention & Expansion",
+    metrics: [
+      { label: "GRR", value: "91%" },
+      { label: "NRR", value: "108%" },
+      { label: "Logo Retention", value: "89%" },
+      { label: "Cohort Retention (6 mo)", value: "85%" },
+      { label: "Quick Ratio", value: "4.2" },
+      { label: "Magic Number", value: "0.9" },
+    ],
+  },
+  {
+    title: "Onboarding & Ops",
+    metrics: [
+      {
+        label: "Time to go-live (median/p90)",
+        value: "7d / 12d",
+      },
+      {
+        label: "Cost to onboard/venue",
+        value: "$350",
+      },
+      {
+        label: "Onboarding capacity (actual/plan)",
+        value: "5 / 6 per day",
+      },
+      { label: "Install success rate", value: "96%" },
+      {
+        label: "Support minutes per venue/month",
+        value: "35",
+      },
+      { label: "AE ramp time", value: "5.5 mo" },
+    ],
+  },
+  {
+    title: "Usage & Engagement",
+    metrics: [
+      {
+        label: "Sessions / Users per venue (monthly)",
+        value: "320 / 140",
+      },
+      { label: "Minutes per session", value: "12" },
+      { label: "Hours/venue/month", value: "64" },
+      { label: "QR funnel completion", value: "45%" },
+      { label: "Wearer participation", value: "70%" },
+      { label: "Staff-triggered activation", value: "55%" },
+    ],
+  },
+  {
+    title: "Pipeline & Forecasting",
+    metrics: [
+      {
+        label: "Lead → Demo → Pilot → Paid",
+        value: "30% → 60% → 50% → 40%",
+      },
+      {
+        label: "Avg venues per closed-won",
+        value: "3",
+      },
+      {
+        label: "Bookings per pod/month",
+        value: "12",
+      },
+      { label: "Forecast accuracy (60d)", value: "85%" },
+    ],
+  },
+  {
+    title: "Board Metrics",
+    metrics: [
+      { label: "Rule of 40", value: "45%" },
+      { label: "MRR / ARR", value: "$75k / $900k" },
+      { label: "GM%", value: "78%" },
+      { label: "CAC Payback", value: "14 mo" },
+      { label: "Burn Multiple", value: "1.9" },
+      { label: "Magic Number", value: "0.9" },
+    ],
+  },
+];
+
+export default function EmbedDashboard() {
+  return (
+    <div className="min-h-screen bg-white p-4 md:p-8 text-slate-800">
+      <h1 className="text-2xl font-bold mb-6 text-center">
+        Blueprint Metrics Dashboard
+      </h1>
+      {sections.map((section) => (
+        <div key={section.title} className="mb-8">
+          <h2 className="text-xl font-semibold mb-4">{section.title}</h2>
+          <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+            {section.metrics.map((m) => (
+              <div
+                key={m.label}
+                className="rounded-lg border bg-slate-50 p-4 shadow-sm"
+              >
+                <div className="text-sm text-slate-500">{m.label}</div>
+                <div className="text-2xl font-semibold">{m.value}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- create EmbedDashboard page with grouped metrics for quick daily insights
- expose dashboard through `/embed/dashboard` route

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68ae456741788323be215ec0516970e0