### PR TITLE
feat: add QR deep link redirect

### DIFF
--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -49,6 +49,8 @@ const MuseumOS = lazy(() => import("./pages/blog/MuseumOS"));
 const HospitalityOS = lazy(() => import("./pages/blog/HospitalityOS"));
 const RestaurantOS = lazy(() => import("./pages/blog/RestaurantOS"));
 const WorkplaceOS = lazy(() => import("./pages/blog/WorkplaceOS"));
+const Launch = lazy(() => import("./pages/Launch"));
+const WebXR = lazy(() => import("./pages/WebXR"));
 
 function Router() {
   return (
@@ -78,6 +80,8 @@ function Router() {
       <Route path="/scanner-portal" component={ScannerPortal} />
       <Route path="/accept-invite" component={AcceptInvite} />
       <Route path="/pilot-program" component={PilotProgram} />
+      <Route path="/launch" component={Launch} />
+      <Route path="/webxr" component={WebXR} />
       <Route path="/privacy" component={PrivacyPolicy} />
       <Route path="/terms" component={Terms} />
       <Route path="/faq" component={FAQ} />

--- a/client/src/pages/Launch.tsx
+++ b/client/src/pages/Launch.tsx
@@ -1,0 +1,27 @@
+import { useEffect } from "react";
+
+export default function Launch() {
+  useEffect(() => {
+    const appUrl = "blueprint://open"; // custom URL scheme for native app
+    const fallbackUrl = "/webxr"; // local fallback route
+    const start = Date.now();
+
+    // attempt to open the native app
+    window.location.href = appUrl;
+
+    // if the app isn't installed, redirect to fallback after 1.5s
+    const timer = setTimeout(() => {
+      if (Date.now() - start < 2000) {
+        window.location.href = fallbackUrl;
+      }
+    }, 1500);
+
+    return () => clearTimeout(timer);
+  }, []);
+
+  return (
+    <div className="flex h-screen w-full items-center justify-center">
+      <p className="text-lg text-gray-700">Launching Blueprint…</p>
+    </div>
+  );
+}

--- a/client/src/pages/WebXR.tsx
+++ b/client/src/pages/WebXR.tsx
@@ -1,0 +1,7 @@
+export default function WebXR() {
+  return (
+    <div className="flex h-screen w-full items-center justify-center">
+      <p className="text-lg text-gray-700">WebXR experience coming soon…</p>
+    </div>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build && npx esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "db:push": "drizzle-kit push"
+    "db:push": "drizzle-kit push",
+    "generate-qr": "tsx scripts/generate-qr.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.52.0",

--- a/scripts/generate-qr.ts
+++ b/scripts/generate-qr.ts
@@ -1,0 +1,18 @@
+import QRCode from "qrcode";
+import { writeFile } from "fs/promises";
+import path from "path";
+
+const url = "https://www.tryblueprint.io/launch";
+const outPath = path.resolve("Blueprint-QR.png");
+
+async function generate() {
+  try {
+    const data = await QRCode.toBuffer(url, { width: 512 });
+    await writeFile(outPath, data);
+    console.log(`QR code created at ${outPath}`);
+  } catch (err) {
+    console.error("Failed to generate QR code", err);
+  }
+}
+
+generate();


### PR DESCRIPTION
## Summary
- redirect users to native app via custom scheme with WebXR fallback
- expose `/launch` and `/webxr` routes in SPA router
- add QR code generator script and npm target

## Testing
- `npm test` *(fails: Missing script)*
- `npm run generate-qr`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68c71bd01d1483238679b1c1e75c75c3