### PR TITLE
Add App Clip domain association support

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -26,12 +26,6 @@
       content="black-translucent"
     />
 
-    <!-- iOS Smart App Banner -->
-    <meta
-      name="apple-itunes-app"
-      content="app-id=YOUR_APP_ID, app-argument=https://bp.link/go"
-    />
-
     <!-- Primary Meta Tags -->
     <title>Blueprint | Custom AR & AI Solutions For Any Space</title>
     <meta

--- a/client/src/pages/Go.tsx
+++ b/client/src/pages/Go.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Helmet } from "react-helmet";
 
 const APP_STORE_URL =
   import.meta.env.VITE_APP_STORE_URL ??
@@ -6,6 +7,21 @@ const APP_STORE_URL =
 const PLAY_STORE_URL =
   import.meta.env.VITE_PLAY_STORE_URL ??
   "https://play.google.com/store/apps/details?id=io.tryblueprint.app";
+
+const APP_CLIP_URL = "https://www.tryblueprint.io/go";
+const APP_STORE_APP_ID =
+  (import.meta.env.VITE_APP_STORE_APP_ID as string | undefined)?.trim() ?? "";
+const APP_CLIP_BUNDLE_ID =
+  (import.meta.env.VITE_APP_CLIP_BUNDLE_ID as string | undefined)?.trim() ??
+  "";
+
+const APP_CLIP_META_CONTENT = [
+  APP_STORE_APP_ID ? `app-id=${APP_STORE_APP_ID}` : null,
+  APP_CLIP_BUNDLE_ID ? `app-clip-bundle-id=${APP_CLIP_BUNDLE_ID}` : null,
+  `app-clip-url=${APP_CLIP_URL}`,
+]
+  .filter((segment): segment is string => Boolean(segment && segment.length))
+  .join(", ");
 
 type Platform = "ios" | "android" | "other";
 
@@ -539,9 +555,13 @@ export default function Go() {
   );
 
   return (
-    <div className="min-h-screen bg-slate-950 text-slate-50">
-      <div className="mx-auto flex min-h-screen max-w-3xl flex-col gap-8 px-6 pb-16 pt-12">
-        <header className="space-y-2">
+    <>
+      <Helmet>
+        <meta name="apple-itunes-app" content={APP_CLIP_META_CONTENT} />
+      </Helmet>
+      <div className="min-h-screen bg-slate-950 text-slate-50">
+        <div className="mx-auto flex min-h-screen max-w-3xl flex-col gap-8 px-6 pb-16 pt-12">
+          <header className="space-y-2">
           <p className="text-sm font-semibold uppercase tracking-[0.28em] text-blue-300">
             Blueprint Link
           </p>
@@ -696,5 +716,6 @@ export default function Go() {
         </footer>
       </div>
     </div>
+    </>
   );
 }

--- a/docs/app-clip-setup.md
+++ b/docs/app-clip-setup.md
@@ -1,0 +1,54 @@
+# App Clip Domain Association Setup
+
+The web stack now exposes the assets that iOS needs in order to launch the
+Blueprint App Clip when somebody scans a QR code that points at
+`https://www.tryblueprint.io/go`. To enable the end-to-end flow you must supply
+the identifiers that Apple issued for your production app and App Clip.
+
+## Required environment variables
+
+Populate these environment variables wherever the Express server runs:
+
+| Variable | Description |
+| --- | --- |
+| `APPLE_TEAM_ID` | Your 10-character Apple Developer Team ID. |
+| `IOS_APP_BUNDLE_ID` | The primary iOS app bundle identifier that hosts the App Clip experience. |
+| `IOS_APP_CLIP_BUNDLE_ID` | The App Clip target bundle identifier. |
+| `APP_CLIP_ADDITIONAL_PATHS` | *(optional)* Comma-separated list of additional URL paths that should open the App Clip. Each entry may start with `/`; the server normalises missing leading slashes. |
+
+The server responds to both `/.well-known/apple-app-site-association` and
+`/apple-app-site-association` with a JSON payload that includes the
+`applinks.details` and `appclips.apps` sections derived from these variables.
+When all identifiers are present the payload is cached for an hour and shared
+across both GET and HEAD requests, which is what Apple’s association service
+expects during verification.
+
+## Front-end configuration
+
+Expose the same bundle identifiers to the Vite build so Safari can render the
+App Clip card banner when the Go page loads:
+
+| Vite variable | Purpose |
+| --- | --- |
+| `VITE_APP_STORE_APP_ID` | The numeric App Store ID for the full Blueprint app. |
+| `VITE_APP_CLIP_BUNDLE_ID` | The App Clip bundle identifier shown in the Smart App Banner metadata. |
+
+Add both keys to your `.env` or hosting provider secrets. The Go QR experience
+page resolves them at runtime and injects an `apple-itunes-app` meta tag via
+`react-helmet`, keeping the banner scoped to
+`https://www.tryblueprint.io/go` while the rest of the marketing site stays
+unchanged.
+
+## Checklist before testing on device
+
+1. **Deploy the updated server** so the `apple-app-site-association` endpoint is
+   publicly reachable over HTTPS.
+2. **Host the QR code** that resolves to `https://www.tryblueprint.io/go`.
+3. **Create and approve an App Clip Experience** for that URL inside App Store
+   Connect and include the same Team ID / bundle IDs you configured above.
+4. **Publish the App Clip-capable build** signed with provisioning profiles that
+   contain the Associated Domains entitlement for `appclips:tryblueprint.io` and
+   `applinks:tryblueprint.io`.
+
+Once all steps are complete, scanning the QR code from an iOS device should
+present the App Clip card and hand the invocation URL to the Unity runtime.

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -11,8 +11,10 @@ import postSignupWorkflowsHandler from "./routes/post-signup-workflows";
 import webhooksRouter from "./routes/webhooks";
 import aiStudioRouter from "./routes/ai-studio";
 import qrLinkRouter from "./routes/qr-link";
