### PR TITLE
Add blog section with WarehouseOS article

### DIFF
--- a/client/src/components/Nav.jsx
+++ b/client/src/components/Nav.jsx
@@ -69,6 +69,7 @@ export default function Nav({
   const userInitials = getInitials(userData?.name || userData?.displayName);
 
   const navLinks = [
+    { href: "/blog", label: "Blog" },
     { href: "/pilot-program", label: "Pilot Program", badge: "New" },
     // Show these only if authenticated and not hidden
     ...(currentUser && !hideAuthenticatedFeatures

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -40,6 +40,8 @@ const Terms = lazy(() => import("./pages/Terms"));
 const FAQ = lazy(() => import("./pages/FAQ"));
 const EmbedCalendar = lazy(() => import("./pages/EmbedCalendar"));
 const EmbedDashboard = lazy(() => import("./pages/EmbedDashboard"));
+const Blog = lazy(() => import("./pages/Blog"));
+const WarehouseOS = lazy(() => import("./pages/blog/WarehouseOS"));
 
 function Router() {
   return (
@@ -55,6 +57,8 @@ function Router() {
       <Route path="/outbound-signup" component={OutboundSignUpFlow} />
       <Route path="/workspace" component={WorkspacePage} />
       <Route path="/help" component={Help} />
+      <Route path="/blog" component={Blog} />
+      <Route path="/blog/warehouse-os" component={WarehouseOS} />
       <Route path="/manage-plan" component={ManagePlan} />
       <Route path="/team-members" component={TeamMembers} />
       <Route path="/settings" component={Settings} />

--- a/client/src/pages/Blog.tsx
+++ b/client/src/pages/Blog.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { Link } from "wouter";
+import Nav from "@/components/Nav";
+import Footer from "@/components/Footer";
+import { Card, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+
+export default function Blog() {
+  const posts = [
+    {
+      title: "warehouseOS – our first vertical",
+      description: "How Blueprint brings AR and AI to warehouses for faster, safer operations.",
+      href: "/blog/warehouse-os",
+    },
+  ];
+
+  return (
+    <div className="flex flex-col min-h-screen bg-gradient-to-br from-blue-50 via-indigo-50 to-white">
+      <Nav />
+      <main className="flex-1 pt-24 px-4 md:px-8">
+        <section className="max-w-4xl mx-auto">
+          <h1 className="text-4xl md:text-5xl font-bold text-center mb-8 gradient-text">Blueprint Blog</h1>
+          <div className="grid gap-6 md:grid-cols-2">
+            {posts.map((post) => (
+              <Link key={post.href} href={post.href} className="block group">
+                <Card className="h-full hover:shadow-xl transition-shadow">
+                  <CardHeader>
+                    <CardTitle className="group-hover:text-blue-600 transition-colors">
+                      {post.title}
+                    </CardTitle>
+                    <CardDescription>{post.description}</CardDescription>
+                  </CardHeader>
+                </Card>
+              </Link>
+            ))}
+          </div>
+        </section>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/client/src/pages/blog/WarehouseOS.tsx
+++ b/client/src/pages/blog/WarehouseOS.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { Link } from "wouter";
+import Nav from "@/components/Nav";
+import Footer from "@/components/Footer";
+
+export default function WarehouseOS() {
+  return (
+    <div className="flex flex-col min-h-screen bg-gradient-to-br from-blue-50 via-indigo-50 to-white">
+      <Nav />
+      <main className="flex-1 pt-24 px-4 md:px-8">
+        <article className="prose prose-slate md:prose-lg mx-auto">
+          <h1 className="mb-4">warehouseOS – our first vertical</h1>
+          <p>
+            Blueprint is building the operating system for physical spaces—our motto is
+            <strong>"know the place to serve the person."</strong> warehouseOS brings that
+            vision to distribution centers and fulfillment sites, blending AR and AI to
+            understand every aisle, rack and bin so people can work faster and safer.
+          </p>
+          <h2>Key capabilities</h2>
+          <ul>
+            <li>Ask where any SKU lives and get an AR path directly to the bin.</li>
+            <li>Vision picking with hands-free confirmations cuts walking and errors.</li>
+            <li>Smart slotting suggestions and putaway guidance reduce travel time.</li>
+            <li>Safety overlays warn about forklifts, no-go zones and pedestrian traffic.</li>
+            <li>Cycle counting and receiving QA use computer vision for instant accuracy.</li>
+          </ul>
+          <h2>ROI snapshot</h2>
+          <ul>
+            <li>15–25% faster picks compared to paper or handheld scanners.</li>
+            <li>Mispicks often cost $22–$100 each; halving them saves six figures yearly.</li>
+            <li>AR-guided training can cut ramp time by 50% or more.</li>
+          </ul>
+          <p>
+            warehouseOS is just the beginning. By treating location as a first-class
+            interface, Blueprint unlocks new efficiency and safety gains for every type of
+            facility.
+          </p>
+          <p>
+            <Link href="/blog" className="text-blue-600">&larr; Back to all posts</Link>
+          </p>
+        </article>
+      </main>
+      <Footer />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add site-wide blog route and navigation link
- Introduce main blog page with card-based layout
- Publish initial post "warehouseOS – our first vertical"

## Testing
- `npx vitest run` *(fails: ReferenceError google is not defined, invalid hook calls)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0b6089a88323ac367c9e7f3a035f