### PR TITLE
Ensure signup flows advance even if Lindy webhook fails

### DIFF
--- a/client/src/pages/OffWaitlistSignUpFlow.tsx
+++ b/client/src/pages/OffWaitlistSignUpFlow.tsx
@@ -585,26 +585,28 @@ export default function OffWaitlistSignUpFlow() {
         setErrorMessage("No user found. Please sign up first.");
         return;
       }
+
+      const bookingDate = scheduleDate.toISOString().split("T")[0];
+      const bookingId = `${bookingDate}_${scheduleTime}`;
+      const blueprintId = crypto.randomUUID();
+      const demoBookingDate = demoDate.toISOString().split("T")[0];
+      const demoBookingId = `demo_${demoBookingDate}_${demoTime}`;
+      const estimatedSquareFootage = squareFootage ?? 0;
+      const estimatedMappingPayout = parseFloat(
+        (estimatedSquareFootage / 60).toFixed(2),
+      );
+      const estimatedMappingTime = parseFloat(
+        (estimatedSquareFootage / 100 + 15).toFixed(2),
+      );
+      const estimatedDesignPayout = parseFloat(
+        (estimatedSquareFootage / 80).toFixed(2),
+      );
+
       try {
         await updateDoc(doc(db, "users", user.uid), {
           demoScheduleDate: demoDate,
           demoScheduleTime: demoTime,
         });
-
-        const bookingDate = scheduleDate.toISOString().split("T")[0];
-        const bookingId = `${bookingDate}_${scheduleTime}`;
-        const blueprintId = crypto.randomUUID();
-
-        const estimatedSquareFootage = squareFootage ?? 0;
-        const estimatedMappingPayout = parseFloat(
-          (estimatedSquareFootage / 60).toFixed(2),
-        );
-        const estimatedMappingTime = parseFloat(
-          ((estimatedSquareFootage / 100) + 15).toFixed(2)
-        );
-        const estimatedDesignPayout = parseFloat(
-          (estimatedSquareFootage / 80).toFixed(2),
-        );
 
         await setDoc(doc(db, "bookings", bookingId), {
           id: bookingId,
@@ -618,7 +620,7 @@ export default function OffWaitlistSignUpFlow() {
           email: email.trim(),
           status: "pending",
           blueprintId,
-          demoScheduleDate: demoDate.toISOString().split("T")[0],
+          demoScheduleDate: demoBookingDate,
           demoScheduleTime: demoTime,
           createdAt: serverTimestamp(),
           estimatedSquareFootage,
@@ -642,16 +644,12 @@ export default function OffWaitlistSignUpFlow() {
           phone: phoneNumber.trim(),
         });
 
-        // Create a placeholder file to initialize the blueprint's storage folder
         const storage = getStorage();
         const placeholderRef = ref(
           storage,
           `blueprints/${blueprintId}/placeholder.txt`,
         );
         await uploadBytes(placeholderRef, new Uint8Array());
-
-        const demoBookingDate = demoDate.toISOString().split("T")[0];
-        const demoBookingId = `demo_${demoBookingDate}_${demoTime}`;
 
         await setDoc(doc(db, "demoBookings", demoBookingId), {
           id: demoBookingId,
@@ -674,57 +672,61 @@ export default function OffWaitlistSignUpFlow() {
         await updateDoc(doc(db, "users", user.uid), {
           createdBlueprintIDs: arrayUnion(blueprintId),
         });
-
-        setStep((p) => p + 1);
-        setPaymentStatus("idle");
-        setPaymentError(null);
-
-        const chosenDate = scheduleDate.toISOString().split("T")[0];
-        const chosenTime = scheduleTime;
-
-        fetch(
-          "https://public.lindy.ai/api/v1/webhooks/lindy/43c7b7d7-bc40-4593-acfe-ba79ad6488b8",
-          {
-            method: "POST",
-            headers: {
-              Authorization:
-                "Bearer 1b1338d68dff4f009bbfaee1166cb9fc48b5fefa6dddbea797264674e2ee0150",
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify({
-              have_we_onboarded: "No",
-              chosen_time_of_mapping: chosenTime,
-              chosen_date_of_mapping: chosenDate,
-              have_user_chosen_date: "Yes",
-              address: address.trim(),
-              company_url: companyWebsite.trim() || "",
-              company_name: organizationName.trim(),
-              contact_name: contactName.trim(),
-              contact_phone_number: phoneNumber.trim(),
-              estimated_square_footage: squareFootage,
-              contact_email: email.trim(),
-              blueprint_id: blueprintId,
-              chosen_date_of_demo: demoDate.toISOString().split("T")[0],
-              chosen_time_of_demo: demoTime,
-            }),
-          },
-        )
-          .then(async (resp) => {
-            if (!resp.ok) {
-              const text = await resp.text();
-              console.error("Lindy webhook failed:", text);
-            } else {
-              const result = await resp.json();
-              console.log("Lindy webhook ok:", result);
-            }
-          })
-          .catch((err) => console.error("Lindy webhook error:", err));
       } catch (error: unknown) {
         console.error("Error completing booking setup:", error);
         const msg = error instanceof Error ? error.message : "Unknown error";
         setErrorMessage("Error completing booking setup: " + msg);
         return;
       }
+
+      setStep((p) => p + 1);
+      setPaymentStatus("idle");
+      setPaymentError(null);
+
+      const lindyPayload = {
+        have_we_onboarded: "No",
+        chosen_time_of_mapping: scheduleTime,
+        chosen_date_of_mapping: bookingDate,
+        have_user_chosen_date: "Yes",
+        address: address.trim(),
+        company_url: companyWebsite.trim() || "",
+        company_name: organizationName.trim(),
+        contact_name: contactName.trim(),
+        contact_phone_number: phoneNumber.trim(),
+        estimated_square_footage: squareFootage,
+        contact_email: email.trim(),
+        blueprint_id: blueprintId,
+        chosen_date_of_demo: demoBookingDate,
+        chosen_time_of_demo: demoTime,
+      };
+
+      void (async () => {
+        try {
+          const resp = await fetch(
+            "https://public.lindy.ai/api/v1/webhooks/lindy/43c7b7d7-bc40-4593-acfe-ba79ad6488b8",
+            {
+              method: "POST",
+              headers: {
+                Authorization:
+                  "Bearer 1b1338d68dff4f009bbfaee1166cb9fc48b5fefa6dddbea797264674e2ee0150",
+                "Content-Type": "application/json",
+              },
+              body: JSON.stringify(lindyPayload),
+            },
+          );
+
+          if (!resp.ok) {
+            const text = await resp.text();
+            console.error("Lindy webhook failed:", text);
+            return;
+          }
+
+          const result = await resp.json();
+          console.log("Lindy webhook ok:", result);
+        } catch (err) {
+          console.error("Lindy webhook error:", err);
+        }
+      })();
     }
   }
 


### PR DESCRIPTION
## Summary
- refactor the demo-day scheduling step in the outbound and off-waitlist signup flows to separate required Firestore work from the optional Lindy webhook
- run the Lindy webhook fire-and-forget with defensive error handling so the UI advances even if the webhook fails

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c9023b504483238e5c1059839e6390