### PR TITLE
Add policy filtering and cards to environment catalog

### DIFF
--- a/client/src/components/site/PolicyCard.tsx
+++ b/client/src/components/site/PolicyCard.tsx
@@ -1,0 +1,43 @@
+import type { EnvironmentPolicy } from "@/data/content";
+
+interface PolicyCardProps {
+  policy: EnvironmentPolicy;
+}
+
+export function PolicyCard({ policy }: PolicyCardProps) {
+  return (
+    <article className="flex h-full flex-col gap-4 rounded-2xl border border-slate-200 bg-white/80 p-6 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md">
+      <header className="flex items-center justify-between gap-3">
+        <span className="text-[11px] uppercase tracking-[0.3em] text-slate-400">
+          Policy
+        </span>
+        <span className="rounded-full bg-slate-900 px-3 py-1 text-[11px] font-medium uppercase tracking-[0.2em] text-white">
+          {policy.focus}
+        </span>
+      </header>
+
+      <div>
+        <h3 className="text-lg font-semibold text-slate-900">{policy.title}</h3>
+        <p className="mt-2 text-sm text-slate-600">{policy.summary}</p>
+      </div>
+
+      <ul className="flex flex-col gap-2 text-sm text-slate-600">
+        {policy.coverage.map((item) => (
+          <li key={item} className="flex items-start gap-3">
+            <span className="mt-1 h-1.5 w-1.5 flex-none rounded-full bg-emerald-500" />
+            <span>{item}</span>
+          </li>
+        ))}
+      </ul>
+
+      <footer className="mt-auto flex flex-wrap items-center justify-between gap-3 text-xs uppercase tracking-[0.2em] text-slate-400">
+        <span>{policy.cadence}</span>
+        {policy.metric ? (
+          <span className="text-sm font-medium normal-case tracking-normal text-slate-900">
+            {policy.metric}
+          </span>
+        ) : null}
+      </footer>
+    </article>
+  );
+}

--- a/client/src/data/content.ts
+++ b/client/src/data/content.ts
@@ -44,6 +44,17 @@ export interface EnvironmentCategory {
   scenes: string[];
 }
 
+export interface EnvironmentPolicy {
+  slug: string;
+  title: string;
+  focus: string;
+  cadence: string;
+  summary: string;
+  coverage: string[];
+  metric?: string;
+  environments: string[];
+}
+
 export interface CaseStudy {
   title: string;
   slug: string;
@@ -135,6 +146,113 @@ export const environmentCategories: EnvironmentCategory[] = [
       "Consumer-grade washer/dryer stacks with articulated doors, knobs, and hampers for assistive robotics research.",
     tags: ["Home"],
     scenes: ["laundry-alcove"],
+  },
+];
+
+export const environmentPolicies: EnvironmentPolicy[] = [
+  {
+    slug: "restocking-planogram",
+    title: "Restocking & Planogram QA",
+    focus: "Inventory accuracy",
+    cadence: "Shift open + close",
+    summary:
+      "Monitor shelf compliance, restock priorities, and aisle readiness with structured annotations for each bay.",
+    coverage: [
+      "Facing and gap detection across gondolas",
+      "Dynamic restock queue export for associates",
+      "Exception hand-off with annotated product IDs",
+    ],
+    metric: "96% shelf compliance in sim",
+    environments: ["grocery-aisles"],
+  },
+  {
+    slug: "kitchen-safety-sops",
+    title: "Kitchen Safety SOP Walkthrough",
+    focus: "Food safety",
+    cadence: "Pre-service",
+    summary:
+      "Validate sanitation, cookline readiness, and HACCP checkpoints before service windows open.",
+    coverage: [
+      "Hot-zone clearance and PPE confirmation",
+      "Chemical storage and label verification",
+      "Temperature log capture from articulated equipment",
+    ],
+    metric: "Cuts audit prep time by 40%",
+    environments: ["kitchens"],
+  },
+  {
+    slug: "dock-safety-checks",
+    title: "Dock Safety Checklist",
+    focus: "Operations safety",
+    cadence: "Per trailer move",
+    summary:
+      "Run restraint, light curtain, and chock confirmation before AMRs or lift operators engage the bay.",
+    coverage: [
+      "Verify restraint engagement and signal lights",
+      "Scan dock pit for foreign objects",
+      "Confirm staged pallet clearances for AMR entries",
+    ],
+    metric: "90% incident reduction in pilots",
+    environments: ["loading-docks", "warehouse-lanes"],
+  },
+  {
+    slug: "lane-clearance-monitoring",
+    title: "Lane Clearance Monitoring",
+    focus: "AMR readiness",
+    cadence: "Continuous",
+    summary:
+      "Ensure high-traffic warehouse lanes stay within clearance tolerances for autonomous fleets.",
+    coverage: [
+      "Detect protrusions into AMR lanes",
+      "Alert on pallet overhang and tote stack height",
+      "Log timestamped exceptions for retraining",
+    ],
+    metric: "Keeps 1.8m clearance 99% of shift",
+    environments: ["warehouse-lanes", "utility-rooms"],
+  },
+  {
+    slug: "lab-protocol-audit",
+    title: "Lab Protocol Audit",
+    focus: "Compliance",
+    cadence: "Run start",
+    summary:
+      "Verify bench readiness, sample custody, and enclosure interlocks before lab automation kicks off.",
+    coverage: [
+      "Checklist for PPE storage and eyewash access",
+      "Sample ID validation via label scans",
+      "Enclosure door and sensor interlock tests",
+    ],
+    metric: "Automates 18-point GLP checklist",
+    environments: ["labs"],
+  },
+  {
+    slug: "office-service-routes",
+    title: "Office Service Routes",
+    focus: "Hospitality",
+    cadence: "Daily",
+    summary:
+      "Guide service robots through office pods and pantries to restock amenities and reset collaboration rooms.",
+    coverage: [
+      "Prioritized loop for pantry restock and waste pickup",
+      "Door, drawer, and switch manipulation prompts",
+      "End-of-route report with consumable counts",
+    ],
+    environments: ["office-pods", "utility-rooms"],
+  },
+  {
+    slug: "laundry-assist",
+    title: "Laundry Assist Program",
+    focus: "Assistive",
+    cadence: "On-demand",
+    summary:
+      "Coordinate washer/dryer cycles, hamper sorting, and folding sequences for in-home service robots.",
+    coverage: [
+      "Cycle scheduling with detergent prompts",
+      "Adaptive hamper sorting by fabric class",
+      "Fold stack placement with reach envelopes",
+    ],
+    metric: "Cuts cycle handling time to 12 min",
+    environments: ["home-laundry"],
   },
 ];
 


### PR DESCRIPTION
## Summary
- add structured policy metadata alongside existing environment content
- update the environments page to filter by policy and render per-environment policy cards
- introduce a reusable policy card component for consistent display of policy coverage

## Testing
- npm run check

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69114dadcf6883298e203908e6b44e70)