### PR TITLE
Remove unused skip link from layout

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -36,7 +36,6 @@
     <meta name="robots" content="index, follow" />
   </head>
   <body class="font-sans">
-    <a class="skip-link" href="#main-content">Skip to content</a>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -78,19 +78,3 @@
   transform: translateY(-2px);
 }
 
-.skip-link {
-  position: absolute;
-  top: 0.75rem;
-  left: 50%;
-  transform: translate(-50%, -120%);
-  background-color: #000;
-  color: #fff;
-  padding: 0.75rem 1.25rem;
-  border-radius: 9999px;
-  z-index: 50;
-  transition: transform 0.2s ease;
-}
-
-.skip-link:focus {
-  transform: translate(-50%, 0);
-}


### PR DESCRIPTION
## Summary
- remove the skip-to-content anchor from the base HTML template
- delete the unused skip-link styling

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691236ec5e688329bddb5451db3f7dc5)