### PR TITLE
Initialize storage folder for new blueprints

### DIFF
--- a/client/src/pages/OffWaitlistSignUpFlow.tsx
+++ b/client/src/pages/OffWaitlistSignUpFlow.tsx
@@ -55,6 +55,7 @@ import {
 } from "firebase/firestore";
 import { GoogleOAuthProvider, GoogleLogin } from "@react-oauth/google";
 import { db } from "@/lib/firebase";
+import { getStorage, ref, uploadBytes } from "firebase/storage";
 
 export default function OffWaitlistSignUpFlow() {
   // ------------------------------
@@ -553,6 +554,14 @@ export default function OffWaitlistSignUpFlow() {
           email: email.trim(),
           phone: phoneNumber.trim(),
         });
+
+        // Create a placeholder file to initialize the blueprint's storage folder
+        const storage = getStorage();
+        const placeholderRef = ref(
+          storage,
+          `blueprints/${blueprintId}/placeholder.txt`,
+        );
+        await uploadBytes(placeholderRef, new Uint8Array());
 
         const demoBookingDate = demoDate.toISOString().split("T")[0];
         const demoBookingId = `demo_${demoBookingDate}_${demoTime}`;

--- a/client/src/pages/OutboundSignUpFlow.tsx
+++ b/client/src/pages/OutboundSignUpFlow.tsx
@@ -56,6 +56,7 @@ import {
 } from "firebase/firestore";
 import { GoogleOAuthProvider, GoogleLogin } from "@react-oauth/google";
 import { db } from "@/lib/firebase";
+import { getStorage, ref, uploadBytes } from "firebase/storage";
 
 // ---------------------------------------------------------
 // Component
@@ -438,6 +439,14 @@ export default function OutboundSignUpFlow() {
           email: email.trim(),
           phone: phoneNumber.trim(),
         });
+
+        // Initialize storage folder for this blueprint with a placeholder file
+        const storage = getStorage();
+        const placeholderRef = ref(
+          storage,
+          `blueprints/${blueprintId}/placeholder.txt`,
+        );
+        await uploadBytes(placeholderRef, new Uint8Array());
 
         // Demo booking
         const demoBookingDate = demoDate.toISOString().split("T")[0];


### PR DESCRIPTION
## Summary
- create Firebase Storage folder for new blueprints in OffWaitlistSignUpFlow
- create Firebase Storage folder for new blueprints in OutboundSignUpFlow

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx vitest run` *(fails: ReferenceError: google is not defined and other hook errors)*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68ba05e8698483238a5e7af98985c65e