### PR TITLE
Add policy-aware filtering to environments catalog

### DIFF
--- a/client/src/components/site/PolicyCard.tsx
+++ b/client/src/components/site/PolicyCard.tsx
@@ -1,0 +1,39 @@
+import type { Policy } from "@/data/content";
+
+interface PolicyCardProps {
+  policy: Policy;
+  isHighlighted?: boolean;
+}
+
+export function PolicyCard({ policy, isHighlighted = false }: PolicyCardProps) {
+  return (
+    <div
+      className={`flex h-full flex-col rounded-2xl border bg-white p-6 shadow-sm transition ${
+        isHighlighted
+          ? "border-emerald-500 shadow-emerald-100"
+          : "border-slate-200 hover:-translate-y-1 hover:shadow-md"
+      }`}
+    >
+      <div className="flex flex-col gap-2">
+        <div className="text-xs uppercase tracking-[0.3em] text-slate-400">
+          {policy.tags.join(" • ")}
+        </div>
+        <h3 className="text-lg font-semibold text-slate-900">{policy.title}</h3>
+        <p className="text-sm text-slate-600">{policy.summary}</p>
+      </div>
+      {policy.focusAreas.length ? (
+        <ul className="mt-4 space-y-2 text-sm text-slate-500">
+          {policy.focusAreas.map((item) => (
+            <li key={item} className="flex gap-2">
+              <span aria-hidden className="mt-1 h-1 w-1 rounded-full bg-emerald-500" />
+              <span>{item}</span>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+      <div className="mt-6 text-xs text-slate-400">
+        Supports: {policy.environments.length} environment{policy.environments.length === 1 ? "" : "s"}
+      </div>
+    </div>
+  );
+}

--- a/client/src/data/content.ts
+++ b/client/src/data/content.ts
@@ -44,6 +44,15 @@ export interface EnvironmentCategory {
   scenes: string[];
 }
 
+export interface Policy {
+  title: string;
+  slug: string;
+  summary: string;
+  focusAreas: string[];
+  tags: string[];
+  environments: string[];
+}
+
 export interface CaseStudy {
   title: string;
   slug: string;
@@ -135,6 +144,100 @@ export const environmentCategories: EnvironmentCategory[] = [
       "Consumer-grade washer/dryer stacks with articulated doors, knobs, and hampers for assistive robotics research.",
     tags: ["Home"],
     scenes: ["laundry-alcove"],
+  },
+];
+
+export const policies: Policy[] = [
+  {
+    title: "Inventory Replenishment",
+    slug: "inventory-replenishment",
+    summary:
+      "Sequenced pick, place, and verification routines for keeping high-demand SKUs stocked without interrupting shoppers or operators.",
+    focusAreas: [
+      "Bin and shelf restock playbooks",
+      "Cart traffic awareness",
+      "Exception logging for missing items",
+    ],
+    tags: ["Fulfillment", "Perception"],
+    environments: ["grocery-aisles", "warehouse-lanes"],
+  },
+  {
+    title: "Dock Turnaround",
+    slug: "dock-turnaround",
+    summary:
+      "Coordinated trailer arrival, restraint, and staging workflows for shortening dwell time at busy distribution hubs.",
+    focusAreas: [
+      "Trailer presence validation",
+      "Restraint engagement checks",
+      "Hand-off to yard management",
+    ],
+    tags: ["Logistics", "Safety"],
+    environments: ["loading-docks", "warehouse-lanes"],
+  },
+  {
+    title: "Kitchen Line QA",
+    slug: "kitchen-line-qa",
+    summary:
+      "Sanitation, temperature, and station readiness inspections designed for multi-shift commercial kitchen operations.",
+    focusAreas: [
+      "Surface contact verification",
+      "Thermal probe sampling",
+      "Consumables stock confirmation",
+    ],
+    tags: ["Safety", "Inspection"],
+    environments: ["kitchens"],
+  },
+  {
+    title: "Sample Chain of Custody",
+    slug: "sample-chain-of-custody",
+    summary:
+      "Interlocked hand-off and labeling routines that preserve specimen traceability across prep, analysis, and cold storage.",
+    focusAreas: [
+      "Label verification",
+      "Instrument queue staging",
+      "Cold room access logging",
+    ],
+    tags: ["Compliance", "Precision"],
+    environments: ["labs"],
+  },
+  {
+    title: "Office Service Sweep",
+    slug: "office-service-sweep",
+    summary:
+      "After-hours routes for desk reset, amenity restock, and occupant feedback capture in flexible office footprints.",
+    focusAreas: [
+      "Surface reset playbook",
+      "Amenity stock sensing",
+      "Feedback kiosk sync",
+    ],
+    tags: ["Hospitality", "Experience"],
+    environments: ["office-pods", "utility-rooms"],
+  },
+  {
+    title: "Laundry Assist Loop",
+    slug: "laundry-assist-loop",
+    summary:
+      "Loading, cycle monitoring, and folding preparation designed for assistive home robotics pilots.",
+    focusAreas: [
+      "Washer and dryer door actuation",
+      "Detergent dosing guidance",
+      "Laundry bin hand-offs",
+    ],
+    tags: ["Assistive", "Manipulation"],
+    environments: ["home-laundry"],
+  },
+  {
+    title: "Mechanical Room Inspection",
+    slug: "mechanical-room-inspection",
+    summary:
+      "Routine valve, gauge, and panel checks to surface anomalies before they escalate into outages.",
+    focusAreas: [
+      "Gauge reading digitization",
+      "Valve position confirmation",
+      "Service ticket escalation",
+    ],
+    tags: ["Maintenance", "Safety"],
+    environments: ["utility-rooms", "warehouse-lanes"],
   },
 ];
 

--- a/client/src/pages/Environments.tsx
+++ b/client/src/pages/Environments.tsx
@@ -1,62 +1,58 @@
 import { useEffect, useMemo, useState } from "react";
-import { SceneCard } from "@/components/site/SceneCard";
-import { environmentCategories, scenes } from "@/data/content";
+import { PolicyCard } from "@/components/site/PolicyCard";
+import { environmentCategories, policies } from "@/data/content";
 
 const badgeFilters = ["Indoor", "Industrial", "Retail", "Home"];
-
-const sortOptions = [
-  { label: "Most requested", value: "most-requested" },
-  { label: "Industrial", value: "industrial" },
-  { label: "Household", value: "household" },
-  { label: "Newest", value: "newest" },
-];
 
 export default function Environments() {
   const [categoryFilter, setCategoryFilter] = useState<string | null>(null);
   const [badgeFilter, setBadgeFilter] = useState<string | null>(null);
-  const [sortOption, setSortOption] = useState<string>("most-requested");
+  const [policyFilter, setPolicyFilter] = useState<string | null>(null);
 
   useEffect(() => {
     if (typeof window !== "undefined") {
       const params = new URLSearchParams(window.location.search);
       const category = params.get("category");
+      const policy = params.get("policy");
       if (category) {
         setCategoryFilter(category);
+      }
+      if (policy) {
+        setPolicyFilter(policy);
       }
     }
   }, []);
 
-  const filteredScenes = useMemo(() => {
-    let result = scenes.slice();
+  const filteredCategories = useMemo(() => {
+    let result = environmentCategories.slice();
 
     if (categoryFilter) {
-      result = result.filter((scene) =>
-        scene.categories.includes(categoryFilter),
-      );
+      result = result.filter((category) => category.slug === categoryFilter);
     }
 
     if (badgeFilter) {
-      result = result.filter((scene) => scene.tags.includes(badgeFilter));
+      result = result.filter((category) => category.tags.includes(badgeFilter));
     }
 
-    switch (sortOption) {
-      case "industrial":
-        result = result.filter((scene) => scene.tags.includes("Industrial"));
-        break;
-      case "household":
-        result = result.filter((scene) => scene.tags.includes("Home"));
-        break;
-      case "newest":
-        result = result
-          .slice()
-          .reverse();
-        break;
-      default:
-        break;
+    if (policyFilter) {
+      result = result.filter((category) =>
+        policies.some(
+          (policy) => policy.slug === policyFilter && policy.environments.includes(category.slug),
+        ),
+      );
     }
 
     return result;
-  }, [badgeFilter, categoryFilter, sortOption]);
+  }, [badgeFilter, categoryFilter, policyFilter]);
+
+  const policyOptions = useMemo(
+    () =>
+      policies.map((policy) => ({
+        label: policy.title,
+        value: policy.slug,
+      })),
+    [],
+  );
 
   return (
     <div className="mx-auto max-w-6xl space-y-12 px-4 pb-24 pt-16 sm:px-6">
@@ -70,7 +66,8 @@ export default function Environments() {
         <p className="max-w-2xl text-sm text-slate-600">
           Every environment below includes articulated joints, physics-clean colliders, and simulation validation notes. Each
           synthetic build is patterned after a documented real-world location so dataset diversity tracks what your fleets see
-          in production. Filter by environment type, interaction coverage, or deployment focus.
+          in production. Filter by environment type, policy coverage, or deployment focus to assemble the right training
+          package.
         </p>
       </header>
 
@@ -78,13 +75,14 @@ export default function Environments() {
         <button
           type="button"
           className={`rounded-full border px-4 py-2 text-sm transition ${
-            badgeFilter === null && !categoryFilter
+            badgeFilter === null && !categoryFilter && !policyFilter
               ? "border-slate-900 bg-slate-900 text-white"
               : "border-slate-200 text-slate-600 hover:border-slate-300"
           }`}
           onClick={() => {
             setBadgeFilter(null);
             setCategoryFilter(null);
+            setPolicyFilter(null);
           }}
         >
           All environments
@@ -98,7 +96,9 @@ export default function Environments() {
                 ? "border-slate-900 bg-slate-900 text-white"
                 : "border-slate-200 text-slate-600 hover:border-slate-300"
             }`}
-            onClick={() => setCategoryFilter(category.slug)}
+            onClick={() =>
+              setCategoryFilter((prev) => (prev === category.slug ? null : category.slug))
+            }
           >
             {category.title}
           </button>
@@ -125,32 +125,109 @@ export default function Environments() {
       </div>
 
       <div className="flex flex-wrap items-center gap-3 text-sm text-slate-500">
-        <span>Sort by</span>
-        {sortOptions.map((option) => (
+        <span>Filter by policy</span>
+        {policyOptions.map((option) => (
           <button
             key={option.value}
             type="button"
             className={`rounded-full border px-4 py-2 transition ${
-              sortOption === option.value
-                ? "border-slate-900 bg-slate-900 text-white"
+              policyFilter === option.value
+                ? "border-emerald-500 bg-emerald-500 text-black"
                 : "border-slate-200 text-slate-600 hover:border-slate-300"
             }`}
-            onClick={() => setSortOption(option.value)}
+            onClick={() =>
+              setPolicyFilter((prev) => (prev === option.value ? null : option.value))
+            }
           >
             {option.label}
           </button>
         ))}
       </div>
 
-      <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
-        {filteredScenes.map((scene) => (
-          <SceneCard key={scene.slug} scene={scene} />
-        ))}
+      <div className="space-y-8">
+        {filteredCategories.map((category) => {
+          const categoryPolicies = policies.filter(
+            (policy) =>
+              policy.environments.includes(category.slug) &&
+              (!policyFilter || policy.slug === policyFilter),
+          );
+
+          if (policyFilter && categoryPolicies.length === 0) {
+            return null;
+          }
+
+          return (
+            <section
+              key={category.slug}
+              className="overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-sm"
+            >
+              <div className="grid gap-6 lg:grid-cols-[0.85fr_1.15fr]">
+                <div className="space-y-6 p-6 sm:p-8">
+                  <div className="overflow-hidden rounded-3xl border border-slate-200">
+                    <img
+                      src={category.heroImage}
+                      alt={category.title}
+                      className="h-full w-full object-cover"
+                      loading="lazy"
+                    />
+                  </div>
+                  <div className="space-y-4">
+                    <div className="flex flex-wrap items-center gap-2 text-xs uppercase tracking-[0.3em] text-slate-400">
+                      {category.tags.map((tag) => (
+                        <span key={tag}>{tag}</span>
+                      ))}
+                    </div>
+                    <div className="space-y-2">
+                      <h2 className="text-2xl font-semibold text-slate-900">
+                        {category.title}
+                      </h2>
+                      <p className="text-sm text-slate-600">{category.summary}</p>
+                    </div>
+                    <a
+                      href={`#policy-${category.slug}`}
+                      className="inline-flex items-center justify-center rounded-full border border-slate-300 px-5 py-2 text-sm font-semibold text-slate-900 transition hover:border-slate-400 hover:text-slate-700"
+                    >
+                      View policies ↓
+                    </a>
+                  </div>
+                </div>
+                <div
+                  id={`policy-${category.slug}`}
+                  className="border-t border-slate-200 bg-slate-50 p-6 sm:p-8 lg:border-l lg:border-t-0"
+                >
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <h3 className="text-lg font-semibold text-slate-900">
+                      Policies in this environment
+                    </h3>
+                    <span className="rounded-full bg-white px-3 py-1 text-xs font-medium text-slate-500">
+                      {categoryPolicies.length} active
+                    </span>
+                  </div>
+                  {categoryPolicies.length ? (
+                    <div className="mt-6 grid gap-4 sm:grid-cols-2">
+                      {categoryPolicies.map((policy) => (
+                        <PolicyCard
+                          key={policy.slug}
+                          policy={policy}
+                          isHighlighted={policyFilter === policy.slug}
+                        />
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="mt-6 text-sm text-slate-500">
+                      No policies currently mapped. Adjust your filters to explore related playbooks.
+                    </p>
+                  )}
+                </div>
+              </div>
+            </section>
+          );
+        })}
       </div>
 
-      {filteredScenes.length === 0 ? (
+      {filteredCategories.length === 0 ? (
         <p className="text-sm text-slate-500">
-          No scenes found. Adjust your filters to explore more environments.
+          No environments match the current filters. Adjust your selection to explore more options.
         </p>
       ) : null}
     </div>


### PR DESCRIPTION
## Summary
- add structured policy metadata to the shared content dataset
- render environments with nested policy cards and expose a policy filter on the catalog page
- introduce a reusable PolicyCard component for highlighting policy focus areas

## Testing
- npx tsc --noEmit --pretty false -p tsconfig.client.json *(terminated after ~30s due to environment runtime limits)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69114dadcf6883298e203908e6b44e70)