### PR TITLE
Revamp contact request flow for dataset and scene requests

### DIFF
--- a/client/src/components/site/ContactForm.tsx
+++ b/client/src/components/site/ContactForm.tsx
@@ -1,44 +1,82 @@
 import { useState } from "react";
 
-const projectTypes = [
-  "Catalog scene license (non-exclusive)",
-  "Exclusive dataset program",
-  "Procedural synthetic scene",
-  "Real-world scan to SimReady",
-];
+const requestPaths = [
+  {
+    id: "dataset",
+    label: "I need a dataset",
+    description:
+      "Recommended for labs and autonomy teams that need broad coverage across layouts, tasks, and interaction types.",
+  },
+  {
+    id: "scene",
+    label: "I need a specific scene",
+    description: "Order a targeted scene with the exact fixtures and interactions you need to validate a workflow.",
+  },
+] as const;
 
-const engagementScopes = [
-  "Single scene",
-  "Multi-scene dataset",
-  "Ongoing refresh program",
-];
+const datasetTiers = [
+  {
+    value: "pilot",
+    title: "Pilot",
+    metrics: "5 scenes · 30–50 articulated links · 50–100 pickable props",
+    note: "Replicator semantics optional.",
+  },
+  {
+    value: "lab-pack",
+    title: "Lab Pack",
+    metrics: "20–30 scenes · 200–400 articulated links · Full semantics",
+    note: "Includes Isaac 4.x/5.x validation notes.",
+  },
+  {
+    value: "enterprise",
+    title: "Enterprise / Custom",
+    metrics: "50–100+ scenes · On-site capture option",
+    note: "Exclusivity and SLA coverage available.",
+  },
+] as const;
 
-const emailOptInOptions = ["Yes", "Not right now"] as const;
+const sceneCategories = ["Kitchen", "Warehouse", "Retail", "Office", "Lab"] as const;
 
-const policyOptions = [
-  "Open/slide",
+const interactionOptions = [
+  "Revolute",
+  "Prismatic",
+  "Buttons",
+  "Knobs",
+  "Pickables",
+] as const;
+
+const useCaseOptions = [
+  "Open",
+  "Slide",
   "Pick-place",
-  "Buttons/knobs",
   "Palletize",
-  "Bin-pick",
-];
+] as const;
 
