### PR TITLE
Add AI welcome message templates to post-signup workflow

### DIFF
--- a/docs/blueprint_document.md
+++ b/docs/blueprint_document.md
@@ -1,0 +1,18 @@
+# Blueprint Firestore Document Field Reference
+
+## AI assistant welcome messages
+
+| Field name | Type | Description |
+| --- | --- | --- |
+| `aiAssistantWelcomeMessages` | object | Mapping of persona identifiers to the default welcome message text generated after deep research completes for a location. |
+| `aiAssistantWelcomeMessagesUpdatedAt` | Firestore timestamp | Server timestamp recorded when welcome messages are generated or refreshed. |
+
+### Persona keys stored in `aiAssistantWelcomeMessages`
+
+- `targetCustomer`
+- `casualVisitor`
+- `vipMember`
+- `staffMember`
+- `partnerPress`
+
+Each value is a short 1–2 sentence greeting tailored to the persona, encouraging guests to ask the Blueprint assistant for help.


### PR DESCRIPTION
## Summary
- extend the post-signup workflow to request AI-generated welcome messages for each persona and persist them on the blueprint document
- add helpers for normalizing welcome message payloads and storing updated timestamps and counts
- document the new `aiAssistantWelcomeMessages` fields in the blueprint Firestore field reference

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68cdb6c8de608323a170ab50347ddbab