### PR TITLE
Add policy detail panel and laundry folding coverage

### DIFF
--- a/client/src/components/site/PolicyCard.tsx
+++ b/client/src/components/site/PolicyCard.tsx
@@ -1,12 +1,22 @@
+import { InformationCircleIcon } from "@heroicons/react/24/outline";
+
 import type { EnvironmentPolicy } from "@/data/content";
 
 interface PolicyCardProps {
   policy: EnvironmentPolicy;
+  onSelect?: (policy: EnvironmentPolicy) => void;
+  isActive?: boolean;
 }
 
-export function PolicyCard({ policy }: PolicyCardProps) {
+export function PolicyCard({ policy, onSelect, isActive = false }: PolicyCardProps) {
   return (
-    <article className="flex h-full flex-col gap-4 rounded-2xl border border-slate-200 bg-white/80 p-6 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md">
+    <article
+      className={`flex h-full flex-col gap-4 rounded-2xl border bg-white/80 p-6 shadow-sm transition ${
+        isActive
+          ? "border-emerald-500 shadow-emerald-100 ring-1 ring-emerald-200"
+          : "border-slate-200 hover:-translate-y-0.5 hover:shadow-md"
+      }`}
+    >
       <header className="flex items-center justify-between gap-3">
         <span className="text-[11px] uppercase tracking-[0.3em] text-slate-400">
           Policy
@@ -30,13 +40,21 @@ export function PolicyCard({ policy }: PolicyCardProps) {
         ))}
       </ul>
 
-      <footer className="mt-auto flex flex-wrap items-center justify-between gap-3 text-xs uppercase tracking-[0.2em] text-slate-400">
-        <span>{policy.cadence}</span>
+      <footer className="mt-auto space-y-3">
         {policy.metric ? (
-          <span className="text-sm font-medium normal-case tracking-normal text-slate-900">
-            {policy.metric}
-          </span>
+          <div className="text-sm font-medium text-slate-900">{policy.metric}</div>
         ) : null}
+        <div className="flex flex-wrap items-center justify-between gap-3 text-xs uppercase tracking-[0.2em] text-slate-400">
+          <span>{policy.cadence}</span>
+          <button
+            type="button"
+            onClick={() => onSelect?.(policy)}
+            className="flex items-center gap-1 rounded-full bg-emerald-50 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-emerald-700 transition hover:bg-emerald-100 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2"
+          >
+            <InformationCircleIcon className="h-4 w-4" aria-hidden="true" />
+            <span>Read more</span>
+          </button>
+        </div>
       </footer>
     </article>
   );

