### PR TITLE
Switch post-signup workflows to Parallel deep research

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -8,9 +8,11 @@ import processWaitlistHandler from "./routes/process-waitlist";
 import demoDayConfirmationHandler from "./routes/demo-day-confirmation";
 import uploadToB2Handler from "../client/src/pages/api/upload-to-b2";
 import postSignupWorkflowsHandler from "./routes/post-signup-workflows";
+import webhooksRouter from "./routes/webhooks";
 
 export function registerRoutes(app: Express) {
   // API routes for Express
+  app.use("/api/webhooks", webhooksRouter);
   app.post("/api/create-checkout-session", createCheckoutSessionHandler);
   app.get("/api/googlePlaces", googlePlacesHandler);
   app.all("/api/generate-image", generateImageHandler);

--- a/server/routes/post-signup-workflows.ts
+++ b/server/routes/post-signup-workflows.ts
@@ -9,99 +9,378 @@ import {
   type PostSignupWorkflowPromptInput,
 } from "../utils/ai-prompts";
 
-const perplexityApiKey =
-  process.env.PERPLEXITY_API_KEY ||
-  "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";
-const perplexityTimeoutMs = Number(process.env.PERPLEXITY_TIMEOUT_MS ?? 60_000);
-const deepResearchModel =
-  process.env.PERPLEXITY_DEEP_RESEARCH_MODEL || "sonar-deep-research";
-const instructionsModel =
-  process.env.PERPLEXITY_INSTRUCTIONS_MODEL || deepResearchModel;
-const reasoningEffort = (process.env.PERPLEXITY_REASONING_EFFORT ?? "high") as
-  | "low"
-  | "medium"
-  | "high";
-const PERPLEXITY_ENDPOINT = "https://api.perplexity.ai/chat/completions";
-const PERPLEXITY_SYSTEM_MESSAGE =
-  "You are Blueprint's automation copilot. Follow the user's instructions exactly and respond with valid JSON whenever a schema is provided.";
+const parallelApiKey =
+  process.env.PARALLEL_API_KEY ||
+  "V9xyphAxwfrJb1faYC5c_-x4T93eYzbZDWdenFEw";
+const rawParallelBaseUrl =
+  process.env.PARALLEL_API_BASE_URL || "https://api.parallel.ai";
+const parallelBaseUrl = rawParallelBaseUrl.replace(/\/+$/, "");
+const parallelProcessor = process.env.PARALLEL_PROCESSOR || "ultra";
+const parallelResearchProcessor =
+  process.env.PARALLEL_RESEARCH_PROCESSOR || parallelProcessor;
+const parallelInstructionsProcessor =
+  process.env.PARALLEL_INSTRUCTIONS_PROCESSOR || parallelProcessor;
+const parallelWelcomeProcessor =
+  process.env.PARALLEL_WELCOME_PROCESSOR || parallelInstructionsProcessor;
+const parallelApiVersion = process.env.PARALLEL_API_VERSION;
+const parallelHttpTimeoutMs = Number(
+  process.env.PARALLEL_HTTP_TIMEOUT_MS ?? 120_000,
+);
+const parallelMaxWaitMs = Number(
+  process.env.PARALLEL_MAX_WAIT_MS ?? 30 * 60 * 1_000,
+);
+const parallelPollIntervalMs = Math.max(
+  500,
+  Number(process.env.PARALLEL_POLL_INTERVAL_MS ?? 5_000),
+);
+const parallelResultTimeoutSeconds = Math.max(
+  30,
+  Number(process.env.PARALLEL_RESULT_TIMEOUT_SECONDS ?? 240),
+);
+const parallelWebhookUrl = process.env.PARALLEL_WEBHOOK_URL;
+const parallelWebhookSecret = process.env.PARALLEL_WEBHOOK_SECRET;
+const parallelWebhookEvents = process.env.PARALLEL_WEBHOOK_EVENTS
+  ? process.env.PARALLEL_WEBHOOK_EVENTS.split(",")
+      .map((event) => event.trim())
+      .filter(Boolean)
+  : ["task.updated", "task.completed", "task.failed"];
 
-type PerplexityMessage = {
-  role: "system" | "user" | "assistant";
-  content: string;
-};
+type ParallelFetchOptions = RequestInit & { timeoutMs?: number };
 
-async function callPerplexity({
-  model,
-  prompt,
-  useReasoning = false,
-  maxOutputTokens,
-}: {
-  model: string;
-  prompt: string;
-  useReasoning?: boolean;
-  maxOutputTokens?: number;
-}) {
-  if (!perplexityApiKey) {
-    throw new Error("Perplexity API key is not configured");
+type ParallelTaskStatus =
+  | "pending"
+  | "queued"
+  | "running"
+  | "in_progress"
+  | "processing"
+  | "completed"
+  | "succeeded"
+  | "finished"
+  | "failed"
+  | "errored"
+  | "error"
+  | "cancelled"
+  | "canceled"
+  | "timeout";
+
+function waitFor(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function parallelApiFetch<T = any>(
+  path: string,
+  options: ParallelFetchOptions = {},
+): Promise<T> {
+  if (!parallelApiKey) {
+    throw new Error("Parallel API key is not configured");
+  }
+
+  const { timeoutMs, headers: requestHeaders, ...init } = options;
+  const url = path.startsWith("http") ? path : `${parallelBaseUrl}${path}`;
+
+  const headers = new Headers(requestHeaders ?? undefined);
+  headers.set("x-api-key", parallelApiKey);
+  headers.set("Accept", "application/json");
+  if (parallelApiVersion && !headers.has("parallel-version")) {
+    headers.set("parallel-version", parallelApiVersion);
+  }
+
+  if (init.body && !headers.has("Content-Type")) {
+    headers.set("Content-Type", "application/json");
   }
 
   const controller = new AbortController();
-  const timeoutId = setTimeout(
-    () => controller.abort(),
-    Math.max(1_000, perplexityTimeoutMs),
-  );
+  const httpTimeout = Math.max(1_000, Number(timeoutMs ?? parallelHttpTimeoutMs));
+  const timeoutId = setTimeout(() => controller.abort(), httpTimeout);
 
   try {
-    const messages: PerplexityMessage[] = [
-      { role: "system", content: PERPLEXITY_SYSTEM_MESSAGE },
-      { role: "user", content: prompt },
-    ];
-
-    const body: Record<string, unknown> = {
-      model,
-      messages,
-      temperature: 0.2,
-      return_references: true,
-      stream: false,
-    };
-
-    if (useReasoning) {
-      body.reasoning = { effort: reasoningEffort };
-    }
-
-    if (typeof maxOutputTokens === "number") {
-      body.max_output_tokens = maxOutputTokens;
-    }
-
-    const response = await fetch(PERPLEXITY_ENDPOINT, {
-      method: "POST",
-      headers: {
-        Accept: "application/json",
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${perplexityApiKey}`,
-      },
-      body: JSON.stringify(body),
+    const response = await fetch(url, {
+      ...init,
+      headers,
       signal: controller.signal,
     });
 
+    const responseText = await response.text().catch(() => "");
+
     if (!response.ok) {
-      const errorText = await response.text().catch(() => "");
-      throw new Error(
-        `Perplexity request failed: ${response.status} ${response.statusText}${
-          errorText ? ` - ${errorText}` : ""
+      const error = new Error(
+        `Parallel API request failed: ${response.status} ${response.statusText}${
+          responseText ? ` - ${responseText}` : ""
         }`,
       );
+      (error as any).status = response.status;
+      (error as any).statusCode = response.status;
+      (error as any).body = responseText;
+      throw error;
     }
 
-    return (await response.json()) as any;
+    if (!responseText) {
+      return undefined as T;
+    }
+
+    try {
+      return JSON.parse(responseText) as T;
+    } catch {
+      return responseText as T;
+    }
   } catch (error: any) {
     if (error?.name === "AbortError") {
-      throw new Error("Perplexity request timed out");
+      const abortError = new Error(
+        `Parallel API request to ${url} timed out after ${httpTimeout} ms`,
+      );
+      (abortError as any).status = 408;
+      (abortError as any).statusCode = 408;
+      throw abortError;
     }
     throw error;
   } finally {
     clearTimeout(timeoutId);
   }
+}
+
+function normalizeParallelResult(result: any) {
+  if (!result || typeof result !== "object") {
+    return result;
+  }
+
+  const normalized: Record<string, any> = { ...result };
+
+  const nestedCandidates = [result.result, result.data, result.output];
+  for (const candidate of nestedCandidates) {
+    if (!candidate || typeof candidate !== "object") continue;
+    for (const key of [
+      "output",
+      "output_text",
+      "text",
+      "citations",
+      "references",
+      "messages",
+      "choices",
+    ]) {
+      if (normalized[key] === undefined && candidate[key] !== undefined) {
+        normalized[key] = candidate[key];
+      }
+    }
+  }
+
+  if (
+    normalized.output_text === undefined &&
+    Array.isArray(normalized.output)
+  ) {
+    const textBuffer = normalized.output
+      .map((entry: any) => {
+        if (!entry) return "";
+        if (typeof entry === "string") return entry;
+        if (typeof entry.text === "string") return entry.text;
+        if (entry?.type === "output_text" && entry?.text?.value) {
+          return entry.text.value;
+        }
+        if (entry?.text?.value) {
+          return entry.text.value;
+        }
+        if (Array.isArray(entry.content)) {
+          return entry.content
+            .map((chunk: any) =>
+              typeof chunk === "string"
+                ? chunk
+                : chunk?.text?.value || chunk?.text || "",
+            )
+            .filter(Boolean)
+            .join("\n");
+        }
+        return "";
+      })
+      .filter(Boolean)
+      .join("\n");
+
+    if (textBuffer.trim()) {
+      normalized.output_text = textBuffer;
+    }
+  }
+
+  normalized.run_id = normalized.run_id || result.run_id || result.id;
+  normalized._rawParallelResponse = result;
+
+  return normalized;
+}
+
+async function callParallelTask({
+  prompt,
+  metadata,
+  maxOutputTokens,
+  requestMeta,
+  processor,
+}: {
+  prompt: string;
+  metadata?: Record<string, unknown>;
+  maxOutputTokens?: number;
+  requestMeta?: Record<string, unknown>;
+  processor?: string;
+}) {
+  const taskProcessor = processor || parallelProcessor;
+  const taskSpec: Record<string, any> = {
+    output_schema: {
+      type: "text",
+      description:
+        "Return a concise yet comprehensive JSON object that follows the schema described in the prompt.",
+    },
+  };
+
+  if (typeof maxOutputTokens === "number") {
+    taskSpec.max_output_tokens = maxOutputTokens;
+  }
+
+  const body: Record<string, any> = {
+    input: prompt,
+    processor: taskProcessor,
+    task_spec: taskSpec,
+  };
+
+  if (metadata && Object.keys(metadata).length > 0) {
+    body.metadata = metadata;
+  }
+
+  if (parallelWebhookUrl) {
+    body.webhook = {
+      url: parallelWebhookUrl,
+      events: parallelWebhookEvents,
+      ...(parallelWebhookSecret ? { secret: parallelWebhookSecret } : {}),
+    };
+    body.webhook_url = parallelWebhookUrl;
+    if (parallelWebhookSecret) {
+      body.webhook_secret = parallelWebhookSecret;
+    }
+  }
+
+  logger.info(
+    attachRequestMeta({
+      ...requestMeta,
+      processor: taskProcessor,
+    }),
+    "Submitting Parallel deep research task",
+  );
+
+  const createResponse = await parallelApiFetch<any>("/v1/tasks/runs", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+
+  const runId = createResponse?.run_id || createResponse?.id;
+  if (!runId) {
+    throw new Error("Parallel API response did not include a run identifier");
+  }
+
+  let latestStatus: ParallelTaskStatus | undefined =
+    (createResponse?.status as ParallelTaskStatus | undefined) ||
+    (createResponse?.run_status as ParallelTaskStatus | undefined);
+
+  if (latestStatus) {
+    latestStatus = latestStatus.toLowerCase() as ParallelTaskStatus;
+    logger.info(
+      attachRequestMeta({
+        ...requestMeta,
+        runId,
+        status: latestStatus,
+      }),
+      "Parallel task status update",
+    );
+    if (["completed", "succeeded", "finished"].includes(latestStatus)) {
+      return normalizeParallelResult(createResponse);
+    }
+    if (["failed", "errored", "error", "cancelled", "canceled"].includes(latestStatus)) {
+      throw new Error(`Parallel task ${runId} ${latestStatus}`);
+    }
+  }
+
+  const startTime = Date.now();
+  let attempt = 0;
+
+  while (Date.now() - startTime < parallelMaxWaitMs) {
+    attempt += 1;
+    let shouldContinue = false;
+
+    const elapsed = Date.now() - startTime;
+    const remainingMs = Math.max(1_000, parallelMaxWaitMs - elapsed);
+    const timeoutSeconds = Math.min(
+      parallelResultTimeoutSeconds,
+      Math.max(30, Math.floor(remainingMs / 1_000)),
+    );
+
+    try {
+      const result = await parallelApiFetch<any>(
+        `/v1/tasks/runs/${runId}/result?timeout=${timeoutSeconds}`,
+        {
+          method: "GET",
+          timeoutMs: remainingMs + 5_000,
+        },
+      );
+
+      latestStatus =
+        (result?.status as ParallelTaskStatus | undefined) ||
+        (result?.run_status as ParallelTaskStatus | undefined) ||
+        (result?.result?.status as ParallelTaskStatus | undefined);
+
+      if (latestStatus) {
+        latestStatus = latestStatus.toLowerCase() as ParallelTaskStatus;
+        logger.info(
+          attachRequestMeta({
+            ...requestMeta,
+            runId,
+            status: latestStatus,
+            attempt,
+          }),
+          "Parallel task status update",
+        );
+
+        if (["completed", "succeeded", "finished"].includes(latestStatus)) {
+          return normalizeParallelResult(result);
+        }
+
+        if (
+          [
+            "failed",
+            "errored",
+            "error",
+            "cancelled",
+            "canceled",
+            "timeout",
+          ].includes(latestStatus)
+        ) {
+          throw new Error(`Parallel task ${runId} ${latestStatus}`);
+        }
+      }
+
+      shouldContinue = true;
+    } catch (error: any) {
+      if (error?.status === 408 || error?.statusCode === 408) {
+        logger.info(
+          attachRequestMeta({
+            ...requestMeta,
+            runId,
+            attempt,
+            status: "poll_timeout",
+          }),
+          "Parallel task poll timed out, retrying",
+        );
+        shouldContinue = true;
+      } else {
+        throw error;
+      }
+    }
+
+    if (!shouldContinue) {
+      break;
+    }
+
+    const waitMs = Math.min(parallelPollIntervalMs, remainingMs);
+    await waitFor(waitMs);
+  }
+
+  throw new Error(
+    `Parallel task ${
+      (latestStatus && `${latestStatus} `) || ""
+    }did not complete within ${Math.round(parallelMaxWaitMs / 1000)} seconds`,
+  );
 }
 
 type PostSignupWorkflowRequest = PostSignupWorkflowPromptInput & {
@@ -118,6 +397,29 @@ type KnowledgeSource = {
 
 function extractResponseText(response: any): string {
   if (!response) return "";
+
+  if (Array.isArray(response)) {
+    const buffer = response
+      .map((item) => extractResponseText(item))
+      .filter(Boolean)
+      .join("\n");
+    if (buffer.trim()) {
+      return buffer;
+    }
+  }
+
+  if (response && typeof response === "object") {
+    for (const key of ["output_text", "result", "data", "response"]) {
+      if (key === "output_text") continue;
+      const nested = (response as any)[key];
+      if (nested) {
+        const nestedText = extractResponseText(nested);
+        if (nestedText.trim()) {
+          return nestedText;
+        }
+      }
+    }
+  }
 
   if (typeof response.output_text === "string" && response.output_text.trim()) {
     return response.output_text;
@@ -438,10 +740,10 @@ export default async function postSignupWorkflowsHandler(
     });
   }
 
-  if (!perplexityApiKey) {
+  if (!parallelApiKey) {
     logger.error(
       requestMetaBase,
-      "Perplexity API key not configured for post-signup workflows",
+      "Parallel API key not configured for post-signup workflows",
     );
     return res.status(500).json({ error: "Service temporarily unavailable" });
   }
@@ -506,11 +808,19 @@ export default async function postSignupWorkflowsHandler(
 
     const researchPrompt = buildPostSignupDeepResearchPrompt(promptInput);
 
-    const researchResponse = await callPerplexity({
-      model: deepResearchModel,
+    const researchResponse = await callParallelTask({
       prompt: researchPrompt,
-      useReasoning: true,
       maxOutputTokens: 4_096,
+      processor: parallelResearchProcessor,
+      metadata: {
+        blueprintId,
+        workflow: "post-signup.deep-research",
+        triggeredBy: userId || null,
+      },
+      requestMeta: {
+        ...requestMeta,
+        stage: "deepResearch",
+      },
     });
 
     const researchText = extractResponseText(researchResponse);
@@ -529,7 +839,12 @@ export default async function postSignupWorkflowsHandler(
     );
     const referenceKnowledgeSources = knowledgeSourcesFromReferences(
       (researchResponse &&
-        (researchResponse.references || researchResponse.citations)) ||
+        (researchResponse.references ||
+          researchResponse.citations ||
+          researchResponse.result?.references ||
+          researchResponse.result?.citations ||
+          researchResponse.data?.references ||
+          researchResponse.data?.citations)) ||
         researchJson.references,
     );
     const knowledgeSources = mergeKnowledgeSources(
@@ -567,9 +882,18 @@ export default async function postSignupWorkflowsHandler(
       },
     );
 
-    const instructionsResponse = await callPerplexity({
-      model: instructionsModel,
+    const instructionsResponse = await callParallelTask({
       prompt: instructionsPrompt,
+      processor: parallelInstructionsProcessor,
+      metadata: {
+        blueprintId,
+        workflow: "post-signup.system-instructions",
+        triggeredBy: userId || null,
+      },
+      requestMeta: {
+        ...requestMeta,
+        stage: "systemInstructions",
+      },
     });
 
     const instructionsText = extractResponseText(instructionsResponse);
@@ -633,9 +957,18 @@ export default async function postSignupWorkflowsHandler(
         },
       );
 
-      const welcomeMessagesResponse = await callPerplexity({
-        model: instructionsModel,
+      const welcomeMessagesResponse = await callParallelTask({
         prompt: welcomeMessagesPrompt,
+        processor: parallelWelcomeProcessor,
+        metadata: {
+          blueprintId,
+          workflow: "post-signup.welcome-messages",
+          triggeredBy: userId || null,
+        },
+        requestMeta: {
+          ...requestMeta,
+          stage: "welcomeMessages",
+        },
       });
 
       const welcomeMessagesText = extractResponseText(welcomeMessagesResponse);
@@ -671,8 +1004,9 @@ export default async function postSignupWorkflowsHandler(
       postSignupWorkflowStatus: {
         lastRunAt: timestamp,
         triggeredBy: userId || null,
-        deepResearchModel,
-        instructionsModel,
+        researchProcessor: parallelResearchProcessor,
+        instructionsProcessor: parallelInstructionsProcessor,
+        welcomeProcessor: parallelWelcomeProcessor,
       },
       aiResearchRawReport: researchText,
     };


### PR DESCRIPTION
## Summary
- replace the Perplexity helper with a Parallel Tasks client that configures headers, polling, and response normalization for post-signup research, instructions, and welcome prompts
- persist the configured Parallel processors in Firestore alongside the generated research artefacts
- expose a `/api/webhooks/parallel` endpoint that logs webhook events and register the router for future real-time updates

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cde895e54c8323aa6daefd043a334e