### PR TITLE
Add estimated payout fields to booking flows

### DIFF
--- a/Blueprint-WebApp/client/src/pages/OffWaitlistSignUpFlow.tsx
+++ b/Blueprint-WebApp/client/src/pages/OffWaitlistSignUpFlow.tsx
@@ -243,6 +243,15 @@ export default function OffWaitlistSignUpFlow() {
         // Create a unique blueprintId that will be used later when uploading files
         const blueprintId = crypto.randomUUID();
 
+        // Calculate estimated payouts
+        const estimatedSquareFootage = squareFootage ?? 0;
+        const estimatedMappingPayout = parseFloat(
+          (estimatedSquareFootage / 60).toFixed(2),
+        );
+        const estimatedDesignPayout = parseFloat(
+          (estimatedSquareFootage / 80).toFixed(2),
+        );
+
         // Create a more comprehensive booking record
         await setDoc(doc(db, "bookings", bookingId), {
           id: bookingId,
@@ -257,6 +266,9 @@ export default function OffWaitlistSignUpFlow() {
           status: "pending",
           blueprintId: blueprintId, // Add the blueprint ID for reference
           createdAt: serverTimestamp(),
+          estimatedSquareFootage,
+          estimatedMappingPayout,
+          estimatedDesignPayout,
         });
 
         // Also create a placeholder blueprint document that will be updated later with scan files

--- a/client/src/pages/OffWaitlistSignUpFlow.tsx
+++ b/client/src/pages/OffWaitlistSignUpFlow.tsx
@@ -507,6 +507,14 @@ export default function OffWaitlistSignUpFlow() {
         const bookingId = `${bookingDate}_${scheduleTime}`;
         const blueprintId = crypto.randomUUID();
 
+        const estimatedSquareFootage = squareFootage ?? 0;
+        const estimatedMappingPayout = parseFloat(
+          (estimatedSquareFootage / 60).toFixed(2),
+        );
+        const estimatedDesignPayout = parseFloat(
+          (estimatedSquareFootage / 80).toFixed(2),
+        );
+
         await setDoc(doc(db, "bookings", bookingId), {
           id: bookingId,
           date: bookingDate,
@@ -522,6 +530,9 @@ export default function OffWaitlistSignUpFlow() {
           demoScheduleDate: demoDate.toISOString().split("T")[0],
           demoScheduleTime: demoTime,
           createdAt: serverTimestamp(),
+          estimatedSquareFootage,
+          estimatedMappingPayout,
+          estimatedDesignPayout,
         });
 
         await setDoc(doc(db, "blueprints", blueprintId), {

--- a/client/src/pages/OutboundSignUpFlow.tsx
+++ b/client/src/pages/OutboundSignUpFlow.tsx
@@ -389,6 +389,15 @@ export default function OutboundSignUpFlow() {
         const bookingId = `${bookingDate}_${scheduleTime}`;
         const blueprintId = crypto.randomUUID();
 
+        // Estimated payouts
+        const estimatedSquareFootage = squareFootage ?? 0;
+        const estimatedMappingPayout = parseFloat(
+          (estimatedSquareFootage / 60).toFixed(2),
+        );
+        const estimatedDesignPayout = parseFloat(
+          (estimatedSquareFootage / 80).toFixed(2),
+        );
+
         // Mapping booking
         await setDoc(doc(db, "bookings", bookingId), {
           id: bookingId,
@@ -405,6 +414,9 @@ export default function OutboundSignUpFlow() {
           demoScheduleDate: demoDate.toISOString().split("T")[0],
           demoScheduleTime: demoTime,
           createdAt: serverTimestamp(),
+          estimatedSquareFootage,
+          estimatedMappingPayout,
+          estimatedDesignPayout,
         });
 
         // Blueprint placeholder


### PR DESCRIPTION
## Summary
- compute estimated square footage, mapping payout, and design payout when creating bookings
- store new estimated payout values in OutboundSignUpFlow and OffWaitlistSignUpFlow booking records

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx vitest run`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68af1cddfc8083238339c307b2f26418