### PR TITLE
Handle Lindy webhook failures without blocking onboarding

### DIFF
--- a/client/src/pages/OffWaitlistSignUpFlow.tsx
+++ b/client/src/pages/OffWaitlistSignUpFlow.tsx
@@ -61,6 +61,10 @@ import {
 import { GoogleOAuthProvider, GoogleLogin } from "@react-oauth/google";
 import { db } from "@/lib/firebase";
 import { getStorage, ref, uploadBytes } from "firebase/storage";
+import {
+  triggerLindyWebhook,
+  type LindyWebhookPayload,
+} from "@/utils/lindyWebhook";
 
 const ONBOARDING_FEE = 499.99;
 const MONTHLY_RATE = 49.99;
@@ -690,11 +694,11 @@ export default function OffWaitlistSignUpFlow() {
         return;
       }
 
-      setStep((p) => p + 1);
+      setStep((current) => (current >= 5 ? current : current + 1));
       setPaymentStatus("idle");
       setPaymentError(null);
 
-      const lindyPayload = {
+      const lindyPayload: LindyWebhookPayload = {
         have_we_onboarded: "No",
         chosen_time_of_mapping: scheduleTime,
         chosen_date_of_mapping: bookingDate,
@@ -711,33 +715,11 @@ export default function OffWaitlistSignUpFlow() {
         chosen_time_of_demo: demoTime,
       };
 
-      void (async () => {
-        try {
-          const resp = await fetch(
-            "https://public.lindy.ai/api/v1/webhooks/lindy/43c7b7d7-bc40-4593-acfe-ba79ad6488b8",
-            {
-              method: "POST",
-              headers: {
-                Authorization:
-                  "Bearer 1b1338d68dff4f009bbfaee1166cb9fc48b5fefa6dddbea797264674e2ee0150",
-                "Content-Type": "application/json",
-              },
-              body: JSON.stringify(lindyPayload),
-            },
-          );
-
-          if (!resp.ok) {
-            const text = await resp.text();
-            console.error("Lindy webhook failed:", text);
-            return;
-          }
-
-          const result = await resp.json();
-          console.log("Lindy webhook ok:", result);
-        } catch (err) {
-          console.error("Lindy webhook error:", err);
-        }
-      })();
+      try {
+        triggerLindyWebhook(lindyPayload);
+      } catch (err) {
+        console.error("Lindy webhook invocation error:", err);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- route Lindy webhook traffic for both sign-up flows through the shared helper so failures are logged without interrupting onboarding
- ensure the transition from demo scheduling to the payment step always advances, preventing double increments and continuing even if the webhook is unreachable

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c96cf8aa6483239498c9d2ffdf0f45