--- a/client/src/components/site/PolicyDetailPanel.tsx
+++ b/client/src/components/site/PolicyDetailPanel.tsx
@@ -1,0 +1,73 @@
+import { InformationCircleIcon, XMarkIcon } from "@heroicons/react/24/outline";
+
+import type { EnvironmentPolicy } from "@/data/content";
+
+interface PolicyDetailPanelProps {
+  policy: EnvironmentPolicy | null;
+  onClear: () => void;
+}
+
+export function PolicyDetailPanel({ policy, onClear }: PolicyDetailPanelProps) {
+  return (
+    <aside className="order-first lg:order-last lg:sticky lg:top-24">
+      <div className="space-y-4 rounded-3xl border border-slate-200 bg-white/80 p-6 shadow-sm backdrop-blur">
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex items-center gap-2">
+            <InformationCircleIcon className="h-5 w-5 text-emerald-600" aria-hidden="true" />
+            <span className="text-xs uppercase tracking-[0.3em] text-slate-400">Policy details</span>
+          </div>
+          {policy ? (
+            <button
+              type="button"
+              onClick={onClear}
+              className="rounded-full p-1 text-slate-400 transition hover:bg-slate-100 hover:text-slate-600 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2"
+              aria-label="Close policy details"
+            >
+              <XMarkIcon className="h-4 w-4" aria-hidden="true" />
+            </button>
+          ) : null}
+        </div>
+
+        {policy ? (
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <span className="inline-flex items-center rounded-full bg-slate-900 px-3 py-1 text-[11px] font-medium uppercase tracking-[0.2em] text-white">
+                {policy.focus}
+              </span>
+              <h2 className="text-xl font-semibold text-slate-900">{policy.title}</h2>
+              <p className="text-sm text-slate-600">{policy.summary}</p>
+            </div>
+
+            <div className="space-y-3">
+              <h3 className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">What it covers</h3>
+              <ul className="space-y-2 text-sm text-slate-600">
+                {policy.coverage.map((item) => (
+                  <li key={item} className="flex items-start gap-2">
+                    <span className="mt-1 h-1.5 w-1.5 flex-none rounded-full bg-emerald-500" />
+                    <span>{item}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            <div className="flex flex-wrap items-center justify-between gap-2 text-xs uppercase tracking-[0.2em] text-slate-500">
+              <span>{policy.cadence}</span>
+              {policy.metric ? (
+                <span className="text-sm font-medium normal-case tracking-normal text-slate-900">
+                  {policy.metric}
+                </span>
+              ) : null}
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-3 text-sm text-slate-600">
+            <p className="font-medium text-slate-900">Select a policy to learn more.</p>
+            <p>
+              Tap the <span className="inline-flex items-center gap-1 rounded-full bg-emerald-50 px-2 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-emerald-700"><InformationCircleIcon className="h-4 w-4" aria-hidden="true" /> Read more</span> button on any policy card to bring the full coverage details into this panel.
+            </p>
+          </div>
+        )}
+      </div>
+    </aside>
+  );
+}

--- a/client/src/data/content.ts
+++ b/client/src/data/content.ts
@@ -225,6 +225,21 @@ export const environmentPolicies: EnvironmentPolicy[] = [
     metric: "<0.5 mm positional drift across 10k simulated insertions",
     environments: ["labs", "utility-rooms"],
   },
+  {
+    slug: "laundry-folding-assist",
+    title: "Laundry Sorting & Folding Assist",
+    focus: "Home Services",
+    cadence: "Biweekly sim QA",
+    summary:
+      "Bedroom and laundry alcove routines tuned for hamper pickup, garment classification, and fold placement autonomy.",
+    coverage: [
+      "Washer, dryer, and hamper retrieval loops with Isaac Manipulator cloth proxies",
+      "Garment spread, fold, and stack sequences referencing FoldingBench and ALOHA laundry baselines",
+      "Closet handoff routines with hanger alignment and dresser drawer organization checks",
+    ],
+    metric: "Maintains 88% fold quality on FoldingBench long-horizon tasks",
+    environments: ["home-laundry"],
+  },
 ];
 
 export const scenes: Scene[] = [

--- a/client/src/pages/Environments.tsx
+++ b/client/src/pages/Environments.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useMemo, useState } from "react";
 import { PolicyCard } from "@/components/site/PolicyCard";
+import { PolicyDetailPanel } from "@/components/site/PolicyDetailPanel";
 import {
   environmentCategories,
   environmentPolicies,
 } from "@/data/content";
+import type { EnvironmentPolicy } from "@/data/content";
 
 const badgeFilters = ["Indoor", "Industrial", "Retail", "Home"];
 
@@ -24,6 +26,7 @@ export default function Environments() {
   const [badgeFilter, setBadgeFilter] = useState<string | null>(null);
   const [policyFilter, setPolicyFilter] = useState<string | null>(null);
   const [sortOption, setSortOption] = useState<string>("most-requested");
+  const [selectedPolicy, setSelectedPolicy] = useState<EnvironmentPolicy | null>(null);
 
   useEffect(() => {
     if (typeof window !== "undefined") {
@@ -35,9 +38,24 @@ export default function Environments() {
       const policy = params.get("policy");
       if (policy) {
         setPolicyFilter(policy);
+        const match = environmentPolicies.find((entry) => entry.slug === policy);
+        if (match) {
+          setSelectedPolicy(match);
+        }
       }
     }
   }, []);
+
+  useEffect(() => {
+    if (!policyFilter) {
+      return;
+    }
+
+    const match = environmentPolicies.find((policy) => policy.slug === policyFilter);
+    if (match && match.slug !== selectedPolicy?.slug) {
+      setSelectedPolicy(match);
+    }
+  }, [policyFilter, selectedPolicy?.slug]);
 
   const filteredCategories = useMemo(() => {
     let result = environmentCategories.slice();
@@ -102,210 +120,225 @@ export default function Environments() {
   );
 
   return (
-    <div className="mx-auto max-w-6xl space-y-12 px-4 pb-24 pt-16 sm:px-6">
-      <header className="space-y-6">
-        <p className="text-xs uppercase tracking-[0.3em] text-slate-400">
-          Environment catalog
-        </p>
-        <h1 className="text-4xl font-semibold text-slate-900">
-          Browse ready-to-train scenes.
-        </h1>
-        <p className="max-w-2xl text-sm text-slate-600">
-          Every environment below includes articulated joints, physics-clean colliders, and simulation validation notes. Each
-          synthetic build is patterned after a documented real-world location so dataset diversity tracks what your fleets see
-          in production. Filter by environment type, policy coverage, interaction focus, or deployment cadence.
-        </p>
-        {activePolicy ? (
-          <div className="flex items-center gap-3 rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-slate-700">
-            <span className="text-xs uppercase tracking-[0.3em] text-emerald-600">
-              Policy focus
-            </span>
-            <span className="font-medium text-slate-900">{activePolicy.title}</span>
-            <span className="hidden text-slate-500 sm:inline">{activePolicy.summary}</span>
-          </div>
-        ) : null}
-      </header>
+    <div className="mx-auto max-w-6xl px-4 pb-24 pt-16 sm:px-6">
+      <div className="grid gap-12 lg:grid-cols-[minmax(0,1fr)_320px]">
+        <div className="order-1 space-y-12 lg:order-none">
+          <header className="space-y-6">
+            <p className="text-xs uppercase tracking-[0.3em] text-slate-400">
+              Environment catalog
+            </p>
+            <h1 className="text-4xl font-semibold text-slate-900">
+              Browse ready-to-train scenes.
+            </h1>
+            <p className="max-w-2xl text-sm text-slate-600">
+              Every environment below includes articulated joints, physics-clean colliders, and simulation validation notes. Each
+              synthetic build is patterned after a documented real-world location so dataset diversity tracks what your fleets see
+              in production. Filter by environment type, policy coverage, interaction focus, or deployment cadence.
+            </p>
+            {activePolicy ? (
+              <div className="flex items-center gap-3 rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-slate-700">
+                <span className="text-xs uppercase tracking-[0.3em] text-emerald-600">
+                  Policy focus
+                </span>
+                <span className="font-medium text-slate-900">{activePolicy.title}</span>
+                <span className="hidden text-slate-500 sm:inline">{activePolicy.summary}</span>
+              </div>
+            ) : null}
+          </header>
 
-      <div className="flex flex-wrap items-center gap-3">
-        <button
-          type="button"
-          className={`rounded-full border px-4 py-2 text-sm transition ${
-            badgeFilter === null && !categoryFilter
-              ? "border-slate-900 bg-slate-900 text-white"
-              : "border-slate-200 text-slate-600 hover:border-slate-300"
-          }`}
-          onClick={() => {
-            setBadgeFilter(null);
-            setCategoryFilter(null);
-            setPolicyFilter(null);
-          }}
-        >
-          All environments
-        </button>
-        {environmentCategories.map((category) => (
-          <button
-            key={category.slug}
-            type="button"
-            className={`rounded-full border px-4 py-2 text-sm transition ${
-              categoryFilter === category.slug
-                ? "border-slate-900 bg-slate-900 text-white"
-                : "border-slate-200 text-slate-600 hover:border-slate-300"
-            }`}
-            onClick={() => setCategoryFilter(category.slug)}
-          >
-            {category.title}
-          </button>
-        ))}
-      </div>
-
-      <div className="flex flex-wrap items-center gap-3">
-        {badgeFilters.map((filter) => (
-          <button
-            key={filter}
-            type="button"
-            className={`rounded-full border px-4 py-2 text-xs uppercase tracking-[0.2em] transition ${
-              badgeFilter === filter
-                ? "border-emerald-500 bg-emerald-500 text-black"
-                : "border-slate-200 text-slate-500 hover:border-slate-300"
-            }`}
-            onClick={() =>
-              setBadgeFilter((prev) => (prev === filter ? null : filter))
-            }
-          >
-            {filter}
-          </button>
-        ))}
-      </div>
-
-      <div className="flex flex-wrap items-center gap-3">
-        <button
-          type="button"
-          className={`rounded-full border px-4 py-2 text-sm transition ${
-            policyFilter === null
-              ? "border-emerald-500 bg-emerald-500 text-black"
-              : "border-slate-200 text-slate-600 hover:border-slate-300"
-          }`}
-          onClick={() => setPolicyFilter(null)}
-        >
-          All policies
-        </button>
-        {policyFilters.map((policy) => (
-          <button
-            key={policy.value}
-            type="button"
-            className={`rounded-full border px-4 py-2 text-sm transition ${
-              policyFilter === policy.value
-                ? "border-emerald-500 bg-emerald-500 text-black"
-                : "border-slate-200 text-slate-600 hover:border-slate-300"
-            }`}
-            onClick={() =>
-              setPolicyFilter((prev) =>
-                prev === policy.value ? null : policy.value,
-              )
-            }
-          >
-            {policy.label}
-          </button>
-        ))}
-      </div>
-
-      <div className="flex flex-wrap items-center gap-3 text-sm text-slate-500">
-        <span>Sort by</span>
-        {sortOptions.map((option) => (
-          <button
-            key={option.value}
-            type="button"
-            className={`rounded-full border px-4 py-2 transition ${
-              sortOption === option.value
-                ? "border-slate-900 bg-slate-900 text-white"
-                : "border-slate-200 text-slate-600 hover:border-slate-300"
-            }`}
-            onClick={() => setSortOption(option.value)}
-          >
-            {option.label}
-          </button>
-        ))}
-      </div>
-
-      <div className="space-y-10">
-        {filteredCategories.map((category) => {
-          const categoryPolicies = environmentPolicies.filter(
-            (policy) =>
-              policy.environments.includes(category.slug) &&
-              (!policyFilter || policy.slug === policyFilter),
-          );
-
-          return (
-            <section
-              key={category.slug}
-              className="overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-sm"
+          <div className="flex flex-wrap items-center gap-3">
+            <button
+              type="button"
+              className={`rounded-full border px-4 py-2 text-sm transition ${
+                badgeFilter === null && !categoryFilter
+                  ? "border-slate-900 bg-slate-900 text-white"
+                  : "border-slate-200 text-slate-600 hover:border-slate-300"
+              }`}
+              onClick={() => {
+                setBadgeFilter(null);
+                setCategoryFilter(null);
+                setPolicyFilter(null);
+              }}
             >
-              <div className="flex flex-col gap-6 md:flex-row">
-                <div className="flex-1 space-y-4 p-6 md:p-8">
-                  <span className="text-xs uppercase tracking-[0.3em] text-slate-400">
-                    Environment type
-                  </span>
-                  <div>
-                    <h2 className="text-2xl font-semibold text-slate-900">
-                      {category.title}
-                    </h2>
-                    <p className="mt-3 text-sm text-slate-600">
-                      {category.summary}
-                    </p>
-                  </div>
-                  <div className="flex flex-wrap gap-2">
-                    {category.tags.map((tag) => (
-                      <span
-                        key={tag}
-                        className="rounded-full bg-slate-100 px-3 py-1 text-xs uppercase tracking-[0.2em] text-slate-500"
-                      >
-                        {tag}
-                      </span>
-                    ))}
-                  </div>
-                </div>
-                <div className="relative h-56 w-full flex-1 overflow-hidden md:h-auto">
-                  <img
-                    src={category.heroImage}
-                    alt={category.title}
-                    className="h-full w-full object-cover"
-                    loading="lazy"
-                  />
-                </div>
-              </div>
-              <div className="border-t border-slate-200 bg-slate-50/70 p-6 md:p-8">
-                <div className="flex items-center justify-between gap-4">
-                  <h3 className="text-sm font-semibold uppercase tracking-[0.3em] text-slate-500">
-                    Policy coverage
-                  </h3>
-                  <span className="text-sm text-slate-500">
-                    {categoryPolicies.length} {categoryPolicies.length === 1 ? "policy" : "policies"}
-                  </span>
-                </div>
-                {categoryPolicies.length > 0 ? (
-                  <div className="mt-6 grid gap-6 md:grid-cols-2">
-                    {categoryPolicies.map((policy) => (
-                      <PolicyCard key={policy.slug} policy={policy} />
-                    ))}
-                  </div>
-                ) : (
-                  <p className="mt-6 text-sm text-slate-500">
-                    {policyFilter
-                      ? "This environment does not include the selected policy yet."
-                      : "Policy cards for this environment are coming soon."}
-                  </p>
-                )}
-              </div>
-            </section>
-          );
-        })}
-      </div>
+              All environments
+            </button>
+            {environmentCategories.map((category) => (
+              <button
+                key={category.slug}
+                type="button"
+                className={`rounded-full border px-4 py-2 text-sm transition ${
+                  categoryFilter === category.slug
+                    ? "border-slate-900 bg-slate-900 text-white"
+                    : "border-slate-200 text-slate-600 hover:border-slate-300"
+                }`}
+                onClick={() => setCategoryFilter(category.slug)}
+              >
+                {category.title}
+              </button>
+            ))}
+          </div>
 
-      {filteredCategories.length === 0 ? (
-        <p className="text-sm text-slate-500">
-          No environments found. Adjust your filters to explore more policy coverage.
-        </p>
-      ) : null}
+          <div className="flex flex-wrap items-center gap-3">
+            {badgeFilters.map((filter) => (
+              <button
+                key={filter}
+                type="button"
+                className={`rounded-full border px-4 py-2 text-xs uppercase tracking-[0.2em] transition ${
+                  badgeFilter === filter
+                    ? "border-emerald-500 bg-emerald-500 text-black"
+                    : "border-slate-200 text-slate-500 hover:border-slate-300"
+                }`}
+                onClick={() =>
+                  setBadgeFilter((prev) => (prev === filter ? null : filter))
+                }
+              >
+                {filter}
+              </button>
+            ))}
+          </div>
+
+          <div className="flex flex-wrap items-center gap-3">
+            <button
+              type="button"
+              className={`rounded-full border px-4 py-2 text-sm transition ${
+                policyFilter === null
+                  ? "border-emerald-500 bg-emerald-500 text-black"
+                  : "border-slate-200 text-slate-600 hover:border-slate-300"
+              }`}
+              onClick={() => setPolicyFilter(null)}
+            >
+              All policies
+            </button>
+            {policyFilters.map((policy) => (
+              <button
+                key={policy.value}
+                type="button"
+                className={`rounded-full border px-4 py-2 text-sm transition ${
+                  policyFilter === policy.value
+                    ? "border-emerald-500 bg-emerald-500 text-black"
+                    : "border-slate-200 text-slate-600 hover:border-slate-300"
+                }`}
+                onClick={() =>
+                  setPolicyFilter((prev) =>
+                    prev === policy.value ? null : policy.value,
+                  )
+                }
+              >
+                {policy.label}
+              </button>
+            ))}
+          </div>
+
+          <div className="flex flex-wrap items-center gap-3 text-sm text-slate-500">
+            <span>Sort by</span>
+            {sortOptions.map((option) => (
+              <button
+                key={option.value}
+                type="button"
+                className={`rounded-full border px-4 py-2 transition ${
+                  sortOption === option.value
+                    ? "border-slate-900 bg-slate-900 text-white"
+                    : "border-slate-200 text-slate-600 hover:border-slate-300"
+                }`}
+                onClick={() => setSortOption(option.value)}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+
+          <div className="space-y-10">
+            {filteredCategories.map((category) => {
+              const categoryPolicies = environmentPolicies.filter(
+                (policy) =>
+                  policy.environments.includes(category.slug) &&
+                  (!policyFilter || policy.slug === policyFilter),
+              );
+
+              return (
+                <section
+                  key={category.slug}
+                  className="overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-sm"
+                >
+                  <div className="flex flex-col gap-6 md:flex-row">
+                    <div className="flex-1 space-y-4 p-6 md:p-8">
+                      <span className="text-xs uppercase tracking-[0.3em] text-slate-400">
+                        Environment type
+                      </span>
+                      <div>
+                        <h2 className="text-2xl font-semibold text-slate-900">
+                          {category.title}
+                        </h2>
+                        <p className="mt-3 text-sm text-slate-600">
+                          {category.summary}
+                        </p>
+                      </div>
+                      <div className="flex flex-wrap gap-2">
+                        {category.tags.map((tag) => (
+                          <span
+                            key={tag}
+                            className="rounded-full bg-slate-100 px-3 py-1 text-xs uppercase tracking-[0.2em] text-slate-500"
+                          >
+                            {tag}
+                          </span>
+                        ))}
+                      </div>
+                    </div>
+                    <div className="relative h-56 w-full flex-1 overflow-hidden md:h-auto">
+                      <img
+                        src={category.heroImage}
+                        alt={category.title}
+                        className="h-full w-full object-cover"
+                        loading="lazy"
+                      />
+                    </div>
+                  </div>
+                  <div className="border-t border-slate-200 bg-slate-50/70 p-6 md:p-8">
+                    <div className="flex items-center justify-between gap-4">
+                      <h3 className="text-sm font-semibold uppercase tracking-[0.3em] text-slate-500">
+                        Policy coverage
+                      </h3>
+                      <span className="text-sm text-slate-500">
+                        {categoryPolicies.length} {categoryPolicies.length === 1 ? "policy" : "policies"}
+                      </span>
+                    </div>
+                    {categoryPolicies.length > 0 ? (
+                      <div className="mt-6 grid gap-6 md:grid-cols-2">
+                        {categoryPolicies.map((policy) => (
+                          <PolicyCard
+                            key={policy.slug}
+                            policy={policy}
+                            onSelect={(nextPolicy) => setSelectedPolicy(nextPolicy)}
+                            isActive={selectedPolicy?.slug === policy.slug}
+                          />
+                        ))}
+                      </div>
+                    ) : (
+                      <p className="mt-6 text-sm text-slate-500">
+                        {policyFilter
+                          ? "This environment does not include the selected policy yet."
+                          : "Policy cards for this environment are coming soon."}
+                      </p>
+                    )}
+                  </div>
+                </section>
+              );
+            })}
+          </div>
+
+          {filteredCategories.length === 0 ? (
+            <p className="text-sm text-slate-500">
+              No environments found. Adjust your filters to explore more policy coverage.
+            </p>
+          ) : null}
+        </div>
+        <div className="order-2 lg:order-none">
+          <PolicyDetailPanel
+            policy={selectedPolicy}
+            onClear={() => setSelectedPolicy(null)}
+          />
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add a sticky policy detail panel to the environments catalog and wire it to policy selection state
- update policy cards with a read more action and highlight styling when focused
- expand the content data with a laundry sorting and folding policy for the home laundry environment

## Testing
- npm run check

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912176d87f08329b32378ff6d263e0d)