### PR TITLE
feat: upload 3d models to backblaze

### DIFF
--- a/client/src/components/ThreeViewer.tsx
+++ b/client/src/components/ThreeViewer.tsx
@@ -4828,32 +4828,13 @@ const ThreeViewer = React.memo(
 
       const loader = new GLTFLoader();
 
-      //  const fullModelPath =
-      //    //  "https://f005.backblazeb2.com/file/objectModels-dev/4_27_2025.glb";
-      //   // "https://f005.backblazeb2.com/file/objectModels-dev/home.glb";
-      //  // "https://f005.backblazeb2.com/file/objectModels-dev/+HLF+-+Uniform+%E2%80%A2+100%25+%E2%80%A2+8k.glb";
+      const fullModelPath = modelPath || "";
 
-      // // "https://f005.backblazeb2.com/file/objectModels-dev/Library+-+Uniform+%E2%80%A2+100%25+%E2%80%A2+4k.glb";
-      //https://f005.backblazeb2.com/file/objectModels-dev/6_26_2025.glb
-      // With this:
-      const fullModelPath =
-        "https://f005.backblazeb2.com/file/objectModels-dev/Art+Demo+-+Uniform+%E2%80%A2+99%25+%E2%80%A2+4k.glb";
-      //"https://f005.backblazeb2.com/file/objectModels-dev/+HLF+-+Uniform+%E2%80%A2+100%25+%E2%80%A2+8k.glb"; //modelPath || ""; // Use the prop directly
-
-      // Add validation
       if (!fullModelPath) {
         console.error("No modelPath provided to ThreeViewer");
         onError?.("No 3D model path provided");
         return;
       }
-
-      // Determine if modelPath is an external URL or local path
-      // let fullModelPath = modelPath;
-
-      // // If it's not an external URL, prepend a slash for local path
-      // if (!modelPath.startsWith('http') && !modelPath.startsWith('/')) {
-      //   fullModelPath = `/${modelPath}`;
-      // }
 
       console.log("Attempting to fetch 3D model from:", fullModelPath);
 

--- a/client/src/pages/api/upload-to-b2.ts
+++ b/client/src/pages/api/upload-to-b2.ts
@@ -1,100 +1,53 @@
-// import B2 from "backblaze-b2";
-// import { IncomingForm } from "formidable";
-// import fs from "fs";
-// import { NextApiRequest, NextApiResponse } from "next";
+import type { Request, Response } from "express";
+import multer from "multer";
+// @ts-ignore - library has no types
+import B2 from "backblaze-b2";
 
-// // Disable body parser for file uploads
-// export const config = {
-//   api: {
-//     bodyParser: false,
-//   },
-// };
+const upload = multer({ storage: multer.memoryStorage() });
 
-// // Initialize B2 with credentials
-// const b2 = new B2({
-//   applicationKeyId: "00550218f7653950000000002",
-//   applicationKey: "K005uyFTIjJ2mxwupnkSdfl2UYt0tIU",
-// });
+const b2 = new B2({
+  applicationKeyId: process.env.B2_KEY_ID || "",
+  applicationKey: process.env.B2_APP_KEY || "",
+});
 
-// export default async function handler(
-//   req: NextApiRequest,
-//   res: NextApiResponse,
-// ) {
-//   // Check if request method is POST
-//   if (req.method !== "POST") {
-//     return res.status(405).json({ error: "Method not allowed" });
-//   }
+export default function handler(req: Request, res: Response) {
+  upload.single("file")(req, res, async (err: any) => {
+    if (err) {
+      console.error("Multer error:", err);
+      return res.status(500).json({ error: "File upload failed" });
+    }
 
-//   try {
-//     // Create form parser
-//     const form = new IncomingForm({
-//       multiples: false,
-//       maxFileSize: 50 * 1024 * 1024, // 50MB limit
-//     });
+    const file = (req as any).file as Express.Multer.File | undefined;
+    if (!file) {
+      return res.status(400).json({ error: "No file uploaded" });
+    }
 
-//     // Parse form data
-//     const [fields, files] = await new Promise<[any, any]>((resolve, reject) => {
-//       form.parse(req, (err, fields, files) => {
-//         if (err) reject(err);
-//         else resolve([fields, files]);
-//       });
-//     });
+    try {
+      if (!process.env.B2_BUCKET_ID) {
+        return res.status(500).json({ error: "Missing B2 configuration" });
+      }
 
-//     // Check if we have files
-//     if (!files.file) {
-//       return res.status(400).json({ error: "No file uploaded" });
-//     }
+      await b2.authorize();
+      const { data } = await b2.getUploadUrl({
+        bucketId: process.env.B2_BUCKET_ID,
+      });
 
-//     // Get the uploaded file
-//     const uploadedFile = Array.isArray(files.file) ? files.file[0] : files.file;
+      const fileName = `models/${Date.now()}_${file.originalname}`;
+      await b2.uploadFile({
+        uploadUrl: data.uploadUrl,
+        uploadAuthToken: data.authorizationToken,
+        fileName,
+        data: file.buffer,
+        contentType: file.mimetype,
+      });
 
-//     // Read file content
-//     const fileBuffer = fs.readFileSync(uploadedFile.filepath);
+      const bucketName = process.env.B2_BUCKET_NAME || "objectModels-dev";
+      const publicUrl = `https://f005.backblazeb2.com/file/${bucketName}/${fileName}`;
 
-//     // Clean up temp file
-//     fs.unlinkSync(uploadedFile.filepath);
-
-//     // Authorize with B2
-//     await b2.authorize();
-
-//     // Get upload URL
-//     const response = await b2.getUploadUrl({
-//       bucketId: "d570327198bfd72685d30915", // Your bucket ID
-//     });
-
-//     // Extract field values (they might be arrays)
-//     const blueprintId = Array.isArray(fields.blueprintId)
-//       ? fields.blueprintId[0]
-//       : fields.blueprintId;
-//     const category = Array.isArray(fields.category)
-//       ? fields.category[0]
-//       : fields.category;
-//     const filename = Array.isArray(fields.filename)
-//       ? fields.filename[0]
-//       : fields.filename;
-
-//     // Upload file to B2
-//     const uploadResponse = await b2.uploadFile({
-//       uploadUrl: response.data.uploadUrl,
-//       uploadAuthToken: response.data.authorizationToken,
-//       fileName: `uploads/${blueprintId}/${category}/${filename}`,
-//       data: fileBuffer,
-//       mime: uploadedFile.mimetype || "application/octet-stream",
-//     });
-
-//     // Construct the public URL
-//     const publicUrl = `https://f005.backblazeb2.com/file/uploadedFiles-dev/uploads/${blueprintId}/${category}/${filename}`;
-
-//     // Return success response
-//     res.status(200).json({
-//       url: publicUrl,
-//       fileId: uploadResponse.data.fileId,
-//     });
-//   } catch (error) {
-//     console.error("B2 upload error:", error);
-//     res.status(500).json({
-//       error: "Failed to upload to B2",
-//       details: error instanceof Error ? error.message : "Unknown error",
-//     });
-//   }
-// }
+      res.status(200).json({ url: publicUrl, fileName });
+    } catch (error) {
+      console.error("B2 upload error:", error);
+      res.status(500).json({ error: "Failed to upload to B2" });
+    }
+  });
+}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -6,6 +6,7 @@ import submitToSheetsHandler from "../client/src/pages/api/submit-to-sheets";
 import processWaitlistHandler from "./routes/process-waitlist";
 // import processMappingConfirmationHandler from "./routes/mapping-confirmation"; // Commented out - handler is not exported
 import demoDayConfirmationHandler from "./routes/demo-day-confirmation";
+import uploadToB2Handler from "../client/src/pages/api/upload-to-b2";
 
 export function registerRoutes(app: Express) {
   // API routes for Express
@@ -16,4 +17,5 @@ export function registerRoutes(app: Express) {
   app.post("/api/process-waitlist", processWaitlistHandler);
   // app.post("/api/mapping-confirmation", processMappingConfirmationHandler); // Commented out - handler is not exported
   app.post("/api/demo-day-confirmation", demoDayConfirmationHandler);
+  app.post("/api/upload-to-b2", uploadToB2Handler);
 }


### PR DESCRIPTION
## Summary
- add Backblaze B2 upload API and register route
- upload models to Backblaze from ScannerPortal
- load ThreeViewer models from provided URL instead of hard-coded asset

## Testing
- `npm test` (fails: Missing script "test")
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b0c3fa9404832389d412b35585c644