### PR TITLE
Replace Vision Pro references with VR headset and update Pilot Program

### DIFF
--- a/Blueprint-WebApp/client/src/pages/PilotProgram.jsx
+++ b/Blueprint-WebApp/client/src/pages/PilotProgram.jsx
@@ -183,7 +183,7 @@ export default function PilotProgram() {
         "Experience your space transformed with AR using cutting-edge devices. See the magic firsthand!",
       color: "from-purple-500 to-pink-500",
       benefit: "Hands-on experience",
-      details: ["Vision Pro demo", "Team training", "Immediate feedback"],
+      details: ["VR headset demo", "Team training", "Immediate feedback"],
     },
   ];
 
@@ -224,7 +224,7 @@ export default function PilotProgram() {
     {
       icon: <Monitor className="w-6 h-6" />,
       title: "Premium Hardware",
-      description: "Test with Apple Vision Pro and other cutting-edge devices",
+      description: "Test with a VR headset and other cutting-edge devices",
       highlight: "No purchase needed",
     },
     {
@@ -280,7 +280,7 @@ export default function PilotProgram() {
     },
     {
       q: "Do we need special hardware for customers?",
-      a: "No! That's the beauty of Blueprint. Your customers access the AR experience through their own devices via web browser - no app download needed. During the pilot, we bring Vision Pro and other devices for demos, but day-to-day operation only requires customer's devices.",
+      a: "No! That's the beauty of Blueprint. Your customers access the AR experience through their own devices via web browser - no app download needed. During the pilot, we bring a VR headset and other devices for demos, but day-to-day operation only requires customer's devices.",
     },
     {
       q: "What do you need from us?",

--- a/client/src/components/pilotCopy.ts
+++ b/client/src/components/pilotCopy.ts
@@ -16,7 +16,7 @@ export const PILOT_FAQ: FAQ[] = [
   },
   {
     q: "Do customers need special hardware?",
-    a: "No. The AR runs in the browser via QR codes. For demo day, we bring an Apple Vision Pro so your team can try it hands-on.",
+    a: "No. The AR runs in the browser via QR codes. For demo day, we bring a VR headset so your team can try it hands-on.",
   },
   {
     q: "What do you need from us?",

--- a/client/src/pages/Discover.tsx
+++ b/client/src/pages/Discover.tsx
@@ -1099,7 +1099,7 @@ const steps = [
     icon: <Rocket className="w-6 h-6 md:w-8 md:h-8" />,
     title: "Demo Day",
     description:
-      "We'll come in with an Apple Vision Pro to give a ~1 hour long demonstration. Open to any and everyone!",
+      "We'll come in with a VR headset to give a ~1 hour long demonstration. Open to any and everyone!",
     benefits: ["Feedback", "Performance analytics", "Continuous optimization"],
     color: "from-fuchsia-500 to-pink-600",
     duration: "Next Week",

--- a/client/src/pages/FAQ.tsx
+++ b/client/src/pages/FAQ.tsx
@@ -34,7 +34,7 @@ export default function FAQ() {
     },
     {
       q: "Do we need special hardware for customers?",
-      a: "No! That's the beauty of Blueprint. Your customers access the AR experience through their own devices via web browser - no app download needed. During the pilot, we bring Vision Pro and other devices for demos, but day-to-day operation only requires customer's devices.",
+      a: "No! That's the beauty of Blueprint. Your customers access the AR experience through their own devices via web browser - no app download needed. During the pilot, we bring a VR headset and other devices for demos, but day-to-day operation only requires customer's devices.",
     },
     {
       q: "What do you need from us?",

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -311,7 +311,7 @@ export default function Home() {
                   <li>• LiDAR mapping of your space</li>
                   <li>• Custom AR layer tailored to your brand</li>
                   <li>• QR kit for instant access on-site</li>
-                  <li>• Apple Vision Pro demo day for your team</li>
+                  <li>• VR headset demo day for your team</li>
                   <li>• Simple engagement recap & next-step options</li>
                 </ul>
               </div>
@@ -401,7 +401,7 @@ export default function Home() {
                   <li>• LiDAR mapping</li>
                   <li>• Custom AR layer</li>
                   <li>• QR kit</li>
-                  <li>• Vision Pro demo day</li>
+                  <li>• VR headset demo day</li>
                   <li>• Engagement recap</li>
                 </ul>
               </div>
@@ -1167,7 +1167,7 @@ function Stat({ label, value }: { label: string; value: string }) {
 //       icon: <Rocket className="w-6 h-6 md:w-8 md:h-8" />,
 //       title: "Demo Day",
 //       description:
-//         "We'll come in with an Apple Vision Pro to give a ~1 hour long demonstration. Open to any and everyone!",
+//         "We'll come in with a VR headset to give a ~1 hour long demonstration. Open to any and everyone!",
 //       benefits: [
 //         "Feedback",
 //         "Performance analytics",

--- a/client/src/pages/PilotProgram.jsx
+++ b/client/src/pages/PilotProgram.jsx
@@ -244,7 +244,7 @@ function getBenefitDetails(title) {
       "Clear next steps after demo",
     ],
     "Premium Hardware": [
-      "Apple Vision Pro demo day",
+      "VR headset demo day",
       "We bring devices on-site",
       "Hands-on staff training",
       "No hardware purchase required",
@@ -844,24 +844,24 @@ export default function PilotProgram() {
       details: ["AI-assisted content", "Review checkpoint (async)", "QR plan"],
     },
     {
-      icon: <Wand2 className="w-6 h-6" />,
-      title: "Prep & Briefing",
-      subtitle: "We get your team ready",
-      description:
-        "We place/ship QR kits, finish polish, and share a quick briefing so demo day runs smoothly.",
-      color: "from-teal-500 to-emerald-500",
-      benefit: "Smooth demo day",
-      details: ["QR placement", "Final adjustments", "Team briefing"],
-    },
-    {
       icon: <PlayCircle className="w-6 h-6" />,
       title: "Visit 2",
       subtitle: "Live Demo Day (1–2 hrs)",
       description:
-        "We bring Apple Vision Pro and run the demo end-to-end. Your team tries it hands-on; we handle devices, setup, and sanitization. The AR is live during the scheduled demo window only.",
+        "We bring a VR headset and run the demo end-to-end. Your team tries it hands-on; we handle devices, setup, and sanitization. The AR is live during the scheduled demo window only.",
       color: "from-emerald-400 to-cyan-400",
       benefit: "Hands-on, on-site",
-      details: ["Vision Pro", "Team walkthrough", "Immediate insights"],
+      details: ["VR headset", "Team walkthrough", "Immediate insights"],
+    },
+    {
+      icon: <Send className="w-6 h-6" />,
+      title: "Feedback & Survey",
+      subtitle: "10 min questionnaire",
+      description:
+        "After the demo, we send a short survey to your team. Your feedback keeps the pilot free and helps Blueprint improve.",
+      color: "from-cyan-400 to-emerald-400",
+      benefit: "Your input matters",
+      details: ["10-minute survey", "Participant insights", "Keeps program free"],
     },
   ];
   // const timeline = [
@@ -908,10 +908,10 @@ export default function PilotProgram() {
   //     title: "Week 2",
   //     subtitle: "Live Demo Day",
   //     description:
-  //       "See your space come alive on Apple Vision Pro and other devices. Collect instant feedback.",
+  //       "See your space come alive on a VR headset and other devices. Collect instant feedback.",
   //     color: "from-emerald-400 to-cyan-400",
   //     benefit: "Hands-on, on-site",
-  //     details: ["Vision Pro demo", "Team training", "Immediate insights"],
+  //     details: ["VR headset demo", "Team training", "Immediate insights"],
   //   },
   // ];
 
@@ -953,7 +953,7 @@ export default function PilotProgram() {
     {
       icon: <Monitor className="w-6 h-6" />,
       title: "Premium Hardware",
-      description: "We bring an Apple Vision Pro to your demo day.",
+      description: "We bring a VR headset to your demo day.",
       highlight: "No hardware needed",
     },
     {
@@ -987,7 +987,7 @@ export default function PilotProgram() {
     },
     {
       q: "Do customers need special hardware?",
-      a: "No. The AR runs in the browser via QR codes. For demo day, we bring an Apple Vision Pro so your team can try it hands-on.",
+      a: "No. The AR runs in the browser via QR codes. For demo day, we bring a VR headset so your team can try it hands-on.",
     },
     {
       q: "What do you need from us?",
@@ -2137,7 +2137,7 @@ export default function PilotProgram() {
 //       "No hidden fees or surprises",
 //     ],
 //     "Premium Hardware": [
-//       "Apple Vision Pro demos included",
+  //       "VR headset demos included",
 //       "Latest AR technology access",
 //       "Professional setup & training",
 //       "Hardware experts on-site",
@@ -3008,7 +3008,7 @@ export default function PilotProgram() {
 //         "Experience your space transformed with AR using cutting-edge devices. See the magic firsthand!",
 //       color: "from-purple-500 to-pink-500",
 //       benefit: "Hands-on experience",
-//       details: ["Vision Pro demo", "Team training", "Immediate feedback"],
+  //       details: ["VR headset demo", "Team training", "Immediate feedback"],
 //     },
 //   ];
 
@@ -3049,7 +3049,7 @@ export default function PilotProgram() {
 //     {
 //       icon: <Monitor className="w-6 h-6" />,
 //       title: "Premium Hardware",
-//       description: "Test with Apple Vision Pro and other cutting-edge devices",
+  //       description: "Test with a VR headset and other cutting-edge devices",
 //       highlight: "No purchase needed",
 //     },
 //     {
@@ -3107,7 +3107,7 @@ export default function PilotProgram() {
 //     },
 //     {
 //       q: "Do we need special hardware for customers?",
-//       a: "No! That's the beauty of Blueprint. Your customers access the AR experience through their own devices via web browser - no app download needed. During the pilot, we bring Vision Pro and other devices for demos, but day-to-day operation only requires customer's devices.",
+  //       a: "No! That's the beauty of Blueprint. Your customers access the AR experience through their own devices via web browser - no app download needed. During the pilot, we bring a VR headset and other devices for demos, but day-to-day operation only requires customer's devices.",
 //     },
 //     {
 //       q: "What do you need from us?",


### PR DESCRIPTION
## Summary
- Replace all mentions of Apple Vision Pro with a VR headset across Home, Discover, FAQ, and Pilot Program pages.
- Revise Pilot Program timeline: Live Demo Day becomes the third step and a new Feedback & Survey card is added.
- Update shared pilot FAQ copy to use VR headset wording.

## Testing
- `npm test` *(fails: Missing script 'test')*
- `npm run build` *(fails: TypeScript errors in BlueprintEditor.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c23d0c4038832386374ce0069fc8c7