### PR TITLE
Enforce next-day demos and highlight 24-hour pilot

### DIFF
--- a/client/src/components/sections/Hero.jsx
+++ b/client/src/components/sections/Hero.jsx
@@ -47,7 +47,7 @@ export default function Hero({ onPrimaryCta }) {
 
   const features = [
     "No app to build",
-    "Setup by tomorrow",
+    "Mapping today, demo tomorrow",
     "On-site demo 1–2 hrs",
     "Works with all smart glasses brands",
     "Analytics & insights included",
@@ -82,7 +82,7 @@ export default function Hero({ onPrimaryCta }) {
 
   const features2 = [
     "Venue scan + AI flows in under 24 hours",
-    "No custom app required",
+    "Mapping today, demo tomorrow",
     "Works with all smart glasses brands",
     "Staff onboarding + playbooks included",
     "Analytics & privacy controls baked in",

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -441,7 +441,7 @@ export default function Home() {
                 <div className="mt-auto flex items-center justify-between gap-3">
                   <div className="flex flex-wrap items-center gap-2">
                     <span className="rounded-full border border-white/15 bg-white/5 px-3 py-1 text-xs text-slate-200">
-                      Replies &lt; 24h
+                      24-hour pilot: map + demo
                     </span>
                     <span className="rounded-full border border-white/15 bg-white/5 px-3 py-1 text-xs text-slate-200">
                       Limited spots
@@ -497,9 +497,9 @@ export default function Home() {
               <p className="mt-3 text-slate-300 max-w-2xl mx-auto">
                 Smart glasses launches from Meta, Google, Apple, and Samsung are
                 bringing hands-free AI into the mainstream. We help you capture
-                your space, design the workflows, and test with your team by
-                tomorrow. One focused visit: a 60-minute scan followed by a
-                same-day activation run-through. The pilot is free.
+                your space, design the workflows, and test with your team in 24
+                hours. Two focused visits: Day 1 mapping (30–60 minutes) and a
+                next-day activation run-through. The pilot is free.
               </p>
               <div className="mt-6 grid grid-cols-1 sm:grid-cols-2 gap-3 justify-center">
                 <Button

--- a/client/src/pages/OffWaitlistSignUpFlow.tsx
+++ b/client/src/pages/OffWaitlistSignUpFlow.tsx
@@ -154,12 +154,20 @@ export default function OffWaitlistSignUpFlow() {
   // Step 4
   const [demoDate, setDemoDate] = useState(() => {
     const date = new Date();
-    date.setDate(date.getDate() + 7);
+    date.setDate(date.getDate() + 1);
     return date;
   });
   const [demoTime, setDemoTime] = useState("11:00");
 
   const [errorMessage, setErrorMessage] = useState("");
+
+  useEffect(() => {
+    setDemoDate((prev) => {
+      const nextDay = new Date(scheduleDate);
+      nextDay.setDate(nextDay.getDate() + 1);
+      return prev.toDateString() === nextDay.toDateString() ? prev : nextDay;
+    });
+  }, [scheduleDate]);
 
   // ------------------------------
   // Validation helpers
@@ -1274,7 +1282,8 @@ export default function OffWaitlistSignUpFlow() {
           </h2>
           <p className="text-slate-300 mt-2">
             Pick a date and time for our specialist to scan your space. Most
-            visits take ~30–60 minutes.
+            visits take ~30–60 minutes, and we’ll be back the very next day for
+            your live demo.
           </p>
         </div>
 
@@ -1417,13 +1426,13 @@ export default function OffWaitlistSignUpFlow() {
 
     const minDemoDate = useCallback(() => {
       const date = new Date(scheduleDate);
-      date.setDate(date.getDate() + 8);
+      date.setDate(date.getDate() + 1);
       return date;
     }, [scheduleDate]);
 
     const maxDemoDate = useCallback(() => {
       const date = new Date(scheduleDate);
-      date.setDate(date.getDate() + 14);
+      date.setDate(date.getDate() + 1);
       return date;
     }, [scheduleDate]);
 
@@ -1490,11 +1499,11 @@ export default function OffWaitlistSignUpFlow() {
       <div className="space-y-6">
         <div>
           <h2 className="text-2xl md:text-3xl font-bold text-white">
-            Schedule Demo Day
+            Schedule Next-Day Demo
           </h2>
           <p className="text-slate-300 mt-2">
-            Choose when we should present your completed Blueprint and AR
-            experience to your team.
+            We present your completed Blueprint within 24 hours. Choose the
+            time for the follow-up visit the day after mapping.
           </p>
         </div>
 
@@ -1504,7 +1513,7 @@ export default function OffWaitlistSignUpFlow() {
             <div className="mb-3 flex items-center gap-2 text-slate-200">
               <Calendar className="w-5 h-5 text-cyan-300" />
               <Label className="font-medium text-slate-200">
-                Select Demo Date
+                Select Demo Date (Next Day)
               </Label>
             </div>
             <DatePicker
@@ -1914,7 +1923,7 @@ export default function OffWaitlistSignUpFlow() {
             onClick={handlePrevStep}
             className="border-white/20 text-slate-200 hover:bg-white/10"
           >
-            <ChevronLeft className="w-4 h-4 mr-1" /> Back to Demo Day
+            <ChevronLeft className="w-4 h-4 mr-1" /> Back to Demo
           </Button>
           <div className="flex flex-col sm:flex-row gap-3 w-full sm:w-auto">
             <Button
@@ -1997,7 +2006,7 @@ export default function OffWaitlistSignUpFlow() {
     { id: 1, label: "Account" },
     { id: 2, label: "Contact & Location" },
     { id: 3, label: "Mapping" },
-    { id: 4, label: "Demo Day" },
+    { id: 4, label: "Next-Day Demo" },
     { id: 5, label: "Plan & Payment" },
   ];
 
@@ -2191,7 +2200,7 @@ export default function OffWaitlistSignUpFlow() {
                         <div className="flex items-start gap-2">
                           <Calendar className="w-4 h-4 text-emerald-300 mt-0.5" />
                           <div>
-                            <p className="text-slate-400">Demo Day</p>
+                            <p className="text-slate-400">Next-Day Demo</p>
                             <p className="text-white">
                               {demoDate ? demoDate.toLocaleDateString() : "—"} •{" "}
                               {demoTime || "—"}
@@ -2322,7 +2331,7 @@ export default function OffWaitlistSignUpFlow() {
                         </span>
                       </div>
                       <div>
-                        Demo Day:{" "}
+                        Next-Day Demo:{" "}
                         <span className="text-white">
                           {demoDate?.toLocaleDateString() || "—"} •{" "}
                           {demoTime || "—"}

--- a/client/src/pages/OutboundSignUpFlow.tsx
+++ b/client/src/pages/OutboundSignUpFlow.tsx
@@ -136,12 +136,13 @@ export default function OutboundSignUpFlow() {
   const [scheduleDate, setScheduleDate] = useState(new Date());
   const [scheduleTime, setScheduleTime] = useState("08:00");
 
-  // When mapping date changes, keep demo date in the valid window (7–14 days later).
+  // When mapping date changes, lock the demo to the next day.
   useEffect(() => {
-    const min = addDays(scheduleDate, 7);
-    const max = addDays(scheduleDate, 14);
+    const nextDay = addDays(scheduleDate, 1);
 
-    setDemoDate((prev) => (prev < min || prev > max ? min : prev));
+    setDemoDate((prev) =>
+      prev.toDateString() === nextDay.toDateString() ? prev : nextDay,
+    );
   }, [scheduleDate]);
 
   // Step 4 — Demo
@@ -151,7 +152,7 @@ export default function OutboundSignUpFlow() {
   //   return d;
   // });
   // Step 4 — Demo
-  const [demoDate, setDemoDate] = useState(new Date()); // effect will snap to 7 days after mapping
+  const [demoDate, setDemoDate] = useState(new Date()); // effect will snap to the next day
 
   const [demoTime, setDemoTime] = useState("11:00");
 
@@ -1174,7 +1175,8 @@ export default function OutboundSignUpFlow() {
           </h2>
           <p className="text-slate-300 mt-2">
             Pick a date and time for our specialist to scan your space. Most
-            visits take ~30–60 minutes.
+            visits take ~30–60 minutes, and we’ll be back the very next day for
+            your live demo.
           </p>
         </div>
 
@@ -1314,9 +1316,9 @@ export default function OutboundSignUpFlow() {
     const [demoBookedTimes, setDemoBookedTimes] = useState<string[]>([]);
     const [isLoading, setIsLoading] = useState(true);
 
-    // Valid demo window = 7–14 days after mapping
-    const demoMin = addDays(scheduleDate, 7);
-    const demoMax = addDays(scheduleDate, 14);
+    // Demo happens the day after mapping
+    const demoMin = addDays(scheduleDate, 1);
+    const demoMax = addDays(scheduleDate, 1);
 
     const formatSlot = (time: string) => {
       const [hh, mm] = time.split(":");
@@ -1381,11 +1383,11 @@ export default function OutboundSignUpFlow() {
       <div className="space-y-6">
         <div>
           <h2 className="text-2xl md:text-3xl font-bold text-white">
-            Schedule Demo Day
+            Schedule Next-Day Demo
           </h2>
           <p className="text-slate-300 mt-2">
-            Choose when we should present your completed Blueprint and AR
-            experience to your team.
+            We present your completed Blueprint within 24 hours. Pick the time
+            for the follow-up visit the day after mapping.
           </p>
         </div>
 
@@ -1395,10 +1397,11 @@ export default function OutboundSignUpFlow() {
             <div className="mb-3 flex items-center gap-2 text-slate-200">
               <Calendar className="w-5 h-5 text-cyan-300" />
               <Label className="font-medium text-slate-200">
-                Select Demo Date
+                Select Demo Date (Next Day)
               </Label>
               <p className="text-xs text-slate-400 -mt-1 mb-2">
-                Demo must be 7–14 days after your mapping date.
+                Demo happens the day after your mapping visit—choose the time
+                for that follow-up.
               </p>
             </div>
             <DatePicker
@@ -1410,7 +1413,7 @@ export default function OutboundSignUpFlow() {
               inline
               minDate={demoMin}
               maxDate={demoMax}
-              // Disable anything not in the 7–14 day window so the UI shows what's possible
+              // Disable anything outside the locked next-day window
               filterDate={(date) => date >= demoMin && date <= demoMax}
               calendarClassName="!bg-transparent !border-0 !shadow-none reactpicker-dark"
               wrapperClassName="!block w-full"
@@ -1814,7 +1817,7 @@ export default function OutboundSignUpFlow() {
             onClick={handlePrevStep}
             className="border-white/20 text-slate-200 hover:bg-white/10"
           >
-            <ChevronLeft className="w-4 h-4 mr-1" /> Back to Demo Day
+            <ChevronLeft className="w-4 h-4 mr-1" /> Back to Demo
           </Button>
           <div className="flex flex-col sm:flex-row gap-3 w-full sm:w-auto">
             <Button
@@ -1897,7 +1900,7 @@ export default function OutboundSignUpFlow() {
     { id: 1, label: "Account" },
     { id: 2, label: "Contact & Location" },
     { id: 3, label: "Mapping" },
-    { id: 4, label: "Demo Day" },
+    { id: 4, label: "Next-Day Demo" },
     { id: 5, label: "Plan & Payment" },
   ];
 
@@ -2025,16 +2028,16 @@ export default function OutboundSignUpFlow() {
                           </p>
                         </div>
                       </div>
-                      <div className="flex items-start gap-2">
-                        <Calendar className="w-4 h-4 text-emerald-300 mt-0.5" />
-                        <div>
-                          <p className="text-slate-400">Demo Day</p>
-                          <p className="text-white">
-                            {demoDate ? demoDate.toLocaleDateString() : "—"} •{" "}
-                            {demoTime || "—"}
-                          </p>
+                        <div className="flex items-start gap-2">
+                          <Calendar className="w-4 h-4 text-emerald-300 mt-0.5" />
+                          <div>
+                            <p className="text-slate-400">Next-Day Demo</p>
+                            <p className="text-white">
+                              {demoDate ? demoDate.toLocaleDateString() : "—"} •{" "}
+                              {demoTime || "—"}
+                            </p>
+                          </div>
                         </div>
-                      </div>
                       {companyWebsite && (
                         <div className="flex items-start gap-2">
                           <Globe className="w-4 h-4 text-emerald-300 mt-0.5" />
@@ -2156,13 +2159,13 @@ export default function OutboundSignUpFlow() {
                         {scheduleTime || "—"}
                       </span>
                     </div>
-                    <div>
-                      Demo Day:{" "}
-                      <span className="text-white">
-                        {demoDate?.toLocaleDateString() || "—"} •{" "}
-                        {demoTime || "—"}
-                      </span>
-                    </div>
+                      <div>
+                        Next-Day Demo:{" "}
+                        <span className="text-white">
+                          {demoDate?.toLocaleDateString() || "—"} •{" "}
+                          {demoTime || "—"}
+                        </span>
+                      </div>
                   </div>
                 </details>
               </div>

--- a/client/src/pages/PilotProgram.jsx
+++ b/client/src/pages/PilotProgram.jsx
@@ -821,8 +821,8 @@ export default function PilotProgram() {
   const timeline = [
     {
       icon: <MapPin className="w-6 h-6" />,
-      title: "Visit 1",
-      subtitle: "30–60 min Mapping",
+      title: "Day 1 · Mapping Visit",
+      subtitle: "30–60 min capture",
       description:
         "We scan your venue with LiDAR to create a precise digital twin—fast, quiet, and disruption-free.",
       color: "from-emerald-500 to-cyan-500",
@@ -835,20 +835,20 @@ export default function PilotProgram() {
     },
     {
       icon: <Sparkles className="w-6 h-6" />,
-      title: "Same-Day Build (<4 hrs)",
-      subtitle: "Design & Activate",
+      title: "Overnight AI Build",
+      subtitle: "Design & automate",
       description:
-        "We turn scans into a brand-aligned AR layer that’s ready for guests before the day is over.",
+        "Our AI turns the scan into a brand-aligned AR layer within hours so everything is ready for the next morning.",
       color: "from-cyan-500 to-teal-500",
       benefit: "Tailored to your venue",
       details: ["AI-assisted content", "Rapid review checkpoint", "QR plan"],
     },
     {
       icon: <PlayCircle className="w-6 h-6" />,
-      title: "Activation Session",
-      subtitle: "Live Walkthrough (1–2 hrs)",
+      title: "Day 2 · Demo Visit",
+      subtitle: "Live walkthrough (1–2 hrs)",
       description:
-        "We bring a VR headset and run the demo end-to-end later that day. Your team tries it hands-on; we handle devices, setup, and sanitization. The AR is live during the scheduled activation window only.",
+        "We bring a VR headset and run the demo end-to-end the very next day. Your team tries it hands-on; we handle devices, setup, and sanitization. The AR is live during the scheduled activation window only.",
       color: "from-emerald-400 to-cyan-400",
       benefit: "Hands-on, on-site",
       details: ["VR headset", "Team walkthrough", "Immediate insights"],
@@ -987,11 +987,11 @@ export default function PilotProgram() {
     },
     {
       q: "Do customers need special hardware?",
-      a: "No. The AR runs in the browser via QR codes. For demo day, we bring a VR headset so your team can try it hands-on.",
+      a: "No. The AR runs in the browser via QR codes. For the demo visit, we bring a VR headset so your team can try it hands-on.",
     },
     {
       q: "What do you need from us?",
-      a: "Access for mapping, some basic business info, access to Wi-Fi, and your feedback after demo day. We handle the rest—design, setup, and analytics. If your Wi-Fi is private, please share the network name and password with the Mapping Specialist during the visit.",
+      a: "Access for mapping, some basic business info, access to Wi-Fi, and your feedback after the demo visit. We handle the rest—design, setup, and analytics. If your Wi-Fi is private, please share the network name and password with the Mapping Specialist during the visit.",
     },
     {
       q: "Is the AR experience live beyond the 24-hour launch?",
@@ -999,7 +999,7 @@ export default function PilotProgram() {
     },
     {
       q: "What happens after the pilot?",
-      a: "We'll send out a survey to all participants of the Demo Day asking about the whole Pilot Program experience. Any feedback from this survey helps us improve Blueprint! As of today, there are no options to discuss continuing with a full implementation of Blueprint for your space.",
+      a: "We'll send out a survey to all participants of the demo visit asking about the whole Pilot Program experience. Any feedback from this survey helps us improve Blueprint! As of today, there are no options to discuss continuing with a full implementation of Blueprint for your space.",
     },
   ];
 
@@ -1043,10 +1043,10 @@ export default function PilotProgram() {
               </h1>
 
               <p className="text-base sm:text-lg md:text-xl text-slate-300 mb-6 md:mb-8 max-w-2xl mx-auto lg:mx-0">
-                One focused visit: a 60-minute mapping session with a same-day
-                activation run-through (1–2 hrs). Free and feedback-only. No apps
-                to install—we provide the headset; guests just scan a QR code to
-                see it in action.
+                Two focused visits inside 24 hours: Day 1 is a 30–60 minute
+                mapping session, Day 2 is the live activation run-through (1–2
+                hrs). Free and feedback-only. No apps to install—we provide the
+                headset; guests just scan a QR code to see it in action.
               </p>
 
               <div className="flex flex-col sm:flex-row gap-4 justify-center lg:justify-start mb-8">


### PR DESCRIPTION
## Summary
- require demos to be booked for the day after mapping in the Off Waitlist and Outbound signup flows, updating labels and helper copy accordingly
- refresh Home and Pilot Program content to emphasize the 24-hour, two-visit pilot experience
- tweak the hero feature chips so the landing experience reinforces mapping today and demo tomorrow

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d018d1520c832380a22a30af3d7697