### PR TITLE
Update pilot messaging to promise 24-hour launch

### DIFF
--- a/client/src/components/pilotCopy.ts
+++ b/client/src/components/pilotCopy.ts
@@ -8,7 +8,7 @@ export const PILOT_FAQ: FAQ[] = [
   },
   {
     q: "What does the pilot cost?",
-    a: "Nothing. The two-visit pilot (~10 days) is free and feedback-only. No contract, and there’s no purchase option yet.",
+    a: "Nothing. The rapid pilot (scan today, live tomorrow) is free and feedback-only. No contract, and there’s no purchase option yet.",
   },
   {
     q: "How long does mapping take?",
@@ -23,8 +23,8 @@ export const PILOT_FAQ: FAQ[] = [
     a: "Access for mapping, some basic business info, and your feedback after demo day. We handle the rest—design, setup, and analytics.",
   },
   {
-    q: "Is the AR experience live for two weeks?",
-    a: "No. The experience is live during the scheduled demo window (1–2 hours) on Visit 2. The goal is to gather feedback and learn, not to run the experience continuously yet.",
+    q: "Is the AR experience live for more than a day?",
+    a: "No. The experience is live during the activation session (1–2 hours) within 24 hours of mapping. The goal is to gather feedback and learn, not to run the experience continuously yet.",
   },
   {
     q: "What happens after the pilot?",

--- a/client/src/components/sections/Hero.jsx
+++ b/client/src/components/sections/Hero.jsx
@@ -28,7 +28,7 @@ export default function Hero({ onPrimaryCta }) {
     {
       k: "how",
       pre: "Fast to pilot:",
-      highlight: "Scan today, go live next week.",
+      highlight: "Scan today, go live tomorrow.",
       sub: "We capture your space, map common questions & tasks, and deliver a hands-on demo for your team.",
     },
     {
@@ -47,7 +47,7 @@ export default function Hero({ onPrimaryCta }) {
 
   const features = [
     "No app to build",
-    "Setup in ~10 days",
+    "Setup by tomorrow",
     "On-site demo 1–2 hrs",
     "Works with all smart glasses brands",
     "Analytics & insights included",
@@ -57,7 +57,7 @@ export default function Hero({ onPrimaryCta }) {
     {
       k: "owners",
       pre: "For location owners:",
-      highlight: "Bring wearable AI service to your venue in weeks.",
+      highlight: "Bring wearable AI service to your venue in 24 hours.",
       sub: "Blueprint packages the new device access toolkits into guest-ready pilots for retail, hospitality, attractions, and campuses.",
     },
     {
@@ -81,7 +81,7 @@ export default function Hero({ onPrimaryCta }) {
   ];
 
   const features2 = [
-    "Venue scan + AI flows in ~10 days",
+    "Venue scan + AI flows in under 24 hours",
     "No custom app required",
     "Works with all smart glasses brands",
     "Staff onboarding + playbooks included",
@@ -291,14 +291,14 @@ export default function Hero({ onPrimaryCta }) {
 //       k: "how",
 //       pre: "We do the heavy lifting:",
 //       highlight:
-//         "Map your location → design the content → on-site demo in ~10 days.",
-//       sub: "Two short visits from us: Day 1 mapping (~60 min), then a demo 1–2 hrs about a week later.",
+//         "Map your location → design the content → go live tomorrow.",
+//       sub: "One focused visit from us: mapping (~60 min) with a same-day activation run-through for your team.",
 //     },
 //     {
 //       k: "pilot",
 //       pre: "Now enrolling in Durham:",
 //       highlight: "$0 to try Blueprint at your location.",
-//       sub: "Free, feedback-only pilot. Two visits: mapping (~60 min) + demo (1–2 hrs). No contract; no purchase option yet.",
+//       sub: "Free, feedback-only pilot. Scan today, live tomorrow. No contract; no purchase option yet.",
 //     },
 //   ];
 
@@ -395,8 +395,8 @@ export default function Hero({ onPrimaryCta }) {
 //           transition={{ delay: 0.15 }}
 //           className="mt-5 flex flex-wrap gap-2"
 //         >
-//           {[
-//             "Two visits (~10 days)",
+//           {[ 
+//             "Launch in under 24 hours",
 //             "Mapping ~60 min",
 //             "Live demo 1–2 hrs",
 //             "Works on headsets & glasses",
@@ -488,14 +488,14 @@ export default function Hero({ onPrimaryCta }) {
 //       k: "how",
 //       pre: "We do the heavy lifting:",
 //       highlight:
-//         "Map your location → design the content → on-site demo in ~10 days.",
-//       sub: "Two short visits from us: Day 1 mapping (~60 min), then a demo 1–2 hrs about a week later.",
+//         "Map your location → design the content → go live tomorrow.",
+//       sub: "One focused visit from us: mapping (~60 min) with a same-day activation run-through for your team.",
 //     },
 //     {
 //       k: "pilot",
 //       pre: "Now enrolling in Durham:",
 //       highlight: "$0 to try Blueprint at your location.",
-//       sub: "Free, feedback-only pilot. Two visits: mapping (~60 min) + demo (1–2 hrs). No contract; no purchase option yet.",
+//       sub: "Free, feedback-only pilot. Scan today, live tomorrow. No contract; no purchase option yet.",
 //     },
 //   ];
 
@@ -592,8 +592,8 @@ export default function Hero({ onPrimaryCta }) {
 //           transition={{ delay: 0.15 }}
 //           className="mt-5 flex flex-wrap gap-2"
 //         >
-//           {[
-//             "Two visits (~10 days)",
+//           {[ 
+//             "Launch in under 24 hours",
 //             "Mapping ~60 min",
 //             "Live demo 1–2 hrs",
 //             "Works on headsets & glasses",

--- a/client/src/components/sections/WearableAIDemos.tsx
+++ b/client/src/components/sections/WearableAIDemos.tsx
@@ -40,7 +40,7 @@ export default function WearableAIDemos() {
           "How the new tooling connects spatial maps, sensor streams, and AI agents so your staff can orchestrate a venue hands-free.",
         takeaways: [
           "Stream real-time spatial anchors into your own AI flows",
-          "Provision wearables for teams in minutes, not weeks",
+          "Provision wearables for teams in minutes, not days",
           "Bring your existing CRM or ticketing data into the experience",
         ],
         video: {

--- a/client/src/pages/Discover.tsx
+++ b/client/src/pages/Discover.tsx
@@ -1039,7 +1039,7 @@ const steps = [
     title: "Join Pilot Program",
     description:
       "Secure your spot in our exclusive Pilot Program. Priority onboarding available.",
-    benefits: ["Priority access", "Free 2 week program", "Dedicated support"],
+    benefits: ["Priority access", "Free 24-hour program", "Dedicated support"],
     color: "from-emerald-500 to-teal-600",
     duration: "1 minute",
   },
@@ -1114,7 +1114,7 @@ const steps = [
 //     description:
 //       "Reserve your spot for priority access to Blueprint's AR platform",
 //     benefits: [
-//       "Free 2 week program access",
+//       "Free 24-hour program access",
 //       "Priority support",
 //       "Custom onboarding",
 //     ],

--- a/client/src/pages/FAQ.tsx
+++ b/client/src/pages/FAQ.tsx
@@ -26,7 +26,7 @@ export default function FAQ() {
     },
     {
       q: "What does the pilot program cost?",
-      a: "Nothing. Zero. Nada. The entire 2 week program is completely free with no hidden fees, no credit card required, and no obligation to continue. This includes the space mapping, AI-generated AR content, hardware demos, and analytics. We're investing in showing you the future because we believe seeing is believing.",
+      a: "Nothing. Zero. Nada. The entire 24-hour program is completely free with no hidden fees, no credit card required, and no obligation to continue. This includes the space mapping, AI-generated AR content, hardware demos, and analytics. We're investing in showing you the future because we believe seeing is believing.",
     },
     {
       q: "How long does the space mapping take?",
@@ -45,8 +45,8 @@ export default function FAQ() {
       a: "The possibilities are endless! For retail: virtual try-ons, product demos, and interactive catalogs. For museums: digital guides, historical recreations, and interactive exhibits. For restaurants: 3D menu visualizations and tableside ordering. For real estate: virtual staging and property tours. Each experience is custom-built for your specific needs.",
     },
     {
-      q: "What happens after the 2 week program?",
-      a: "We'll send out a survey to all participants of the Demo Day asking about the whole Pilot Program experience. Any feedback from this survey helps us improve Blueprint! As of today, there are no options to discuss continuing with a full implementation of Blueprint for your space.",
+      q: "What happens after the 24-hour program?",
+      a: "We'll send out a survey to all participants of the activation asking about the whole Pilot Program experience. Any feedback from this survey helps us improve Blueprint! As of today, there are no options to discuss continuing with a full implementation of Blueprint for your space.",
     },
     {
       q: "How do customers access the AR experience?",

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -352,7 +352,7 @@ export default function Home() {
 
                 <div className="flex flex-wrap items-center gap-2 mb-4">
                   <span className="rounded-full border border-white/15 bg-white/5 px-3 py-1 text-xs text-slate-200">
-                    Two visits (~10 days)
+                    Launch in under 24 hours
                   </span>
                   <span className="rounded-full border border-white/15 bg-white/5 px-3 py-1 text-xs text-slate-200">
                     Live demo 1–2 hrs
@@ -497,9 +497,9 @@ export default function Home() {
               <p className="mt-3 text-slate-300 max-w-2xl mx-auto">
                 Smart glasses launches from Meta, Google, Apple, and Samsung are
                 bringing hands-free AI into the mainstream. We help you capture
-                your space, design the workflows, and test with your team in
-                about 10 days. Two quick visits: a 60-minute scan and a 1–2 hour
-                on-site demo. The pilot is free.
+                your space, design the workflows, and test with your team by
+                tomorrow. One focused visit: a 60-minute scan followed by a
+                same-day activation run-through. The pilot is free.
               </p>
               <div className="mt-6 grid grid-cols-1 sm:grid-cols-2 gap-3 justify-center">
                 <Button
@@ -959,7 +959,7 @@ function Stat({ label, value }: { label: string; value: string }) {
 
 //                 <div className="flex flex-wrap items-center gap-2 mb-4">
 //                   <span className="rounded-full border border-white/15 bg-white/5 px-3 py-1 text-xs text-slate-200">
-//                     Two visits (~10 days)
+//                     Launch in under 24 hours
 //                   </span>
 //                   <span className="rounded-full border border-white/15 bg-white/5 px-3 py-1 text-xs text-slate-200">
 //                     Live demo 1–2 hrs

--- a/client/src/pages/OffWaitlistSignUpFlow.tsx
+++ b/client/src/pages/OffWaitlistSignUpFlow.tsx
@@ -2438,7 +2438,7 @@ export default function OffWaitlistSignUpFlow() {
 
 //   const [demoDate, setDemoDate] = useState(() => {
 //     const date = new Date();
-//     date.setDate(date.getDate() + 7); // Default to 1 week from today
+//     date.setDate(date.getDate() + 1); // Default to 1 day from today
 //     return date;
 //   });
 //   const [demoTime, setDemoTime] = useState("11:00"); // Default to 11:00 AM

--- a/client/src/pages/OutboundSignUpFlow.tsx
+++ b/client/src/pages/OutboundSignUpFlow.tsx
@@ -2254,7 +2254,7 @@ export default function OutboundSignUpFlow() {
 
 //   const [demoDate, setDemoDate] = useState(() => {
 //     const date = new Date();
-//     date.setDate(date.getDate() + 7); // Default to 1 week from today
+//     date.setDate(date.getDate() + 1); // Default to 1 day from today
 //     return date;
 //   });
 //   const [demoTime, setDemoTime] = useState("11:00"); // Default to 11:00 AM

--- a/client/src/pages/PilotProgram.jsx
+++ b/client/src/pages/PilotProgram.jsx
@@ -238,7 +238,7 @@ function MobileBenefitsCarousel({ benefits }) {
 function getBenefitDetails(title) {
   const details = {
     "Zero Risk": [
-      "Free two-visit pilot (~10 days)",
+      "Free rapid pilot (<24 hours)",
       "No credit card or contract",
       "We handle setup end-to-end",
       "Clear next steps after demo",
@@ -817,7 +817,7 @@ export default function PilotProgram() {
     );
   };
 
-  // 10-day flow for clarity
+  // 24-hour flow for clarity
   const timeline = [
     {
       icon: <MapPin className="w-6 h-6" />,
@@ -835,20 +835,20 @@ export default function PilotProgram() {
     },
     {
       icon: <Sparkles className="w-6 h-6" />,
-      title: "Between Visits (~1 week)",
-      subtitle: "Design & Build",
+      title: "Same-Day Build (<4 hrs)",
+      subtitle: "Design & Activate",
       description:
-        "We design a brand-aligned AR layer with smart placements and interactions.",
+        "We turn scans into a brand-aligned AR layer that’s ready for guests before the day is over.",
       color: "from-cyan-500 to-teal-500",
       benefit: "Tailored to your venue",
-      details: ["AI-assisted content", "Review checkpoint (async)", "QR plan"],
+      details: ["AI-assisted content", "Rapid review checkpoint", "QR plan"],
     },
     {
       icon: <PlayCircle className="w-6 h-6" />,
-      title: "Visit 2",
-      subtitle: "Live Demo Day (1–2 hrs)",
+      title: "Activation Session",
+      subtitle: "Live Walkthrough (1–2 hrs)",
       description:
-        "We bring a VR headset and run the demo end-to-end. Your team tries it hands-on; we handle devices, setup, and sanitization. The AR is live during the scheduled demo window only.",
+        "We bring a VR headset and run the demo end-to-end later that day. Your team tries it hands-on; we handle devices, setup, and sanitization. The AR is live during the scheduled activation window only.",
       color: "from-emerald-400 to-cyan-400",
       benefit: "Hands-on, on-site",
       details: ["VR headset", "Team walkthrough", "Immediate insights"],
@@ -947,7 +947,7 @@ export default function PilotProgram() {
       icon: <Shield className="w-6 h-6" />,
       title: "Zero Risk",
       description:
-        "A two-visit pilot (~10 days) that’s free and feedback-only.",
+      "A rapid pilot (scan today, live tomorrow) that’s free and feedback-only.",
       highlight: "100% FREE",
     },
     {
@@ -979,7 +979,7 @@ export default function PilotProgram() {
     },
     {
       q: "What does the pilot cost?",
-      a: "Nothing. The two-visit pilot (~10 days) is free and feedback-only. No contract, and there’s no purchase option yet.",
+    a: "Nothing. The rapid pilot (scan today, live tomorrow) is free and feedback-only. No contract, and there’s no purchase option yet.",
     },
     {
       q: "How long does mapping take?",
@@ -994,8 +994,8 @@ export default function PilotProgram() {
       a: "Access for mapping, some basic business info, access to Wi-Fi, and your feedback after demo day. We handle the rest—design, setup, and analytics. If your Wi-Fi is private, please share the network name and password with the Mapping Specialist during the visit.",
     },
     {
-      q: "Is the AR experience live for two weeks?",
-      a: "No. The experience is live during the scheduled demo window (1–2 hours) on Visit 2. The goal is to gather feedback and learn, not to run the experience continuously yet.",
+      q: "Is the AR experience live beyond the 24-hour launch?",
+      a: "No. The experience is live during the activation window (1–2 hours) within 24 hours of mapping. The goal is to gather feedback and learn, not to run the experience continuously yet.",
     },
     {
       q: "What happens after the pilot?",
@@ -1032,20 +1032,20 @@ export default function PilotProgram() {
             >
               <Badge className="inline-flex items-center gap-2 bg-emerald-400/10 text-emerald-300 border-emerald-500/30 mb-6 px-4 py-2">
                 <Rocket className="w-4 h-4" />
-                Durham Pilot — Two visits (~10 days)
+                Durham Pilot — Live in 24 hours
               </Badge>
 
               <h1 className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-black mb-6 leading-tight text-white">
                 Turn Your Space{" "}
                 <span className="bg-gradient-to-r from-emerald-300 via-cyan-300 to-emerald-200 bg-clip-text text-transparent">
-                  Into a Shareable AR Experience in 10 Days
+                  Into a Shareable AR Experience by Tomorrow
                 </span>
               </h1>
 
               <p className="text-base sm:text-lg md:text-xl text-slate-300 mb-6 md:mb-8 max-w-2xl mx-auto lg:mx-0">
-                Two quick visits about a week apart: mapping (~60 min) and an
-                on-site demo (1–2 hrs). Free and feedback-only. No apps to
-                install—we provide the headset; guests just scan a QR code to
+                One focused visit: a 60-minute mapping session with a same-day
+                activation run-through (1–2 hrs). Free and feedback-only. No apps
+                to install—we provide the headset; guests just scan a QR code to
                 see it in action.
               </p>
 
@@ -1130,9 +1130,9 @@ export default function PilotProgram() {
             },
             {
               label: "Time to Launch",
-              value: "10 days",
+              value: "24 hours",
               icon: <Clock className="w-6 h-6" />,
-              description: "From mapping to on-site demo", // ← replace this line
+              description: "From scan to activation",
               gradient: "from-cyan-500 to-teal-500",
             },
             {
@@ -1250,10 +1250,10 @@ export default function PilotProgram() {
           >
             <Badge className="inline-flex items-center gap-2 bg-cyan-500/10 text-cyan-300 border-cyan-500/30 mb-6 px-4 py-2">
               <CalendarCheck className="w-4 h-4" />
-              Simple Two-Visit Process (~10 days)
+              Simple 24-Hour Launch Process
             </Badge>
             <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold mb-6 text-white">
-              From First Scan to a Live Demo in ~10 Days
+              From First Scan to a Live Demo by Tomorrow
             </h2>
             <p className="text-lg md:text-xl text-slate-300 max-w-3xl mx-auto leading-relaxed">
               We do the heavy lifting—your team just shows up to try it and give
@@ -3043,7 +3043,7 @@ export default function PilotProgram() {
 //     {
 //       icon: <Shield className="w-6 h-6" />,
 //       title: "Zero Risk",
-//       description: "2 week program with absolutely no cost or obligation",
+//       description: "24-hour program with absolutely no cost or obligation",
 //       highlight: "100% FREE",
 //     },
 //     {
@@ -3099,7 +3099,7 @@ export default function PilotProgram() {
 //     },
 //     {
 //       q: "What does the pilot program cost?",
-//       a: "Nothing. Zero. Nada. The entire 2 week program is completely free with no hidden fees, no credit card required, and no obligation to continue. This includes the space mapping, AI-generated AR content, hardware demos, and analytics. We're investing in showing you the future because we believe seeing is believing.",
+//       a: "Nothing. Zero. Nada. The entire 24-hour program is completely free with no hidden fees, no credit card required, and no obligation to continue. This includes the space mapping, AI-generated AR content, hardware demos, and analytics. We're investing in showing you the future because we believe seeing is believing.",
 //     },
 //     {
 //       q: "How long does the space mapping take?",
@@ -3118,7 +3118,7 @@ export default function PilotProgram() {
 //       a: "The possibilities are endless! For retail: virtual try-ons, product demos, and interactive catalogs. For museums: digital guides, historical recreations, and interactive exhibits. For restaurants: 3D menu visualizations and tableside ordering. For real estate: virtual staging and property tours. Each experience is custom-built for your specific needs.",
 //     },
 //     {
-//       q: "What happens after the 2 week program?",
+//       q: "What happens after the 24-hour program?",
 //       a: "We'll send out a survey to all participants of the Demo Day asking about the whole Pilot Program experience. Any feedback from this survey helps us improve Blueprint!",
 //     },
 //     {
@@ -3350,7 +3350,7 @@ export default function PilotProgram() {
 //             },
 //             {
 //               label: "Time to Launch",
-//               value: "< 2 weeks",
+//               value: "< 24 hours",
 //               icon: <Clock className="w-6 h-6" />,
 //               description: "From scan to live experience",
 //               gradient: "from-blue-500 to-cyan-500",

--- a/client/src/pages/Pricing.tsx
+++ b/client/src/pages/Pricing.tsx
@@ -154,13 +154,13 @@ const contrastRows: ContrastRow[] = [
     label: "Time to first location live",
     diy: "6–12+ weeks (build + content + QA) if starting from zero. Agency ranges for AR MVPs are often $30k–$150k over 2–4 months.",
     blueprint:
-      "<1–2 weeks typical for first site (subscribe → scan → place content) once your templates are ready.",
+      "<24 hours typical for first site (subscribe → scan → place content) once your templates are ready.",
     icon: Rocket,
   },
   {
     label: "Time to additional locations",
     diy: "3–7 days each (scheduling mapper, scans, content, QA).",
-    blueprint: "Same day to 2 days if self-scan + templated scenes.",
+    blueprint: "Same day if self-scan + templated scenes.",
     icon: RefreshCcw,
   },
   {
@@ -213,7 +213,7 @@ const tldrHighlights: { label: string; diy: string; blueprint: string }[] = [
   {
     label: "Time to first site live",
     diy: "6–12+ weeks",
-    blueprint: "<1–2 weeks",
+    blueprint: "<24 hours",
   },
   {
     label: "Time per additional site",

--- a/client/src/pages/SignIn.tsx
+++ b/client/src/pages/SignIn.tsx
@@ -170,7 +170,7 @@ export default function SignIn() {
                   className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full border border-emerald-400/30 bg-emerald-400/10 text-emerald-200 mb-5"
                 >
                   <MapPin className="w-4 h-4" />
-                  Durham/Triangle Pilot — Two visits (~10 days)
+                  Durham/Triangle Pilot — Live in 24 hours
                 </motion.div>
 
                 <h1 className="text-4xl md:text-5xl font-black tracking-tight text-white mb-4">
@@ -189,8 +189,8 @@ export default function SignIn() {
                   {[
                     {
                       icon: CalendarCheck,
-                      title: "Two visits (~10 days)",
-                      copy: "Mapping + demo, about a week apart.",
+                      title: "Launch in under 24 hours",
+                      copy: "Mapping + activation within a day.",
                     },
                     {
                       icon: Shield,

--- a/client/src/pages/blog/RoboticsOS.tsx
+++ b/client/src/pages/blog/RoboticsOS.tsx
@@ -186,7 +186,7 @@ export default function RoboticsOS() {
                 <li>
                   <strong>Faster onboarding:</strong> New vendors or third-party
                   robotics fleets can request temporary credentials instead of
-                  weeks of site surveys.
+                  lengthy site surveys.
                 </li>
               </ul>
 


### PR DESCRIPTION
## Summary
- Update hero, home, and supporting marketing copy to promise 24-hour activation with tomorrow-focused messaging.
- Revise pilot program timelines, FAQs, and pricing comparisons to emphasize rapid same-day build and activation.
- Align related components, sign-in prompts, and marketing assets with the new rapid launch positioning.

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d012f41d608323ae2ad0b051bb0b93