### PR TITLE
Enforce next-day demos and update 24-hour pilot messaging

### DIFF
--- a/client/src/components/sections/Hero.jsx
+++ b/client/src/components/sections/Hero.jsx
@@ -29,7 +29,7 @@ export default function Hero({ onPrimaryCta }) {
       k: "how",
       pre: "Fast to pilot:",
       highlight: "Scan today, go live tomorrow.",
-      sub: "We capture your space, map common questions & tasks, and deliver a hands-on demo for your team.",
+      sub: "We capture your space, map common questions & tasks, and deliver a hands-on demo for your team the very next day.",
     },
     {
       k: "why",
@@ -47,7 +47,7 @@ export default function Hero({ onPrimaryCta }) {
 
   const features = [
     "No app to build",
-    "Mapping today, demo tomorrow",
+    "Mapping today, demo tomorrow (required)",
     "On-site demo 1–2 hrs",
     "Works with all smart glasses brands",
     "Analytics & insights included",
@@ -64,7 +64,7 @@ export default function Hero({ onPrimaryCta }) {
       k: "how",
       pre: "What we handle:",
       highlight: "Space scans, agent flows, and hardware provisioning.",
-      sub: "We capture your layout, map the top questions and tasks, and deliver a guided run-through for your team.",
+      sub: "We capture your layout, map the top questions and tasks, and deliver a guided run-through for your team the very next day.",
     },
     {
       k: "why",
@@ -82,7 +82,7 @@ export default function Hero({ onPrimaryCta }) {
 
   const features2 = [
     "Venue scan + AI flows in under 24 hours",
-    "Mapping today, demo tomorrow",
+    "Mapping today, demo tomorrow (required)",
     "Works with all smart glasses brands",
     "Staff onboarding + playbooks included",
     "Analytics & privacy controls baked in",

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -355,7 +355,10 @@ export default function Home() {
                     Launch in under 24 hours
                   </span>
                   <span className="rounded-full border border-white/15 bg-white/5 px-3 py-1 text-xs text-slate-200">
-                    Live demo 1–2 hrs
+                    Mapping Monday? Demo Tuesday.
+                  </span>
+                  <span className="rounded-full border border-white/15 bg-white/5 px-3 py-1 text-xs text-slate-200">
+                    Demo window 1–2 hrs
                   </span>
                   <span className="rounded-full border border-white/15 bg-white/5 px-3 py-1 text-xs text-slate-200">
                     Replies &lt; 24h
@@ -499,7 +502,9 @@ export default function Home() {
                 bringing hands-free AI into the mainstream. We help you capture
                 your space, design the workflows, and test with your team in 24
                 hours. Two focused visits: Day 1 mapping (30–60 minutes) and a
-                next-day activation run-through. The pilot is free.
+                next-day activation run-through. Mapping and demo are always
+                booked on consecutive days (for example: map Monday at 5 PM,
+                demo Tuesday at 8 AM). The pilot is free.
               </p>
               <div className="mt-6 grid grid-cols-1 sm:grid-cols-2 gap-3 justify-center">
                 <Button

--- a/client/src/pages/OffWaitlistSignUpFlow.tsx
+++ b/client/src/pages/OffWaitlistSignUpFlow.tsx
@@ -700,6 +700,20 @@ export default function OffWaitlistSignUpFlow() {
         return;
       }
     } else if (step === 4) {
+      const expectedDemoDate = new Date(scheduleDate);
+      expectedDemoDate.setHours(0, 0, 0, 0);
+      expectedDemoDate.setDate(expectedDemoDate.getDate() + 1);
+
+      const normalizedDemoDate = new Date(demoDate);
+      normalizedDemoDate.setHours(0, 0, 0, 0);
+
+      if (normalizedDemoDate.getTime() !== expectedDemoDate.getTime()) {
+        setErrorMessage(
+          "Demo must happen the day after mapping so we can deliver within 24 hours.",
+        );
+        return;
+      }
+
       const auth = getAuth();
       const user = auth.currentUser;
       if (!user) {

--- a/client/src/pages/OutboundSignUpFlow.tsx
+++ b/client/src/pages/OutboundSignUpFlow.tsx
@@ -584,11 +584,13 @@ export default function OutboundSignUpFlow() {
         return;
       }
     } else if (step === 4) {
-      const min = addDays(scheduleDate, 7);
-      const max = addDays(scheduleDate, 14);
-      if (demoDate < min || demoDate > max) {
+      const expectedDemoDate = addDays(scheduleDate, 1);
+      const normalizedExpected = expectedDemoDate.toDateString();
+      const normalizedActual = demoDate.toDateString();
+
+      if (normalizedActual !== normalizedExpected) {
         setErrorMessage(
-          "Demo must be scheduled 7–14 days after your mapping date.",
+          "Demo must be scheduled the day after your mapping visit.",
         );
         return;
       }

--- a/client/src/pages/PilotProgram.jsx
+++ b/client/src/pages/PilotProgram.jsx
@@ -951,7 +951,7 @@ export default function PilotProgram() {
       icon: <Shield className="w-6 h-6" />,
       title: "Zero Risk",
       description:
-        "A rapid pilot (scan today, live tomorrow) that’s free and feedback-only.",
+        "A rapid pilot (scan today, live tomorrow) that’s free and feedback-only. Mapping + demo are booked on consecutive days.",
       highlight: "100% FREE",
     },
     {
@@ -983,7 +983,7 @@ export default function PilotProgram() {
     },
     {
       q: "What does the pilot cost?",
-      a: "Nothing. The rapid pilot (scan today, live tomorrow) is free and feedback-only. No contract, and there’s no purchase option yet.",
+      a: "Nothing. The rapid pilot (scan today, live tomorrow) is free and feedback-only. Mapping and demo happen on consecutive days to keep the automation tight. No contract, and there’s no purchase option yet.",
     },
     {
       q: "How long does mapping take?",
@@ -1049,8 +1049,10 @@ export default function PilotProgram() {
               <p className="text-base sm:text-lg md:text-xl text-slate-300 mb-6 md:mb-8 max-w-2xl mx-auto lg:mx-0">
                 Two focused visits inside 24 hours: Day 1 is a 30–60 minute
                 mapping session, Day 2 is the live activation run-through (1–2
-                hrs). Free and feedback-only. No apps to install—we provide the
-                headset; guests just scan a QR code to see it in action.
+                hrs). Mapping Monday at 5 PM? Demo Tuesday at 8 AM. Back-to-back
+                scheduling is required so the AI build stays automated. Free and
+                feedback-only. No apps to install—we provide the headset; guests
+                just scan a QR code to see it in action.
               </p>
 
               <div className="flex flex-col sm:flex-row gap-4 justify-center lg:justify-start mb-8">
@@ -1085,6 +1087,10 @@ export default function PilotProgram() {
                 <div className="flex items-center gap-2">
                   <CheckCircle2 className="w-5 h-5 text-emerald-400" />
                   <span className="text-slate-200">We handle everything</span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <CheckCircle2 className="w-5 h-5 text-emerald-400" />
+                  <span className="text-slate-200">Back-to-back visits required</span>
                 </div>
               </div>
               <p className="mt-2 text-xs text-slate-400">


### PR DESCRIPTION
## Summary
- require demo bookings to match the day-after mapping rule in both outbound and off-waitlist signup flows, including updated error messaging
- refresh hero, home, and pilot program copy so the 24-hour, back-to-back visit requirement is explicit across marketing touchpoints

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d0246260b08323951bdc1ab9665b69