### PR TITLE
Add resume upload workflow to career applications

### DIFF
--- a/client/src/components/site/ApplyForm.tsx
+++ b/client/src/components/site/ApplyForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useId, useState } from "react";
 
 interface ApplyFormProps {
   role: string;
@@ -10,11 +10,19 @@ export function ApplyForm({ role, email }: ApplyFormProps) {
     "idle",
   );
   const [message, setMessage] = useState("");
+  const uniqueId = useId();
+  const nameId = `${uniqueId}-name`;
+  const applicantEmailId = `${uniqueId}-email`;
+  const portfolioId = `${uniqueId}-portfolio`;
+  const resumeId = `${uniqueId}-resume`;
+  const notesId = `${uniqueId}-notes`;
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    const data = new FormData(event.currentTarget);
-    const payload = Object.fromEntries(data.entries());
+    const form = event.currentTarget;
+    const data = new FormData(form);
+    data.set("role", role);
+    data.set("email", email);
 
     setStatus("loading");
     setMessage("");
@@ -22,8 +30,7 @@ export function ApplyForm({ role, email }: ApplyFormProps) {
     try {
       const res = await fetch("/api/apply", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ ...payload, role, email }),
+        body: data,
       });
 
       if (!res.ok) {
@@ -31,8 +38,8 @@ export function ApplyForm({ role, email }: ApplyFormProps) {
       }
 
       setStatus("success");
-      setMessage("Application received. We’ll reach out if it’s a fit.");
-      event.currentTarget.reset();
+      setMessage("");
+      form.reset();
     } catch (error) {
       console.error(error);
       setStatus("error");
@@ -40,35 +47,117 @@ export function ApplyForm({ role, email }: ApplyFormProps) {
     }
   };
 
