### PR TITLE
Highlight real-world grounding of procedural scenes

### DIFF
--- a/client/src/pages/Contact.tsx
+++ b/client/src/pages/Contact.tsx
@@ -11,7 +11,9 @@ export default function Contact() {
           Tell us what your robot needs to practice.
         </h1>
         <p className="max-w-3xl text-sm text-slate-600">
-          Share your target policies, categories, and delivery timeline. We support both exclusive dataset programs and non-exclusive catalog scenes, and we’ll follow up within one business day with scope, pricing, and draft coverage.
+          Share your target policies, categories, and delivery timeline. We support both exclusive dataset programs and
+          non-exclusive catalog scenes—each rooted in real-world kitchens, warehouses, utility corridors, bedrooms, and more—
+          and we’ll follow up within one business day with scope, pricing, and draft coverage.
         </p>
       </header>
       <ContactForm />

--- a/client/src/pages/Environments.tsx
+++ b/client/src/pages/Environments.tsx
@@ -68,7 +68,9 @@ export default function Environments() {
           Browse ready-to-train scenes.
         </h1>
         <p className="max-w-2xl text-sm text-slate-600">
-          Every environment below includes articulated joints, physics-clean colliders, and simulation validation notes. Filter by environment type, interaction coverage, or deployment focus.
+          Every environment below includes articulated joints, physics-clean colliders, and simulation validation notes. Each
+          synthetic build is patterned after a documented real-world location so dataset diversity tracks what your fleets see
+          in production. Filter by environment type, interaction coverage, or deployment focus.
         </p>
       </header>
 

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -49,10 +49,14 @@ export default function Home() {
             </h1>
             <p className="max-w-xl text-lg text-slate-600">
               High-fidelity scenes, physics-clean assets, delivered fast.
-              Blueprint finishes procedural and real-world environments so your
-              robots can prove ROI in simulation before hardware hits the floor.
-              Engage on exclusive dataset programs or license non-exclusive
-              catalog scenes depending on your coverage needs.
+              Every procedural world we ship is authored from real kitchens,
+              warehouses, utilities, bedrooms, and other everyday locations so
+              your synthetic datasets reflect the variety your robots meet in
+              the field. Blueprint finishes procedural and real-world
+              environments so your robots can prove ROI in simulation before
+              hardware hits the floor. Engage on exclusive dataset programs or
+              license non-exclusive catalog scenes depending on your coverage
+              needs.
             </p>
           </div>
           <CTAButtons
@@ -71,9 +75,11 @@ export default function Home() {
             </p>
             <p>
               Kitchens, groceries, warehouse lanes, labs, offices, retail,
-              utility, and more. Each environment ships with articulated
-              policy coverage, pickable props, semantic labels, and simulation
-              validation reports.
+              utility, and more. Our procedural sets are grounded in
+              photographic and scan references from active facilities so
+              catalog scenes mirror how real spaces are organized. Each
+              environment ships with articulated policy coverage, pickable
+              props, semantic labels, and simulation validation reports.
             </p>
             <p>
               Add on our on-site capture service to transform your real facility
@@ -108,8 +114,10 @@ export default function Home() {
             </h2>
             <p className="mt-2 max-w-xl text-sm text-slate-600">
               60+ scene archetypes spanning robotic kitchens, warehouses,
-              retail, offices, and labs. Browse categories below or jump into
-              the full catalog.
+              retail, offices, and labs—each patterned after documented real
+              sites to preserve aisle widths, counter heights, and task
+              diversity. Browse categories below or jump into the full
+              catalog.
             </p>
           </div>
           <a

--- a/client/src/pages/Solutions.tsx
+++ b/client/src/pages/Solutions.tsx
@@ -49,7 +49,7 @@ export default function Solutions() {
             Two ways to get SimReady scenes.
           </h1>
           <p className="text-sm text-slate-600">
-            Whether you need procedural synthetic data or a digital twin of a real facility, Blueprint delivers robotics-ready environments with precision pivots, physics materials, and simulation validation. Choose from non-exclusive catalog scenes or commission exclusive dataset programs tailored to your roadmap.
+            Whether you need procedural synthetic data grounded in documented kitchens, warehouses, utility rooms, and other real locations or a digital twin of a facility you operate, Blueprint delivers robotics-ready environments with precision pivots, physics materials, and simulation validation. Choose from non-exclusive catalog scenes or commission exclusive dataset programs tailored to your roadmap.
           </p>
           <CTAButtons
             primaryHref="/environments"
@@ -74,7 +74,7 @@ export default function Solutions() {
             Procedural & Synthetic Scene Data
           </h2>
           <p className="max-w-3xl text-sm text-slate-600">
-            Generate diverse training sets with curated procedural environments. We mix capture data, kitbashed assets, and authored variants to deliver coverage across kitchens, grocery, warehouse, and retail archetypes.
+            Generate diverse training sets with curated procedural environments. Each scene begins with survey photos, scans, or CAD from real-world analogs so the layouts, sight lines, and clutter patterns match kitchens, grocery aisles, warehouse pick lanes, retail floors, and residential rooms your robots will encounter.
           </p>
         </div>
         <div className="grid gap-6 md:grid-cols-3">

--- a/client/src/pages/Terms.tsx
+++ b/client/src/pages/Terms.tsx
@@ -13,6 +13,10 @@ export default function Terms() {
       <section className="space-y-3 text-sm text-slate-600">
         <h2 className="text-lg font-semibold text-slate-900">1. Services</h2>
         <p>Blueprint provides procedural/synthetic scene data, SimReady finishing, and on-site capture services as described in project agreements.</p>
+        <p>
+          Procedural deliverables are derived from real-world references—such as kitchens, warehouses, utility rooms, and
+          residential settings—to maintain the spatial fidelity and diversity required for robotics training datasets.
+        </p>
         <p>Deliverables include USD assets, textures, documentation, and related metadata as specified in the SOW.</p>
       </section>
       <section className="space-y-3 text-sm text-slate-600">


### PR DESCRIPTION
## Summary
- update hero and coverage messaging on the home page to state that procedural environments are built from real-world locations
- reinforce real-world references across the environment catalog, solutions, contact, and terms pages

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69114a0f80f88323bc3ebf2ce0611441)