### PR TITLE
Revamp contact page request flows

### DIFF
--- a/client/src/components/site/ContactForm.tsx
+++ b/client/src/components/site/ContactForm.tsx
@@ -1,44 +1,131 @@
 import { useState } from "react";
 
-const projectTypes = [
-  "Catalog scene license (non-exclusive)",
-  "Exclusive dataset program",
-  "Procedural synthetic scene",
-  "Real-world scan to SimReady",
+const requestOptions = [
+  {
+    value: "dataset" as const,
+    label: "I need a dataset",
+    description:
+      "Best for labs that need coverage across layouts and tasks. We’ll anchor scope, semantics, and delivery windows together.",
+    recommended: true,
+  },
+  {
+    value: "scene" as const,
+    label: "I need a specific scene",
+    description:
+      "Per-scene SKU for targeted pilots. Choose the layout, interactions, and delivery version you need to ship.",
+    recommended: false,
+  },
 ];
 
-const engagementScopes = [
-  "Single scene",
-  "Multi-scene dataset",
-  "Ongoing refresh program",
+const datasetTiers = [
+  {
+    value: "Pilot",
+    label: "Pilot",
+    primary: "5 scenes / 30–50 articulated links",
+    secondary: "50–100 pickable props. Replicator semantics optional.",
+  },
+  {
+    value: "Lab Pack",
+    label: "Lab Pack",
+    primary: "20–30 scenes / 200–400 articulated links",
+    secondary: "Full semantics with Isaac 4.x/5.x validation notes included.",
+  },
+  {
+    value: "Enterprise / Custom",
+    label: "Enterprise / Custom",
+    primary: "50–100+ scenes with optional on-site capture",
+    secondary: "Exclusivity, SLA options, and program co-design for scale.",
+  },
 ];
 
-const emailOptInOptions = ["Yes", "Not right now"] as const;
+const sceneCategories = ["Kitchen", "Warehouse", "Retail", "Office", "Lab"] as const;
 
-const policyOptions = [
+const interactionOptions = [
+  "Revolute",
+  "Prismatic",
+  "Buttons",
+  "Knobs",
+  "Pickables",
+] as const;
+
+const useCaseOptions = [
   "Open/slide",
   "Pick-place",
-  "Buttons/knobs",
   "Palletize",
-  "Bin-pick",
+  "Other",
+] as const;
+
+const exclusivityOptions = [
+  { value: "none", label: "Shared catalog is fine" },
+  { value: "preferred", label: "Prefer exclusivity" },
+  { value: "required", label: "Exclusivity required" },
 ];
 
-const deliveryFormats = ["USD", "USDC", "Both"];
+const budgetRanges = [
+  "Under $10k",
+  "$10k – $25k",
+  "$25k – $50k",
+  "$50k+",
+];
+
+const isaacVersions = ["Isaac 4.x", "Isaac 5.x", "Both", "Other"] as const;
 
 export function ContactForm() {
-  const [status, setStatus] = useState<"idle" | "loading" | "success" | "error">(
-    "idle",
-  );
+  const [status, setStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
   const [message, setMessage] = useState("");
+  const [requestType, setRequestType] = useState<"dataset" | "scene">("dataset");
+  const [datasetTier, setDatasetTier] = useState<string>(datasetTiers[0].value);
+  const [sceneCategory, setSceneCategory] = useState<string>(sceneCategories[0]);
+  const [sceneInteractions, setSceneInteractions] = useState<string[]>([]);
+  const [selectedUseCases, setSelectedUseCases] = useState<string[]>([]);
+  const [exclusivity, setExclusivity] = useState<string>(exclusivityOptions[0].value);
+
+  const handleInteractionToggle = (value: string) => {
+    setSceneInteractions((prev) =>
+      prev.includes(value) ? prev.filter((item) => item !== value) : [...prev, value],
+    );
+  };
+
+  const handleUseCaseToggle = (value: string) => {
+    setSelectedUseCases((prev) => {
+      const next = prev.includes(value)
+        ? prev.filter((item) => item !== value)
+        : [...prev, value];
+      if (
+        next.length > 0 &&
+        status === "error" &&
+        message === "Select at least one use case so we can scope your request."
+      ) {
+        setStatus("idle");
+        setMessage("");
+      }
+      return next;
+    });
+  };
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    const data = new FormData(event.currentTarget);
-    const payload: Record<string, unknown> = Object.fromEntries(
-      data.entries(),
-    );
-    payload["targetPolicies"] = data.getAll("targetPolicies");
-    payload["desiredCategories"] = data.getAll("desiredCategories");
+    const form = event.currentTarget;
+
+    if (selectedUseCases.length === 0) {
+      setStatus("error");
+      setMessage("Select at least one use case so we can scope your request.");
+      return;
+    }
+
+    const data = new FormData(form);
+    data.set("requestType", requestType);
+    data.set("datasetTier", datasetTier);
+    data.set("sceneCategory", sceneCategory);
+
+    const payload: Record<string, unknown> = Object.fromEntries(data.entries());
+    payload["useCases"] = selectedUseCases;
+    payload["sceneInteractions"] = sceneInteractions;
+    payload["requestType"] = requestType;
+    payload["datasetTier"] = datasetTier;
+    payload["sceneCategory"] = sceneCategory;
+    payload["exclusivityNeeds"] = exclusivity;
+    payload["budgetRange"] = data.get("budgetRange") ?? "";
 
     setStatus("loading");
     setMessage("");
@@ -54,9 +141,15 @@ export function ContactForm() {
         throw new Error("Failed to send");
       }
 
+      form.reset();
       setStatus("success");
       setMessage("Thanks — we’ll review and follow up within one business day.");
-      event.currentTarget.reset();
+      setRequestType("dataset");
+      setDatasetTier(datasetTiers[0].value);
+      setSceneCategory(sceneCategories[0]);
+      setSceneInteractions([]);
+      setSelectedUseCases([]);
+      setExclusivity(exclusivityOptions[0].value);
     } catch (error) {
       console.error(error);
       setStatus("error");
@@ -67,178 +160,336 @@ export function ContactForm() {
   return (
     <form
       onSubmit={handleSubmit}
-      className="grid gap-6 rounded-3xl border border-slate-200 bg-white p-6 md:grid-cols-2"
+      className="space-y-8 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8"
     >
-      <div className="grid gap-4">
-        <div>
-          <label className="text-xs uppercase tracking-[0.3em] text-slate-400">Contact</label>
-          <div className="mt-2 grid gap-3 sm:grid-cols-2">
-            <input
-              required
-              name="name"
-              placeholder="Your name"
-              className="rounded-full border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-slate-400 focus:outline-none"
-            />
-            <input
-              required
-              type="email"
-              name="email"
-              placeholder="you@company.com"
-              className="rounded-full border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-slate-400 focus:outline-none"
+      <section className="space-y-3">
+        <div className="flex flex-col gap-1">
+          <span className="text-xs uppercase tracking-[0.3em] text-slate-400">Choose your path</span>
+          <h2 className="text-xl font-semibold text-slate-900">How can we help?</h2>
+          <p className="text-sm text-slate-600">
+            Labs usually start with datasets for coverage. You can still request a single hero scene if you know exactly what
+            you need.
+          </p>
+        </div>
+        <div className="grid gap-4 md:grid-cols-2">
+          {requestOptions.map((option) => (
+            <label
+              key={option.value}
+              className={`group relative flex cursor-pointer flex-col gap-3 rounded-2xl border p-5 transition hover:border-slate-300 ${
+                requestType === option.value
+                  ? "border-slate-900 bg-slate-50 shadow-sm"
+                  : "border-slate-200 bg-white"
+              }`}
+            >
+              <input
+                type="radio"
+                name="requestType"
+                value={option.value}
+                checked={requestType === option.value}
+                onChange={() => setRequestType(option.value)}
+                className="sr-only"
+              />
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-base font-semibold text-slate-900">{option.label}</span>
+                {option.recommended ? (
+                  <span className="rounded-full bg-slate-900 px-3 py-1 text-xs font-medium text-white">Recommended</span>
+                ) : null}
+              </div>
+              <p className="text-sm text-slate-600">{option.description}</p>
+            </label>
+          ))}
+        </div>
+      </section>
+
+      {requestType === "dataset" ? (
+        <section className="space-y-4">
+          <div className="flex flex-col gap-1">
+            <span className="text-xs uppercase tracking-[0.3em] text-slate-400">Dataset tiers</span>
+            <p className="text-sm text-slate-600">
+              These anchors are non-binding, but they map to how teams scope training corpora. Bigger bundles beat one-offs.
+            </p>
+          </div>
+          <div className="grid gap-4 lg:grid-cols-3">
+            {datasetTiers.map((tier) => (
+              <label
+                key={tier.value}
+                className={`flex h-full cursor-pointer flex-col gap-2 rounded-2xl border p-5 transition hover:border-slate-300 ${
+                  datasetTier === tier.value ? "border-slate-900 bg-slate-50 shadow-sm" : "border-slate-200"
+                }`}
+              >
+                <input
+                  type="radio"
+                  name="datasetTier"
+                  value={tier.value}
+                  checked={datasetTier === tier.value}
+                  onChange={() => setDatasetTier(tier.value)}
+                  className="sr-only"
+                />
+                <span className="text-base font-semibold text-slate-900">{tier.label}</span>
+                <p className="text-sm font-medium text-slate-800">{tier.primary}</p>
+                <p className="text-sm text-slate-600">{tier.secondary}</p>
+              </label>
+            ))}
+          </div>
+          <div className="space-y-2">
+            <label className="text-xs uppercase tracking-[0.3em] text-slate-400">Notes</label>
+            <textarea
+              name="datasetNotes"
+              rows={3}
+              placeholder="Anything specific about capture, semantics, or pilot milestones?"
+              className="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-slate-400 focus:outline-none"
             />
           </div>
-        </div>
-        <div className="grid gap-3 sm:grid-cols-2">
-          <div>
+        </section>
+      ) : (
+        <section className="space-y-6">
+          <div className="flex flex-col gap-1">
+            <span className="text-xs uppercase tracking-[0.3em] text-slate-400">Scene details</span>
+            <p className="text-sm text-slate-600">
+              Pick the layout and interactions you need. We’ll confirm lighting, dressing, and any hardware fixtures after you
+              submit.
+            </p>
+          </div>
+          <div className="grid gap-6 md:grid-cols-2">
+            <div className="space-y-3">
+              <p className="text-xs uppercase tracking-[0.3em] text-slate-400">Category</p>
+              <div className="grid gap-2 sm:grid-cols-2">
+                {sceneCategories.map((category) => (
+                  <label
+                    key={category}
+                    className={`flex cursor-pointer items-center justify-between rounded-full border px-4 py-2 text-sm transition hover:border-slate-300 ${
+                      sceneCategory === category ? "border-slate-900 bg-slate-50 font-medium" : "border-slate-200"
+                    }`}
+                  >
+                    <input
+                      type="radio"
+                      name="sceneCategory"
+                      value={category}
+                      checked={sceneCategory === category}
+                      onChange={() => setSceneCategory(category)}
+                      className="sr-only"
+                      required
+                    />
+                    {category}
+                  </label>
+                ))}
+              </div>
+            </div>
+            <div className="space-y-3">
+              <p className="text-xs uppercase tracking-[0.3em] text-slate-400">Interactions</p>
+              <div className="grid gap-2 sm:grid-cols-2">
+                {interactionOptions.map((interaction) => (
+                  <label
+                    key={interaction}
+                    className={`flex cursor-pointer items-center justify-between rounded-full border px-4 py-2 text-sm transition hover:border-slate-300 ${
+                      sceneInteractions.includes(interaction)
+                        ? "border-slate-900 bg-slate-50 font-medium"
+                        : "border-slate-200"
+                    }`}
+                  >
+                    <input
+                      type="checkbox"
+                      name="sceneInteractions"
+                      value={interaction}
+                      checked={sceneInteractions.includes(interaction)}
+                      onChange={() => handleInteractionToggle(interaction)}
+                      className="sr-only"
+                    />
+                    {interaction}
+                  </label>
+                ))}
+              </div>
+            </div>
+          </div>
+          <div className="grid gap-4 md:grid-cols-3">
+            <div className="space-y-2">
+              <label className="text-xs uppercase tracking-[0.3em] text-slate-400">Quantity</label>
+              <input
+                type="number"
+                name="sceneQuantity"
+                min={1}
+                required
+                defaultValue={1}
+                className="w-full rounded-full border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-slate-400 focus:outline-none"
+              />
+            </div>
+            <div className="space-y-2">
+              <label className="text-xs uppercase tracking-[0.3em] text-slate-400">Delivery date</label>
+              <input
+                type="date"
+                name="sceneDeliveryDate"
+                required
+                className="w-full rounded-full border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-slate-400 focus:outline-none"
+              />
+            </div>
+            <div className="space-y-2">
+              <label className="text-xs uppercase tracking-[0.3em] text-slate-400">Isaac version</label>
+              <select
+                name="isaacVersion"
+                required
+                className="w-full rounded-full border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-slate-400 focus:outline-none"
+              >
+                {isaacVersions.map((version) => (
+                  <option key={version} value={version}>
+                    {version}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+        </section>
+      )}
+
+      <section className="space-y-6">
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="space-y-2">
             <label className="text-xs uppercase tracking-[0.3em] text-slate-400">Company</label>
             <input
               required
               name="company"
               placeholder="Organization"
-              className="mt-2 rounded-full border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-slate-400 focus:outline-none"
+              className="w-full rounded-full border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-slate-400 focus:outline-none"
             />
           </div>
-          <div>
-            <label className="text-xs uppercase tracking-[0.3em] text-slate-400">Project type</label>
-            <select
-              name="projectType"
-              className="mt-2 w-full rounded-full border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-slate-400 focus:outline-none"
-            >
-              {projectTypes.map((option) => (
-                <option key={option}>{option}</option>
-              ))}
-            </select>
-          </div>
-        </div>
-        <div>
-          <label className="text-xs uppercase tracking-[0.3em] text-slate-400">Engagement scope</label>
-          <div className="mt-3 grid gap-2 sm:grid-cols-3">
-            {engagementScopes.map((option) => (
-              <label key={option} className="flex items-center gap-2 text-sm text-slate-600">
-                <input type="radio" name="engagementScope" value={option} defaultChecked={option === "Single scene"} />
-                {option}
-              </label>
-            ))}
-          </div>
-        </div>
-        <div>
-          <label className="text-xs uppercase tracking-[0.3em] text-slate-400">Target policies</label>
-          <div className="mt-3 grid gap-2 sm:grid-cols-2">
-            {policyOptions.map((option) => (
-              <label key={option} className="flex items-center gap-2 text-sm text-slate-600">
-                <input type="checkbox" name="targetPolicies" value={option} className="h-4 w-4" />
-                {option}
-              </label>
-            ))}
-          </div>
-        </div>
-        <div>
-          <label className="text-xs uppercase tracking-[0.3em] text-slate-400">Desired categories</label>
-          <div className="mt-3 grid gap-2 sm:grid-cols-2">
-            {[
-              "Kitchens",
-              "Grocery",
-              "Warehouse",
-              "Retail",
-              "Office",
-              "Lab",
-              "Utility",
-              "Home",
-            ].map((option) => (
-              <label key={option} className="flex items-center gap-2 text-sm text-slate-600">
-                <input type="checkbox" name="desiredCategories" value={option} className="h-4 w-4" />
-                {option}
-              </label>
-            ))}
-          </div>
-        </div>
-      </div>
-      <div className="grid gap-4">
-        <div className="grid gap-3 sm:grid-cols-2">
-          <div>
-            <label className="text-xs uppercase tracking-[0.3em] text-slate-400">Timeline</label>
+          <div className="space-y-2">
+            <label className="text-xs uppercase tracking-[0.3em] text-slate-400">Robot platform</label>
             <input
-              name="deadline"
-              placeholder="Need by…"
-              className="mt-2 w-full rounded-full border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-slate-400 focus:outline-none"
-            />
-          </div>
-          <div>
-            <label className="text-xs uppercase tracking-[0.3em] text-slate-400">Budget range</label>
-            <select
-              name="budget"
-              className="mt-2 w-full rounded-full border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-slate-400 focus:outline-none"
-            >
-              <option value="<$10k">Under $10k</option>
-              <option value="$10k-$25k">$10k – $25k</option>
-              <option value="$25k-$50k">$25k – $50k</option>
-              <option value=">$50k">$50k+</option>
-            </select>
-          </div>
-        </div>
-        <div>
-          <label className="text-xs uppercase tracking-[0.3em] text-slate-400">Delivery format</label>
-          <div className="mt-3 flex flex-wrap gap-3">
-            {deliveryFormats.map((format) => (
-              <label key={format} className="flex items-center gap-2 text-sm text-slate-600">
-                <input type="radio" name="deliveryFormat" value={format} defaultChecked={format === "USD"} />
-                {format}
-              </label>
-            ))}
-          </div>
-        </div>
-        <div className="grid gap-3 sm:grid-cols-2">
-          <div>
-            <label className="text-xs uppercase tracking-[0.3em] text-slate-400">Integration context</label>
-            <input
-              name="integrationContext"
-              placeholder="Workflow, platform, or downstream use"
-              className="mt-2 w-full rounded-full border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-slate-400 focus:outline-none"
-            />
-          </div>
-          <div>
-            <label className="text-xs uppercase tracking-[0.3em] text-slate-400">Interactables</label>
-            <input
-              name="interactables"
-              placeholder="Number of joints"
-              className="mt-2 w-full rounded-full border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-slate-400 focus:outline-none"
+              required
+              name="robotPlatform"
+              placeholder="Arm, mobile base, AMR fleet, etc."
+              className="w-full rounded-full border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-slate-400 focus:outline-none"
             />
           </div>
         </div>
-        <div>
-          <label className="text-xs uppercase tracking-[0.3em] text-slate-400">Project context</label>
-          <textarea
-            name="message"
-            rows={5}
-            placeholder="Tell us about the scene, success criteria, and timeline."
-            className="mt-2 w-full rounded-3xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-slate-400 focus:outline-none"
-          />
-        </div>
-        <div>
-          <label className="text-xs uppercase tracking-[0.3em] text-slate-400">
-            Do you want to get emails from us about future updates?*
-          </label>
-          <div className="mt-3 flex flex-wrap gap-3">
-            {emailOptInOptions.map((option) => (
-              <label key={option} className="flex items-center gap-2 text-sm text-slate-600">
+        <div className="space-y-2">
+          <span className="text-xs uppercase tracking-[0.3em] text-slate-400">Use case</span>
+          <div className="grid gap-2 sm:grid-cols-2 md:grid-cols-4">
+            {useCaseOptions.map((option) => (
+              <label
+                key={option}
+                className={`flex cursor-pointer items-center justify-between rounded-full border px-4 py-2 text-sm transition hover:border-slate-300 ${
+                  selectedUseCases.includes(option)
+                    ? "border-slate-900 bg-slate-50 font-medium"
+                    : "border-slate-200"
+                }`}
+              >
                 <input
-                  type="radio"
-                  name="emailOptIn"
+                  type="checkbox"
+                  name="useCases"
                   value={option}
-                  required
-                  defaultChecked={option === "Yes"}
+                  checked={selectedUseCases.includes(option)}
+                  onChange={() => handleUseCaseToggle(option)}
+                  className="sr-only"
                 />
                 {option}
               </label>
             ))}
           </div>
         </div>
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="space-y-2">
+            <label className="text-xs uppercase tracking-[0.3em] text-slate-400">Required semantics</label>
+            <textarea
+              required
+              name="requiredSemantics"
+              rows={3}
+              placeholder="Collider fidelity, replicator semantics, material IDs, etc."
+              className="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-slate-400 focus:outline-none"
+            />
+          </div>
+            <div className="space-y-2">
+              <label className="text-xs uppercase tracking-[0.3em] text-slate-400">Exclusivity needs</label>
+              <div className="grid gap-2">
+                {exclusivityOptions.map((option) => (
+                  <label
+                    key={option.value}
+                    className={`flex cursor-pointer items-center justify-between rounded-full border px-4 py-2 text-sm transition hover:border-slate-300 ${
+                      exclusivity === option.value
+                        ? "border-slate-900 bg-slate-50 font-medium"
+                        : "border-slate-200"
+                    }`}
+                  >
+                    <input
+                      type="radio"
+                      name="exclusivityNeeds"
+                      value={option.value}
+                      checked={exclusivity === option.value}
+                      onChange={() => setExclusivity(option.value)}
+                      className="sr-only"
+                    />
+                    {option.label}
+                  </label>
+                ))}
+              </div>
+            </div>
+        </div>
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="space-y-2">
+            <label className="text-xs uppercase tracking-[0.3em] text-slate-400">Budget range</label>
+            <select
+              name="budgetRange"
+              required
+              className="w-full rounded-full border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-slate-400 focus:outline-none"
+            >
+              {budgetRanges.map((range) => (
+                <option key={range} value={range}>
+                  {range}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="space-y-2">
+            <label className="text-xs uppercase tracking-[0.3em] text-slate-400">Deadline</label>
+            <input
+              type="date"
+              name="deadline"
+              required
+              className="w-full rounded-full border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-slate-400 focus:outline-none"
+            />
+          </div>
+        </div>
+        <div className="space-y-2">
+          <label className="text-xs uppercase tracking-[0.3em] text-slate-400">Anything else we should know?</label>
+          <textarea
+            name="message"
+            rows={4}
+            placeholder="Deployment context, evaluation criteria, or tooling preferences."
+            className="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-slate-400 focus:outline-none"
+          />
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="space-y-2">
+            <label className="text-xs uppercase tracking-[0.3em] text-slate-400">Your name</label>
+            <input
+              required
+              name="name"
+              placeholder="Full name"
+              className="w-full rounded-full border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-slate-400 focus:outline-none"
+            />
+          </div>
+          <div className="space-y-2">
+            <label className="text-xs uppercase tracking-[0.3em] text-slate-400">Email</label>
+            <input
+              required
+              type="email"
+              name="email"
+              placeholder="you@company.com"
+              className="w-full rounded-full border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-slate-400 focus:outline-none"
+            />
+          </div>
+        </div>
+      </section>
+
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <button
           type="submit"
-          className="mt-2 inline-flex items-center justify-center rounded-full bg-slate-900 px-6 py-3 text-sm font-semibold text-white transition hover:bg-slate-700 disabled:opacity-60"
+          className="inline-flex items-center justify-center rounded-full bg-slate-900 px-6 py-3 text-sm font-semibold text-white transition hover:bg-slate-700 disabled:opacity-60"
           disabled={status === "loading"}
         >
-          {status === "loading" ? "Sending…" : "Request this scene"}
+          {status === "loading" ? "Sending…" : "Submit request"}
         </button>
         {message ? (
           <p

--- a/client/src/pages/Contact.tsx
+++ b/client/src/pages/Contact.tsx
@@ -4,16 +4,14 @@ export default function Contact() {
   return (
     <div className="mx-auto max-w-6xl space-y-10 px-4 pb-24 pt-16 sm:px-6">
       <header className="space-y-4">
-        <p className="text-xs uppercase tracking-[0.3em] text-slate-400">
-          Request a scene
-        </p>
+        <p className="text-xs uppercase tracking-[0.3em] text-slate-400">Contact Blueprint</p>
         <h1 className="text-4xl font-semibold text-slate-900">
-          Tell us what your robot needs to practice.
+          Start with the dataset your lab actually needs.
         </h1>
         <p className="max-w-3xl text-sm text-slate-600">
-          Share your target policies, categories, and delivery timeline. We support both exclusive dataset programs and
-          non-exclusive catalog scenes—each rooted in real-world kitchens, warehouses, utility corridors, bedrooms, and more—
-          and we’ll follow up within one business day with scope, pricing, and draft coverage.
+          Most robotics teams ask for coverage across kitchens, warehouses, labs, and guest spaces—not just a single demo
+          room. Choose the path that fits your request and we’ll follow up within one business day with scope, pricing, and
+          delivery expectations.
         </p>
       </header>
       <ContactForm />

--- a/server/routes/contact.ts
+++ b/server/routes/contact.ts
@@ -10,13 +10,25 @@ export default async function contactHandler(req: Request, res: Response) {
     name,
     email,
     company,
-    projectType,
-    engagementScope,
+    requestType,
+    datasetTier,
+    datasetNotes,
+    sceneCategory,
+    sceneInteractions,
+    sceneQuantity,
+    sceneDeliveryDate,
+    isaacVersion,
+    useCases,
+    robotPlatform,
+    requiredSemantics,
+    exclusivityNeeds,
+    budgetRange,
+    deadline,
+    message,
     targetPolicies,
     desiredCategories,
-    deadline,
-    budget,
-    message,
+    projectType,
+    engagementScope,
     deliveryFormat,
     integrationContext,
     interactables,
@@ -27,29 +39,126 @@ export default async function contactHandler(req: Request, res: Response) {
     return res.status(400).json({ error: "Missing required fields" });
   }
 
+  const useCaseList = Array.isArray(useCases)
+    ? useCases
+    : useCases
+    ? [useCases]
+    : [];
+  const interactionList = Array.isArray(sceneInteractions)
+    ? sceneInteractions
+    : sceneInteractions
+    ? [sceneInteractions]
+    : [];
   const policies = Array.isArray(targetPolicies)
-    ? targetPolicies.join(", ")
-    : targetPolicies ?? "";
+    ? targetPolicies
+    : targetPolicies
+    ? [targetPolicies]
+    : [];
   const categories = Array.isArray(desiredCategories)
-    ? desiredCategories.join(", ")
-    : desiredCategories ?? "";
+    ? desiredCategories
+    : desiredCategories
+    ? [desiredCategories]
+    : [];
+
+  const summaryLines = [
+    `Name: ${name}`,
+    `Email: ${email}`,
+    `Company: ${company}`,
+  ];
+
+  if (requestType) {
+    summaryLines.push(
+      `Request type: ${requestType === "scene" ? "Specific scene" : "Dataset program"}`,
+    );
+  }
+
+  if (requestType === "dataset") {
+    summaryLines.push(`Dataset tier: ${datasetTier ?? ""}`);
+    if (datasetNotes) {
+      summaryLines.push(`Dataset notes: ${datasetNotes}`);
+    }
+  }
+
+  if (requestType === "scene") {
+    summaryLines.push(`Scene category: ${sceneCategory ?? ""}`);
+    if (interactionList.length > 0) {
+      summaryLines.push(`Interactions: ${interactionList.join(", ")}`);
+    }
+    if (sceneQuantity) {
+      summaryLines.push(`Quantity: ${sceneQuantity}`);
+    }
+    if (sceneDeliveryDate) {
+      summaryLines.push(`Delivery date: ${sceneDeliveryDate}`);
+    }
+    if (isaacVersion) {
+      summaryLines.push(`Isaac version: ${isaacVersion}`);
+    }
+  }
+
+  if (useCaseList.length > 0) {
+    summaryLines.push(`Use case: ${useCaseList.join(", ")}`);
+  }
+
+  if (robotPlatform) {
+    summaryLines.push(`Robot platform: ${robotPlatform}`);
+  }
+
+  if (requiredSemantics) {
+    summaryLines.push(`Required semantics: ${requiredSemantics}`);
+  }
+
+  if (exclusivityNeeds) {
+    summaryLines.push(`Exclusivity needs: ${exclusivityNeeds}`);
+  }
+
+  if (categories.length > 0) {
+    summaryLines.push(`Desired categories: ${categories.join(", ")}`);
+  }
+
+  if (policies.length > 0) {
+    summaryLines.push(`Target policies: ${policies.join(", ")}`);
+  }
+
+  if (projectType) {
+    summaryLines.push(`Project type: ${projectType}`);
+  }
+
+  if (engagementScope) {
+    summaryLines.push(`Engagement scope: ${engagementScope}`);
+  }
+
+  if (integrationContext) {
+    summaryLines.push(`Integration context: ${integrationContext}`);
+  }
+
+  if (interactables) {
+    summaryLines.push(`Interactables: ${interactables}`);
+  }
+
+  const budgetValue = budgetRange ?? req.body?.budget ?? "";
+  if (budgetValue) {
+    summaryLines.push(`Budget: ${budgetValue}`);
+  }
+
+  if (deadline) {
+    summaryLines.push(`Deadline: ${deadline}`);
+  }
+
+  if (deliveryFormat) {
+    summaryLines.push(`Delivery format: ${deliveryFormat}`);
+  }
+
+  if (emailOptIn) {
+    summaryLines.push(`Email opt-in: ${emailOptIn}`);
+  }
+
+  if (message) {
+    summaryLines.push(`Message: ${message}`);
+  }
 
   const to = process.env.CONTACT_TO ?? "ops@tryblueprint.io";
-  const subject = `Scene request from ${company}`;
-  const summary = `Name: ${name}
-Email: ${email}
-Company: ${company}
-Project type: ${projectType ?? ""}
-Engagement scope: ${engagementScope ?? ""}
-Target policies: ${policies}
-Desired categories: ${categories}
-Deadline: ${deadline ?? ""}
-Budget: ${budget ?? ""}
-Delivery format: ${deliveryFormat ?? ""}
-Integration context: ${integrationContext ?? ""}
-Interactables: ${interactables ?? ""}
-Email opt-in: ${emailOptIn ?? ""}
-Message: ${message ?? ""}`;
+  const subject = `Blueprint request from ${company}`;
+  const summary = summaryLines.join("\n");
 
   const { sent } = await sendEmail({ to, subject, text: summary });
 


### PR DESCRIPTION
## Summary
- refresh the /contact hero copy to emphasize dataset-first positioning
- rebuild the contact form with dataset vs. single-scene request paths and the required intake fields
- update the contact API summary email to include the new dataset/scene metadata

## Testing
- npm run check

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911573849c4832989d2212156ab75cb)