+  if (status === "success") {
+    return (
+      <div className="mt-6 space-y-4 rounded-3xl border border-slate-200 bg-slate-50 p-6 text-center">
+        <div className="space-y-3">
+          <span className="text-xs uppercase tracking-[0.3em] text-slate-500">
+            Thanks for applying
+          </span>
+          <h3 className="text-xl font-semibold text-slate-900">
+            We’ll review your materials
+          </h3>
+          <p className="text-sm text-slate-600">
+            Our team will look over your application for the {role} role and
+            reach out at the email you provided if it’s a fit.
+          </p>
+        </div>
+        <div className="flex justify-center">
+          <button
+            type="button"
+            onClick={() => {
+              setStatus("idle");
+              setMessage("");
+            }}
+            className="inline-flex items-center justify-center rounded-full border border-slate-300 px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-400"
+          >
+            Submit another application
+          </button>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <form onSubmit={handleSubmit} className="mt-4 grid gap-3">
-      <div className="grid gap-2 sm:grid-cols-2">
-        <input
+      <div className="grid gap-3 sm:grid-cols-2">
+        <label className="flex flex-col gap-2 text-sm text-slate-600" htmlFor={nameId}>
+          <span className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">
+            Name
+          </span>
+          <input
           required
           name="name"
+            id={nameId}
           placeholder="Your name"
           className="rounded-full border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-slate-400 focus:outline-none"
-        />
-        <input
+          />
+        </label>
+        <label
+          className="flex flex-col gap-2 text-sm text-slate-600"
+          htmlFor={applicantEmailId}
+        >
+          <span className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">
+            Email address
+          </span>
+          <input
           required
           type="email"
           name="contactEmail"
+            id={applicantEmailId}
           placeholder="you@studio.com"
           className="rounded-full border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-slate-400 focus:outline-none"
+          aria-describedby={`${applicantEmailId}-hint`}
         />
+          <span id={`${applicantEmailId}-hint`} className="text-xs text-slate-500">
+            We’ll send updates to this address.
+          </span>
+        </label>
       </div>
-      <input
-        required
-        name="portfolio"
-        placeholder="Portfolio or reel"
-        className="rounded-full border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-slate-400 focus:outline-none"
-      />
-      <textarea
-        name="notes"
-        rows={3}
-        placeholder="Relevant simulation or environment build experience"
-        className="rounded-3xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-slate-400 focus:outline-none"
-      />
+      <label className="flex flex-col gap-2 text-sm text-slate-600" htmlFor={portfolioId}>
+        <span className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">
+          Portfolio URL
+        </span>
+        <input
+          required
+          type="url"
+          name="portfolio"
+          id={portfolioId}
+          placeholder="https://yourstudio.com/portfolio"
+          className="rounded-full border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-slate-400 focus:outline-none"
+          aria-describedby={`${portfolioId}-hint`}
+        />
+        <span id={`${portfolioId}-hint`} className="text-xs text-slate-500">
+          Share your best work—reels, breakdowns, or project sites.
+        </span>
+      </label>
+      <label className="flex flex-col gap-2 text-sm text-slate-600" htmlFor={resumeId}>
+        <span className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">
+          Resume or sample (optional)
+        </span>
+        <input
+          type="file"
+          name="resume"
+          id={resumeId}
+          className="w-full rounded-full border border-dashed border-slate-300 bg-white px-4 py-3 text-sm file:mr-4 file:rounded-full file:border-0 file:bg-slate-900 file:px-4 file:py-2 file:text-sm file:font-semibold file:text-white focus:border-slate-400 focus:outline-none"
+          aria-describedby={`${resumeId}-hint`}
+        />
+        <span id={`${resumeId}-hint`} className="text-xs text-slate-500">
+          Upload resumes, PDFs, ZIPs, or any supporting files.
+        </span>
+      </label>
+      <label className="flex flex-col gap-2 text-sm text-slate-600" htmlFor={notesId}>
+        <span className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">
+          Relevant experience
+        </span>
+        <textarea
+          name="notes"
+          id={notesId}
+          rows={3}
+          placeholder="Share simulation, environment build, or toolchain experience"
+          className="rounded-3xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-slate-400 focus:outline-none"
+        />
+      </label>
       <button
         type="submit"
         className="inline-flex items-center justify-center rounded-full bg-slate-900 px-6 py-3 text-sm font-semibold text-white transition hover:bg-slate-700 disabled:opacity-60"

--- a/client/src/data/content.ts
+++ b/client/src/data/content.ts
@@ -1120,7 +1120,7 @@ export const jobs: Job[] = [
     location: "Remote",
     summary: "Create high-fidelity assets with watertight topology and clean UVs for SimReady delivery.",
     description:
-      "You will translate capture outputs and kitbashed assets into polished simulation-ready geometry. Expect to iterate with our robotics specialists on articulation coverage, pivots, and collider tuning.",
+      "You will translate capture outputs and kitbashed assets into polished simulation-ready geometry. Expect to iterate with our robotics specialists on articulation coverage, pivots, and collider tuning. Compensation is per scene annotated or edited and averages approximately $50 per hour.",
     applyEmail: "apply+artist@tryblueprint.io",
   },
   {

--- a/server/routes/apply.ts
+++ b/server/routes/apply.ts
@@ -1,22 +1,138 @@
 import { Request, Response } from "express";
+import multer from "multer";
+
 import { sendEmail } from "../utils/email";
 
-export default async function applyHandler(req: Request, res: Response) {
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: {
+    fileSize: 25 * 1024 * 1024,
+  },
+});
+
+type RequestWithFile = Request & { file?: Express.Multer.File };
+
+export default function applyHandler(req: Request, res: Response) {
   if (req.method !== "POST") {
     return res.status(405).json({ error: "Method not allowed" });
   }
 
-  const { name, portfolio, notes, role, email, contactEmail } = req.body ?? {};
+  upload.single("resume")(req, res, async (uploadError: unknown) => {
+    if (uploadError) {
+      const errorMessage =
+        uploadError instanceof Error ? uploadError.message : "Failed to upload file";
+      return res.status(400).json({ error: errorMessage });
+    }
 
-  if (!name || !portfolio || !role || !email || !contactEmail) {
-    return res.status(400).json({ error: "Missing required fields" });
-  }
+    try {
+      const { name, portfolio, notes, role, email, contactEmail } = req.body ?? {};
 
-  const to = typeof email === "string" && email.length ? email : "apply@tryblueprint.io";
-  const subject = `Application for ${role}: ${name}`;
-  const text = `Name: ${name}\nApplicant email: ${contactEmail}\nPortfolio: ${portfolio}\nNotes: ${notes ?? ""}`;
+      const applicantName = typeof name === "string" ? name.trim() : "";
+      const applicantPortfolio = typeof portfolio === "string" ? portfolio.trim() : "";
+      const applicantNotes = typeof notes === "string" ? notes.trim() : "";
+      const jobRole = typeof role === "string" ? role.trim() : "";
+      const jobEmail =
+        typeof email === "string" && email.trim().length > 0
+          ? email.trim()
+          : "apply@tryblueprint.io";
+      const applicantEmail = typeof contactEmail === "string" ? contactEmail.trim() : "";
 
-  const { sent } = await sendEmail({ to, subject, text });
+      if (!applicantName || !applicantPortfolio || !jobRole || !jobEmail || !applicantEmail) {
+        return res.status(400).json({ error: "Missing required fields" });
+      }
 
-  return res.status(sent ? 200 : 202).json({ success: true, sent });
+      const file = (req as RequestWithFile).file ?? null;
+      const attachmentSummary = file ? file.originalname : "No file attached";
+
+      const subject = `Application for ${jobRole}: ${applicantName}`;
+      const summaryLines = [
+        `Name: ${applicantName}`,
+        `Applicant email: ${applicantEmail}`,
+        `Portfolio: ${applicantPortfolio}`,
+        `Attachment: ${attachmentSummary}`,
+      ];
+
+      if (applicantNotes) {
+        summaryLines.push(`Notes: ${applicantNotes}`);
+      }
+
+      const { sent } = await sendEmail({
+        to: jobEmail,
+        subject,
+        text: summaryLines.join("\n"),
+        attachments: file
+          ? [
+              {
+                filename: file.originalname,
+                content: file.buffer,
+                contentType: file.mimetype,
+              },
+            ]
+          : undefined,
+      });
+
+      const firstName = applicantName.split(" ")[0] || applicantName;
+      const confirmationSubject = `Thanks for applying for the ${jobRole} role`;
+      const confirmationText = [
+        `Hi ${firstName},`,
+        "",
+        "Thanks for applying to collaborate with Blueprint.",
+        `We’ll review your materials for the ${jobRole} role and reach out if the fit is right.`,
+        "",
+        "Appreciate you taking the time to share your work.",
+        "",
+        "— The Blueprint Team",
+      ].join("\n");
+
+      const confirmationHtml = `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Thanks for applying</title>
+  </head>
+  <body style="margin:0;padding:0;background-color:#0b0b0b;font-family:Arial,Helvetica,sans-serif;color:#f8fafc;">
+    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background-color:#0b0b0b;padding:32px 0;">
+      <tr>
+        <td align="center">
+          <table role="presentation" width="600" cellspacing="0" cellpadding="0" style="max-width:600px;width:100%;background-color:#111827;border-radius:12px;padding:32px;">
+            <tr>
+              <td style="text-align:center;padding-bottom:16px;">
+                <span style="display:inline-block;font-size:14px;letter-spacing:0.3em;color:#94a3b8;text-transform:uppercase;">Blueprint</span>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding-bottom:16px;">
+                <h1 style="margin:0 0 12px;font-size:26px;color:#f8fafc;">Thanks for applying</h1>
+                <p style="margin:0 0 12px;font-size:16px;color:#cbd5f5;">Hi ${firstName},</p>
+                <p style="margin:0 0 12px;font-size:16px;color:#cbd5f5;">
+                  Thanks for applying to collaborate with Blueprint. We’ll review your materials for the ${jobRole} role and reach out if the fit is right.
+                </p>
+                <p style="margin:0 0 12px;font-size:16px;color:#cbd5f5;">Appreciate you taking the time to share your work.</p>
+                <p style="margin:0;font-size:16px;color:#cbd5f5;">— The Blueprint Team</p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>`;
+
+      const confirmationResult = await sendEmail({
+        to: applicantEmail,
+        subject: confirmationSubject,
+        text: confirmationText,
+        html: confirmationHtml,
+        replyTo: "ohstnhunt@gmail.com",
+      });
+
+      return res
+        .status(sent ? 200 : 202)
+        .json({ success: true, sent, confirmationSent: confirmationResult.sent });
+    } catch (error) {
+      console.error(error);
+      return res.status(500).json({ error: "Failed to process application" });
+    }
+  });
 }

--- a/server/utils/email.ts
+++ b/server/utils/email.ts
@@ -7,6 +7,7 @@ interface SendEmailOptions {
   text: string;
   html?: string;
   replyTo?: string;
+  attachments?: nodemailer.SendMailOptions["attachments"];
 }
 
 let cachedTransporter: nodemailer.Transporter | null = null;
@@ -39,7 +40,14 @@ function getTransporter() {
   return cachedTransporter;
 }
 
-export async function sendEmail({ to, subject, text, html, replyTo }: SendEmailOptions) {
+export async function sendEmail({
+  to,
+  subject,
+  text,
+  html,
+  replyTo,
+  attachments,
+}: SendEmailOptions) {
   const transporter = getTransporter();
 
   if (!transporter) {
@@ -55,6 +63,7 @@ export async function sendEmail({ to, subject, text, html, replyTo }: SendEmailO
       text,
       html,
       replyTo,
+      attachments,
     });
 
     logger.info({ to, subject, replyTo }, "Email dispatched");


### PR DESCRIPTION
## Summary
- add clearer labels, resume uploads, and a success state to the careers application form
- note estimated $50/hr compensation for the 3D Artist role
- process resume attachments server-side and send confirmation emails to applicants

## Testing
- npm run check

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69121dfaa5c88329a51a565d8a8e3f14)