### PR TITLE
fix: reset 3D alignment markers

### DIFF
--- a/client/src/pages/ScannerPortal.tsx
+++ b/client/src/pages/ScannerPortal.tsx
@@ -2115,6 +2115,7 @@ export default function ScannerPortal() {
                   modelPath={blueprint3DModelUrl}
                   activeLabel={activeLabel}
                   awaiting3D={awaiting3D}
+                  referencePoints3D={referencePoints3D}
                   setReferencePoints3D={setReferencePoints3D}
                   setAwaiting3D={setAwaiting3D}
                   setActiveLabel={setActiveLabel}


### PR DESCRIPTION
## Summary
- track 3D alignment markers in ThreeViewer
- remove stored markers when reference points are cleared
- wire up ScannerPortal to pass referencePoints3D

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b0dab1ef288323b46a309b99c5a0fc