-const deliveryFormats = ["USD", "USDC", "Both"];
+const exclusivityOptions = [
+  { value: "non-exclusive", label: "Non-exclusive (shared catalog)" },
+  { value: "exclusive", label: "Exclusive / SLA" },
+] as const;
+
+const budgetRanges = [
+  "Under $10k",
+  "$10k – $25k",
+  "$25k – $50k",
+  "$50k+",
+] as const;
+
+const isaacVersions = ["Isaac 3.x", "Isaac 4.x", "Isaac 5.x", "Other"] as const;
 
 export function ContactForm() {
-  const [status, setStatus] = useState<"idle" | "loading" | "success" | "error">(
-    "idle",
-  );
+  const [status, setStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
   const [message, setMessage] = useState("");
+  const [selectedPath, setSelectedPath] = useState<(typeof requestPaths)[number]["id"]>("dataset");
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     const data = new FormData(event.currentTarget);
-    const payload: Record<string, unknown> = Object.fromEntries(
-      data.entries(),
-    );
-    payload["targetPolicies"] = data.getAll("targetPolicies");
-    payload["desiredCategories"] = data.getAll("desiredCategories");
+    const payload: Record<string, unknown> = Object.fromEntries(data.entries());
+    payload["useCases"] = data.getAll("useCases");
+    payload["sceneInteractions"] = data.getAll("sceneInteractions");
 
     setStatus("loading");
     setMessage("");
@@ -57,6 +95,7 @@ export function ContactForm() {
       setStatus("success");
       setMessage("Thanks — we’ll review and follow up within one business day.");
       event.currentTarget.reset();
+      setSelectedPath("dataset");
     } catch (error) {
       console.error(error);
       setStatus("error");
@@ -67,187 +106,250 @@ export function ContactForm() {
   return (
     <form
       onSubmit={handleSubmit}
-      className="grid gap-6 rounded-3xl border border-slate-200 bg-white p-6 md:grid-cols-2"
+      className="grid gap-8 rounded-3xl border border-slate-200 bg-white p-6 text-sm text-slate-700 md:p-10"
     >
-      <div className="grid gap-4">
-        <div>
-          <label className="text-xs uppercase tracking-[0.3em] text-slate-400">Contact</label>
-          <div className="mt-2 grid gap-3 sm:grid-cols-2">
-            <input
-              required
-              name="name"
-              placeholder="Your name"
-              className="rounded-full border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-slate-400 focus:outline-none"
-            />
-            <input
-              required
-              type="email"
-              name="email"
-              placeholder="you@company.com"
-              className="rounded-full border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-slate-400 focus:outline-none"
-            />
-          </div>
+      <section className="grid gap-4">
+        <p className="text-xs uppercase tracking-[0.3em] text-slate-400">Choose your path</p>
+        <div className="grid gap-4 md:grid-cols-2">
+          {requestPaths.map((path) => {
+            const isActive = selectedPath === path.id;
+            return (
+              <label
+                key={path.id}
+                className={`flex cursor-pointer flex-col gap-2 rounded-2xl border p-4 transition focus-within:ring-2 focus-within:ring-slate-300 ${
+                  isActive ? "border-slate-900 bg-slate-900 text-white" : "border-slate-200"
+                }`}
+              >
+                <div className="flex items-center justify-between">
+                  <span className="text-base font-semibold">{path.label}</span>
+                  <input
+                    type="radio"
+                    name="requestType"
+                    value={path.id}
+                    checked={isActive}
+                    onChange={() => setSelectedPath(path.id)}
+                    className="h-4 w-4"
+                  />
+                </div>
+                <p className={`text-xs leading-relaxed ${isActive ? "text-white/80" : "text-slate-500"}`}>
+                  {path.description}
+                </p>
+              </label>
+            );
+          })}
         </div>
-        <div className="grid gap-3 sm:grid-cols-2">
-          <div>
-            <label className="text-xs uppercase tracking-[0.3em] text-slate-400">Company</label>
-            <input
-              required
-              name="company"
-              placeholder="Organization"
-              className="mt-2 rounded-full border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-slate-400 focus:outline-none"
-            />
+      </section>
+
+      {selectedPath === "dataset" ? (
+        <section className="grid gap-4">
+          <p className="text-xs uppercase tracking-[0.3em] text-slate-400">Dataset tiers</p>
+          <div className="grid gap-4 md:grid-cols-3">
+            {datasetTiers.map((tier) => (
+              <label
+                key={tier.value}
+                className="flex cursor-pointer flex-col gap-2 rounded-2xl border border-slate-200 p-4 transition hover:border-slate-300 focus-within:ring-2 focus-within:ring-slate-300"
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <span className="text-base font-semibold text-slate-900">{tier.title}</span>
+                  <input
+                    type="radio"
+                    name="datasetTier"
+                    value={tier.value}
+                    defaultChecked={tier.value === "pilot"}
+                    className="h-4 w-4"
+                  />
+                </div>
+                <p className="text-xs text-slate-600">{tier.metrics}</p>
+                <p className="text-xs text-slate-500">{tier.note}</p>
+              </label>
+            ))}
           </div>
-          <div>
-            <label className="text-xs uppercase tracking-[0.3em] text-slate-400">Project type</label>
-            <select
-              name="projectType"
-              className="mt-2 w-full rounded-full border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-slate-400 focus:outline-none"
-            >
-              {projectTypes.map((option) => (
-                <option key={option}>{option}</option>
+        </section>
+      ) : (
+        <section className="grid gap-6">
+          <div className="grid gap-3">
+            <p className="text-xs uppercase tracking-[0.3em] text-slate-400">Scene category</p>
+            <div className="flex flex-wrap gap-3">
+              {sceneCategories.map((category, index) => (
+                <label
+                  key={category}
+                  className="flex cursor-pointer items-center gap-2 rounded-full border border-slate-200 px-4 py-2 text-sm transition hover:border-slate-300"
+                >
+                  <input
+                    type="radio"
+                    name="sceneCategory"
+                    value={category}
+                    defaultChecked={index === 0}
+                    className="h-4 w-4"
+                  />
+                  {category}
+                </label>
               ))}
-            </select>
+            </div>
           </div>
-        </div>
-        <div>
-          <label className="text-xs uppercase tracking-[0.3em] text-slate-400">Engagement scope</label>
-          <div className="mt-3 grid gap-2 sm:grid-cols-3">
-            {engagementScopes.map((option) => (
-              <label key={option} className="flex items-center gap-2 text-sm text-slate-600">
-                <input type="radio" name="engagementScope" value={option} defaultChecked={option === "Single scene"} />
+          <div className="grid gap-3">
+            <p className="text-xs uppercase tracking-[0.3em] text-slate-400">Interactions</p>
+            <div className="grid gap-2 sm:grid-cols-2">
+              {interactionOptions.map((interaction) => (
+                <label key={interaction} className="flex items-center gap-2 rounded-xl border border-slate-200 p-3 text-sm">
+                  <input type="checkbox" name="sceneInteractions" value={interaction} className="h-4 w-4" />
+                  {interaction}
+                </label>
+              ))}
+            </div>
+          </div>
+          <div className="grid gap-4 sm:grid-cols-3">
+            <label className="grid gap-2 text-xs uppercase tracking-[0.3em] text-slate-400">
+              Quantity
+              <input
+                type="number"
+                name="sceneQuantity"
+                min={1}
+                defaultValue={1}
+                className="rounded-full border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700 focus:border-slate-400 focus:outline-none"
+              />
+            </label>
+            <label className="grid gap-2 text-xs uppercase tracking-[0.3em] text-slate-400">
+              Delivery date
+              <input
+                type="date"
+                name="sceneDeliveryDate"
+                className="rounded-full border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700 focus:border-slate-400 focus:outline-none"
+              />
+            </label>
+            <label className="grid gap-2 text-xs uppercase tracking-[0.3em] text-slate-400">
+              Isaac version
+              <select
+                name="sceneIsaacVersion"
+                className="rounded-full border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700 focus:border-slate-400 focus:outline-none"
+              >
+                {isaacVersions.map((version) => (
+                  <option key={version}>{version}</option>
+                ))}
+              </select>
+            </label>
+          </div>
+        </section>
+      )}
+
+      <section className="grid gap-6 md:grid-cols-2">
+        <label className="grid gap-2 text-xs uppercase tracking-[0.3em] text-slate-400">
+          Name
+          <input
+            required
+            name="name"
+            placeholder="Your name"
+            className="rounded-full border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700 focus:border-slate-400 focus:outline-none"
+          />
+        </label>
+        <label className="grid gap-2 text-xs uppercase tracking-[0.3em] text-slate-400">
+          Work email
+          <input
+            required
+            type="email"
+            name="email"
+            placeholder="you@company.com"
+            className="rounded-full border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700 focus:border-slate-400 focus:outline-none"
+          />
+        </label>
+        <label className="grid gap-2 text-xs uppercase tracking-[0.3em] text-slate-400">
+          Company
+          <input
+            required
+            name="company"
+            placeholder="Organization"
+            className="rounded-full border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700 focus:border-slate-400 focus:outline-none"
+          />
+        </label>
+        <label className="grid gap-2 text-xs uppercase tracking-[0.3em] text-slate-400">
+          Robot platform
+          <input
+            name="robotPlatform"
+            placeholder="Platform, arm, or AMR"
+            className="rounded-full border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700 focus:border-slate-400 focus:outline-none"
+          />
+        </label>
+      </section>
+
+      <section className="grid gap-6 md:grid-cols-2">
+        <div className="grid gap-3">
+          <p className="text-xs uppercase tracking-[0.3em] text-slate-400">Use case</p>
+          <div className="grid gap-2 sm:grid-cols-2">
+            {useCaseOptions.map((option) => (
+              <label key={option} className="flex items-center gap-2 rounded-xl border border-slate-200 p-3 text-sm">
+                <input type="checkbox" name="useCases" value={option} className="h-4 w-4" />
                 {option}
               </label>
             ))}
           </div>
         </div>
-        <div>
-          <label className="text-xs uppercase tracking-[0.3em] text-slate-400">Target policies</label>
-          <div className="mt-3 grid gap-2 sm:grid-cols-2">
-            {policyOptions.map((option) => (
-              <label key={option} className="flex items-center gap-2 text-sm text-slate-600">
-                <input type="checkbox" name="targetPolicies" value={option} className="h-4 w-4" />
-                {option}
+        <label className="grid gap-2 text-xs uppercase tracking-[0.3em] text-slate-400">
+          Required semantics
+          <textarea
+            name="requiredSemantics"
+            rows={4}
+            placeholder="Semantic layers, annotations, or Replicator requirements"
+            className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700 focus:border-slate-400 focus:outline-none"
+          />
+        </label>
+      </section>
+
+      <section className="grid gap-6 md:grid-cols-2">
+        <div className="grid gap-3">
+          <p className="text-xs uppercase tracking-[0.3em] text-slate-400">Exclusivity needs</p>
+          <div className="grid gap-2">
+            {exclusivityOptions.map((option) => (
+              <label key={option.value} className="flex items-center gap-2 rounded-xl border border-slate-200 p-3 text-sm">
+                <input type="radio" name="exclusivity" value={option.value} defaultChecked={option.value === "non-exclusive"} />
+                {option.label}
               </label>
             ))}
           </div>
         </div>
-        <div>
-          <label className="text-xs uppercase tracking-[0.3em] text-slate-400">Desired categories</label>
-          <div className="mt-3 grid gap-2 sm:grid-cols-2">
-            {[
-              "Kitchens",
-              "Grocery",
-              "Warehouse",
-              "Retail",
-              "Office",
-              "Lab",
-              "Utility",
-              "Home",
-            ].map((option) => (
-              <label key={option} className="flex items-center gap-2 text-sm text-slate-600">
-                <input type="checkbox" name="desiredCategories" value={option} className="h-4 w-4" />
-                {option}
-              </label>
-            ))}
-          </div>
-        </div>
-      </div>
-      <div className="grid gap-4">
-        <div className="grid gap-3 sm:grid-cols-2">
-          <div>
-            <label className="text-xs uppercase tracking-[0.3em] text-slate-400">Timeline</label>
-            <input
-              name="deadline"
-              placeholder="Need by…"
-              className="mt-2 w-full rounded-full border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-slate-400 focus:outline-none"
-            />
-          </div>
-          <div>
-            <label className="text-xs uppercase tracking-[0.3em] text-slate-400">Budget range</label>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <label className="grid gap-2 text-xs uppercase tracking-[0.3em] text-slate-400">
+            Budget range
             <select
               name="budget"
-              className="mt-2 w-full rounded-full border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-slate-400 focus:outline-none"
+              required
+              className="rounded-full border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700 focus:border-slate-400 focus:outline-none"
             >
-              <option value="<$10k">Under $10k</option>
-              <option value="$10k-$25k">$10k – $25k</option>
-              <option value="$25k-$50k">$25k – $50k</option>
-              <option value=">$50k">$50k+</option>
+              {budgetRanges.map((range) => (
+                <option key={range}>{range}</option>
+              ))}
             </select>
-          </div>
-        </div>
-        <div>
-          <label className="text-xs uppercase tracking-[0.3em] text-slate-400">Delivery format</label>
-          <div className="mt-3 flex flex-wrap gap-3">
-            {deliveryFormats.map((format) => (
-              <label key={format} className="flex items-center gap-2 text-sm text-slate-600">
-                <input type="radio" name="deliveryFormat" value={format} defaultChecked={format === "USD"} />
-                {format}
-              </label>
-            ))}
-          </div>
-        </div>
-        <div className="grid gap-3 sm:grid-cols-2">
-          <div>
-            <label className="text-xs uppercase tracking-[0.3em] text-slate-400">Integration context</label>
-            <input
-              name="integrationContext"
-              placeholder="Workflow, platform, or downstream use"
-              className="mt-2 w-full rounded-full border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-slate-400 focus:outline-none"
-            />
-          </div>
-          <div>
-            <label className="text-xs uppercase tracking-[0.3em] text-slate-400">Interactables</label>
-            <input
-              name="interactables"
-              placeholder="Number of joints"
-              className="mt-2 w-full rounded-full border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-slate-400 focus:outline-none"
-            />
-          </div>
-        </div>
-        <div>
-          <label className="text-xs uppercase tracking-[0.3em] text-slate-400">Project context</label>
-          <textarea
-            name="message"
-            rows={5}
-            placeholder="Tell us about the scene, success criteria, and timeline."
-            className="mt-2 w-full rounded-3xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-slate-400 focus:outline-none"
-          />
-        </div>
-        <div>
-          <label className="text-xs uppercase tracking-[0.3em] text-slate-400">
-            Do you want to get emails from us about future updates?*
           </label>
-          <div className="mt-3 flex flex-wrap gap-3">
-            {emailOptInOptions.map((option) => (
-              <label key={option} className="flex items-center gap-2 text-sm text-slate-600">
-                <input
-                  type="radio"
-                  name="emailOptIn"
-                  value={option}
-                  required
-                  defaultChecked={option === "Yes"}
-                />
-                {option}
-              </label>
-            ))}
-          </div>
+          <label className="grid gap-2 text-xs uppercase tracking-[0.3em] text-slate-400">
+            Deadline
+            <input
+              type="date"
+              name="deadline"
+              className="rounded-full border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700 focus:border-slate-400 focus:outline-none"
+            />
+          </label>
         </div>
+      </section>
+
+      <section className="grid gap-3">
+        <p className="text-xs uppercase tracking-[0.3em] text-slate-400">Anything else?</p>
+        <textarea
+          name="message"
+          rows={4}
+          placeholder="Context, success criteria, datasets you admire, or delivery constraints"
+          className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700 focus:border-slate-400 focus:outline-none"
+        />
+      </section>
+
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <button
           type="submit"
-          className="mt-2 inline-flex items-center justify-center rounded-full bg-slate-900 px-6 py-3 text-sm font-semibold text-white transition hover:bg-slate-700 disabled:opacity-60"
+          className="inline-flex items-center justify-center rounded-full bg-slate-900 px-6 py-3 text-sm font-semibold text-white transition hover:bg-slate-700 disabled:opacity-60"
           disabled={status === "loading"}
         >
-          {status === "loading" ? "Sending…" : "Request this scene"}
+          {status === "loading" ? "Sending…" : "Submit request"}
         </button>
         {message ? (
-          <p
-            className={`text-sm ${
-              status === "error" ? "text-red-500" : "text-emerald-600"
-            }`}
-          >
-            {message}
-          </p>
+          <p className={`text-sm ${status === "error" ? "text-red-500" : "text-emerald-600"}`}>{message}</p>
         ) : null}
       </div>
     </form>

--- a/client/src/pages/Contact.tsx
+++ b/client/src/pages/Contact.tsx
@@ -4,16 +4,15 @@ export default function Contact() {
   return (
     <div className="mx-auto max-w-6xl space-y-10 px-4 pb-24 pt-16 sm:px-6">
       <header className="space-y-4">
-        <p className="text-xs uppercase tracking-[0.3em] text-slate-400">
-          Request a scene
-        </p>
+        <p className="text-xs uppercase tracking-[0.3em] text-slate-400">Build your training coverage</p>
         <h1 className="text-4xl font-semibold text-slate-900">
-          Tell us what your robot needs to practice.
+          Tell us whether you need a full dataset or a single scene.
         </h1>
         <p className="max-w-3xl text-sm text-slate-600">
-          Share your target policies, categories, and delivery timeline. We support both exclusive dataset programs and
-          non-exclusive catalog scenes—each rooted in real-world kitchens, warehouses, utility corridors, bedrooms, and more—
-          and we’ll follow up within one business day with scope, pricing, and draft coverage.
+          Labs typically need breadth—multiple layouts, articulation types, and semantic layers to keep policies robust. That’s
+          why we lead with dataset programs, while still making it easy to request a specific kitchen, warehouse aisle, or
+          other scene when you’re scoping a pilot. Share what your robot needs and we’ll align on scope, delivery, and budget
+          within one business day.
         </p>
       </header>
       <ContactForm />


### PR DESCRIPTION
## Summary
- redesign the contact form with separate dataset and single-scene request paths and tier details
- collect critical sales qualification fields including use cases, robot platform, semantics, exclusivity, budget, and deadline
- refresh the contact page copy to emphasize dataset programs while keeping single-scene requests available

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911573849c4832989d2212156ab75cb)