### PR TITLE
Fix Stripe API version to supported date

### DIFF
--- a/server/constants/stripe.ts
+++ b/server/constants/stripe.ts
@@ -6,7 +6,7 @@ const STRIPE_SECRET_KEY =
   "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";
 
 export const stripeClient = STRIPE_SECRET_KEY
-  ? new Stripe(STRIPE_SECRET_KEY, { apiVersion: "2024-11-20" })
+  ? new Stripe(STRIPE_SECRET_KEY, { apiVersion: "2024-06-20" })
   : null;
 
 export const STRIPE_CONNECT_ACCOUNT_ID =


### PR DESCRIPTION
## Summary
- update the Stripe server client to request the supported 2024-06-20 API version instead of the invalid 2024-11-20 version

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fd20ec4c408323a074578ce18f7295