+import appleAssociationRouter from "./routes/apple-app-site-association";
 
 export function registerRoutes(app: Express) {
+  app.use(appleAssociationRouter);
   // API routes for Express
   app.use("/api/webhooks", webhooksRouter);
   app.post("/api/create-checkout-session", createCheckoutSessionHandler);

--- a/server/routes/apple-app-site-association.ts
+++ b/server/routes/apple-app-site-association.ts
@@ -1,0 +1,125 @@
+import { Router, type Request, type Response } from "express";
+
+import { logger } from "../logger";
+
+interface AppleAssociationPayload {
+  applinks: {
+    apps: string[];
+    details: Array<{ appID: string; paths: string[] }>;
+  };
+  appclips: {
+    apps: string[];
+  };
+}
+
+const router = Router();
+
+const APPLE_TEAM_ID = process.env.APPLE_TEAM_ID?.trim();
+const IOS_APP_BUNDLE_ID =
+  process.env.IOS_APP_BUNDLE_ID?.trim() || process.env.APP_BUNDLE_ID?.trim();
+const IOS_APP_CLIP_BUNDLE_ID =
+  process.env.IOS_APP_CLIP_BUNDLE_ID?.trim() ||
+  process.env.APP_CLIP_BUNDLE_ID?.trim();
+
+const DEFAULT_INVOCATION_PATHS = ["/go", "/go/*"];
+const additionalPaths = (process.env.APP_CLIP_ADDITIONAL_PATHS || "")
+  .split(",")
+  .map((entry) => entry.trim())
+  .filter(Boolean)
+  .map((entry) => (entry.startsWith("/") ? entry : `/${entry}`));
+
+const invocationPaths = Array.from(
+  new Set([...DEFAULT_INVOCATION_PATHS, ...additionalPaths]),
+);
+
+let associationPayload: AppleAssociationPayload | null = null;
+let configurationError: string | null = null;
+
+if (!APPLE_TEAM_ID) {
+  configurationError =
+    "Missing APPLE_TEAM_ID environment variable for App Clip association.";
+} else if (!IOS_APP_BUNDLE_ID) {
+  configurationError =
+    "Missing IOS_APP_BUNDLE_ID environment variable for App Clip association.";
+} else if (!IOS_APP_CLIP_BUNDLE_ID) {
+  configurationError =
+    "Missing IOS_APP_CLIP_BUNDLE_ID environment variable for App Clip association.";
+} else {
+  const fullAppIdentifier = `${APPLE_TEAM_ID}.${IOS_APP_BUNDLE_ID}`;
+  const fullClipIdentifier = `${APPLE_TEAM_ID}.${IOS_APP_CLIP_BUNDLE_ID}`;
+
+  associationPayload = {
+    applinks: {
+      apps: [],
+      details: [
+        {
+          appID: fullAppIdentifier,
+          paths: invocationPaths,
+        },
+      ],
+    },
+    appclips: {
+      apps: [fullClipIdentifier],
+    },
+  };
+
+  logger.info(
+    {
+      fullAppIdentifier,
+      fullClipIdentifier,
+      invocationPaths,
+    },
+    "App Clip association configured",
+  );
+}
+
+if (configurationError) {
+  logger.warn(
+    {
+      configurationError,
+      invocationPaths,
+    },
+    "App Clip association is not fully configured",
+  );
+}
+
+function respondAssociation(_req: Request, res: Response) {
+  if (!associationPayload) {
+    res
+      .status(503)
+      .json({ error: "App Clip association not configured on server" });
+    return;
+  }
+
+  res
+    .status(200)
+    .set({
+      "Content-Type": "application/json",
+      "Cache-Control": "public, max-age=3600, stale-while-revalidate=86400",
+    })
+    .json(associationPayload);
+}
+
+const associationPaths = [
+  "/.well-known/apple-app-site-association",
+  "/apple-app-site-association",
+];
+
+router.get(associationPaths, respondAssociation);
+
+router.head(associationPaths, (_req: Request, res: Response) => {
+  if (!associationPayload) {
+    res.status(503).end();
+    return;
+  }
+
+  res
+    .status(200)
+    .set({
+      "Content-Type": "application/json",
+      "Cache-Control": "public, max-age=3600, stale-while-revalidate=86400",
+    })
+    .end();
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- add an Express router that serves the apple-app-site-association payload for the App Clip based on environment variables
- inject the App Clip smart banner metadata on the Go QR experience page and drop the outdated static tag from index.html
- document the configuration needed to finish enabling the App Clip experience

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ddf730fc008323a62326892df5b6cc