### PR TITLE
Refocus marketplace and contact experience

### DIFF
--- a/client/src/components/site/ContactForm.tsx
+++ b/client/src/components/site/ContactForm.tsx
@@ -7,17 +7,17 @@ import { getGoogleMapsApiKey } from "@/lib/client-env";
 
 const requestOptions = [
   {
-    value: "dataset" as const,
-    label: "I need a dataset",
+    value: "scene" as const,
+    label: "Scan my real-world facility",
     description:
-      "Best for labs that need coverage across layouts and tasks. We’ll anchor scope, semantics, and delivery windows together.",
+      "Best for labs heading toward deployment. We coordinate on-site capture, rebuild the space in USD, and deliver a plug-and-play package.",
     recommended: true,
   },
   {
-    value: "scene" as const,
-    label: "On-site SimReady location (waitlist)",
+    value: "dataset" as const,
+    label: "Synthetic marketplace wishlist",
     description:
-      "We’ll visit the facility you care about, scan it, and return a validated digital twin so you can prove ROI before hardware ships.",
+      "Tell us which policies, objects, or locations you need most so we can prioritize the next drop. No purchase required.",
     recommended: false,
   },
 ];
@@ -140,7 +140,7 @@ export function ContactForm() {
   >("idle");
   const [message, setMessage] = useState("");
   const [requestType, setRequestType] = useState<"dataset" | "scene">(
-    "dataset",
+    "scene",
   );
   const [datasetTier, setDatasetTier] = useState<string>(datasetTiers[0].value);
   const [selectedUseCases, setSelectedUseCases] = useState<string[]>([]);
@@ -312,7 +312,7 @@ export function ContactForm() {
       form.reset();
       setStatus("success");
       setMessage("");
-      setRequestType("dataset");
+      setRequestType("scene");
       setDatasetTier(datasetTiers[0].value);
       setSelectedUseCases([]);
       setSelectedEnvironments([]);
@@ -371,8 +371,9 @@ export function ContactForm() {
             How can we help?
           </h2>
           <p className="text-sm text-slate-600">
-            Labs usually start with datasets for coverage. You can still request
-            a single hero scene if you know exactly what you need.
+            Most labs start by scanning the real site they plan to deploy into.
+            If you’re just steering the synthetic marketplace, pick the
+            wishlist option and tell us what to drop next.
           </p>
           <p className="text-sm text-slate-500">
             Once you submit, we’ll review your request and email you with next
@@ -417,11 +418,11 @@ export function ContactForm() {
         <section className="space-y-4">
           <div className="flex flex-col gap-1">
             <span className="text-xs uppercase tracking-[0.3em] text-slate-400">
-              Dataset tiers
+              Wishlist scale
             </span>
             <p className="text-sm text-slate-600">
-              These anchors are non-binding, but they map to how teams scope
-              training corpora. Bigger bundles beat one-offs.
+              Non-binding, but helps us size how many scenes/variants to line up
+              when we drop the dataset you care about.
             </p>
           </div>
           <div className="grid gap-4 lg:grid-cols-3">
@@ -454,18 +455,37 @@ export function ContactForm() {
           </div>
           <div className="space-y-2">
             <label className="text-xs uppercase tracking-[0.3em] text-slate-400">
-              Notes
+              Wishlist notes
             </label>
             <textarea
               name="datasetNotes"
               rows={3}
-              placeholder="Anything specific about capture, semantics, or pilot milestones?"
+              placeholder="Tell us which policies, objects, semantics, or deployment milestones we should prioritize."
               className="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-slate-400 focus:outline-none"
             />
           </div>
         </section>
       ) : (
         <section className="space-y-8">
+          <div className="space-y-3 rounded-3xl border border-slate-200 bg-slate-50 p-5">
+            <h3 className="text-base font-semibold text-slate-900">
+              What the capture crew delivers
+            </h3>
+            <ul className="list-disc space-y-2 pl-5 text-sm text-slate-600">
+              <li>
+                Survey-grade lidar + photogrammetry aligned to the facility you
+                specify (labs, warehouses, kitchens, utilities, etc.).
+              </li>
+              <li>
+                SimReady USD/URDF with articulation, materials, semantics, and
+                QA against Isaac 4.x/5.x.
+              </li>
+              <li>
+                Optional randomizer scripts + annotation exports so you can run
+                site-specific experiments immediately.
+              </li>
+            </ul>
+          </div>
           {/* <div className="space-y-4">
             <div className="space-y-2">
               <span className="text-xs uppercase tracking-[0.3em] text-slate-400">
@@ -794,7 +814,7 @@ export function ContactForm() {
             </label>
             <select
               name="budgetRange"
-              required
+              required={requestType === "scene"}
               className="w-full rounded-full border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-slate-400 focus:outline-none"
             >
               {(requestType === "scene"

--- a/client/src/data/content.ts
+++ b/client/src/data/content.ts
@@ -55,6 +55,24 @@ export interface EnvironmentPolicy {
   environments: string[];
 }
 
+export interface SyntheticDataset {
+  slug: string;
+  title: string;
+  description: string;
+  heroImage: string;
+  locationType: string;
+  policySlugs: string[];
+  objectTags: string[];
+  pricePerScene: number;
+  sceneCount: number;
+  variantCount: number;
+  releaseDate: string;
+  tags: string[];
+  randomizerScripts: string[];
+  deliverables: string[];
+  isNew?: boolean;
+}
+
 export interface CaseStudy {
   title: string;
   slug: string;
@@ -239,6 +257,133 @@ export const environmentPolicies: EnvironmentPolicy[] = [
     ],
     metric: "Maintains 88% fold quality on FoldingBench long-horizon tasks",
     environments: ["home-laundry"],
+  },
+];
+
+export const syntheticDatasets: SyntheticDataset[] = [
+  {
+    slug: "prep-line-essentials",
+    title: "Prep-Line Essentials",
+    description:
+      "150-scene bundle covering prep tables, dish pits, and service pass-throughs with drawer, door, and appliance articulation baked in.",
+    heroImage:
+      "https://images.unsplash.com/photo-1504753793650-d4a2b783c15e?auto=format&fit=crop&w=1600&q=80",
+    locationType: "Kitchens",
+    policySlugs: [
+      "dexterous-pick-place",
+      "articulated-access-validation",
+      "panel-interaction-suite",
+    ],
+    objectTags: ["drawers", "dishwashers", "utensils", "appliances"],
+    pricePerScene: 65,
+    sceneCount: 150,
+    variantCount: 8,
+    releaseDate: "2024-12-12",
+    tags: ["Articulated", "Plug & Play", "USD"],
+    randomizerScripts: [
+      "Lighting drift",
+      "Stock level shuffle",
+      "Tool clutter permutations",
+    ],
+    deliverables: ["USD / Isaac 4.x", "Isaac 5.x", "Replicator semantics"],
+    isNew: true,
+  },
+  {
+    slug: "retail-restock-loop",
+    title: "Retail Restock Loop",
+    description:
+      "110 grocery and convenience aisles with planogrammed shelving, refrigeration bays, and pallet drops for mixed-SKU restock policies.",
+    heroImage:
+      "https://images.unsplash.com/photo-1586202692873-0227667ccf6b?auto=format&fit=crop&w=1600&q=80",
+    locationType: "Grocery / Retail",
+    policySlugs: ["dexterous-pick-place", "mixed-sku-logistics"],
+    objectTags: ["shelves", "pallets", "totes", "coolers"],
+    pricePerScene: 58,
+    sceneCount: 110,
+    variantCount: 6,
+    releaseDate: "2024-12-05",
+    tags: ["Retail", "High SKU", "Randomized"],
+    randomizerScripts: ["SKU swaps", "Cart clutter", "Lighting color temp"],
+    deliverables: ["USD", "Onshape", "Synthetic sensor captures"],
+  },
+  {
+    slug: "warehouse-flow-kit",
+    title: "Warehouse Flow Kit",
+    description:
+      "200-lane dataset covering cross-dock staging, tote picking, and pallet buffers tuned for AMR and arm-on-rail deployments.",
+    heroImage:
+      "https://images.unsplash.com/photo-1517502884422-41eaead166d4?auto=format&fit=crop&w=1600&q=80",
+    locationType: "Warehouses",
+    policySlugs: ["mixed-sku-logistics", "dexterous-pick-place"],
+    objectTags: ["pallets", "totes", "cartons", "racking"],
+    pricePerScene: 72,
+    sceneCount: 200,
+    variantCount: 10,
+    releaseDate: "2024-11-28",
+    tags: ["Industrial", "Heavy lift", "Conveyor-ready"],
+    randomizerScripts: [
+      "Forklift traffic",
+      "Pallet height shuffle",
+      "Spill + debris events",
+    ],
+    deliverables: ["USD", "URDF", "Isaac Mission playback"],
+  },
+  {
+    slug: "lab-procedures-pack",
+    title: "Lab Procedures Pack",
+    description:
+      "65 precision lab benches with gloveboxes, articulated enclosures, and sample handoff tooling for panel + insertion curricula.",
+    heroImage:
+      "https://images.unsplash.com/photo-1582719478250-02c3c15b6640?auto=format&fit=crop&w=1600&q=80",
+    locationType: "Labs",
+    policySlugs: [
+      "panel-interaction-suite",
+      "precision-insertion-assembly",
+    ],
+    objectTags: ["valves", "switches", "drawers", "sample racks"],
+    pricePerScene: 84,
+    sceneCount: 65,
+    variantCount: 5,
+    releaseDate: "2024-11-22",
+    tags: ["Cleanroom", "Controls", "QA"],
+    randomizerScripts: ["Gauge offsets", "Cabinet wiring", "Consumable clutter"],
+    deliverables: ["USD", "STEP", "Semantic layers"],
+  },
+  {
+    slug: "utility-panel-tour",
+    title: "Utility Panel Tour",
+    description:
+      "90 mechanical rooms and utility closets with valves, breakers, and switches for inspection and panel interaction testing.",
+    heroImage:
+      "https://images.unsplash.com/photo-1503387762-592deb58ef4e?auto=format&fit=crop&w=1600&q=80",
+    locationType: "Utility Rooms",
+    policySlugs: ["panel-interaction-suite"],
+    objectTags: ["breakers", "knobs", "switches", "valves"],
+    pricePerScene: 52,
+    sceneCount: 90,
+    variantCount: 4,
+    releaseDate: "2024-11-18",
+    tags: ["Inspection", "Low light", "Compact"],
+    randomizerScripts: ["Status LEDs", "Valve state", "Dust + grime"],
+    deliverables: ["USD", "GLTF", "Event scripts"],
+  },
+  {
+    slug: "laundry-assist-starter",
+    title: "Laundry Assist Starter",
+    description:
+      "50 assistive home laundry alcoves with washers, dryers, and hampers for folding and transfer training.",
+    heroImage:
+      "https://images.unsplash.com/photo-1581578731548-c64695cc6952?auto=format&fit=crop&w=1600&q=80",
+    locationType: "Home / Assistive",
+    policySlugs: ["laundry-folding-assist"],
+    objectTags: ["washers", "dryers", "hampers", "folding tables"],
+    pricePerScene: 50,
+    sceneCount: 50,
+    variantCount: 3,
+    releaseDate: "2024-11-12",
+    tags: ["Assistive", "Household", "Soft goods"],
+    randomizerScripts: ["Fabric types", "Lighting temp", "Clutter"],
+    deliverables: ["USD", "URDF", "Teleop demos"],
   },
 ];
 

--- a/client/src/pages/Contact.tsx
+++ b/client/src/pages/Contact.tsx
@@ -1,27 +1,22 @@
 import { ContactForm } from "@/components/site/ContactForm";
-import { environmentPolicies } from "@/data/content";
 
 export default function Contact() {
-  const corePolicies = environmentPolicies.slice(0, 5);
-
   return (
     <div className="mx-auto max-w-6xl space-y-10 px-4 pb-24 pt-16 sm:px-6">
       <header className="space-y-4">
         <p className="text-xs uppercase tracking-[0.3em] text-slate-400">
-          Build your training coverage
+          Real-world capture + marketplace wishlist
         </p>
         <h1 className="text-4xl font-semibold text-slate-900">
-          Start with the dataset your lab actually needs.
+          Scan the site you care about or steer the next drop.
         </h1>
         <p className="max-w-3xl text-sm text-slate-600">
-          Labs are tuning the same manipulation families everyone is
-          benchmarking going into 2025 and 2026—dexterous pick- place,
-          articulated access, panel interaction, mixed-SKU logistics, and
-          precision insertion. That’s why we lead with dataset programs that hit
-          those policy tracks while still making it easy to request a specific
-          kitchen, warehouse aisle, or other hero scene. Share what your robot
-          needs and we’ll align on scope, delivery, and budget within one
-          business day.
+          Most teams land here to book a real-world SimReady capture. We send a
+          crew, scan your facility, and hand back a validated USD/URDF scene so
+          you can tune policies against the layout you actually deploy. If
+          you’re primarily buying synthetic data, use the wishlist path to tell
+          us which policy, object, or location types you need most—the signal
+          helps decide the next drops.
         </p>
       </header>
       <ContactForm />

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -2,7 +2,7 @@ import { CTAButtons } from "@/components/site/CTAButtons";
 import { LogoWall } from "@/components/site/LogoWall";
 import { TileGrid } from "@/components/site/TileGrid";
 import { WaitlistForm } from "@/components/site/WaitlistForm";
-import { environmentCategories } from "@/data/content"; //yeetasdasddasdsadsadsdanjnkjsdasdasd
+import { environmentCategories, syntheticDatasets } from "@/data/content"; //yeetasdasddasdsadsadsdanjnkjsdasdasd
 
 const whySimReady = [
   {
@@ -35,7 +35,36 @@ const artistBullets = [
   "Paid per scene, bonuses for articulation coverage",
 ];
 
+const offeringCards = [
+  {
+    title: "Synthetic SimReady Scenes Marketplace",
+    description:
+      "Daily synthetic dataset drops with plug-and-play USD, randomizer scripts, and policy validation notes.",
+    bullets: [
+      "Filter by policy, object coverage, and facility archetype",
+      "Variants + scripting so labs can train without touching pipelines",
+      "Pricing starts around $50/scene depending on scale",
+    ],
+    ctaLabel: "Browse drops",
+    ctaHref: "/environments",
+  },
+  {
+    title: "Real-world SimReady capture",
+    description:
+      "We scan your exact facility, rebuild it in USD, and return a validated scene tuned to your deployment stack.",
+    bullets: [
+      "On-site capture crews for kitchens, warehouses, labs, and more",
+      "Plug-and-play handoff for Isaac 4.x/5.x, URDF, or custom formats",
+      "Site-specific randomizers + QA so you ship with confidence",
+    ],
+    ctaLabel: "Book a capture",
+    ctaHref: "/contact",
+  },
+];
+
 export default function Home() {
+  const datasetPreview = syntheticDatasets.slice(0, 3);
+
   return (
     <div className="space-y-24 pb-24">
       <section className="mx-auto grid max-w-6xl gap-16 px-4 pt-16 sm:px-6 lg:grid-cols-[1.1fr_0.9fr]">
@@ -48,22 +77,19 @@ export default function Home() {
               SimReady worlds for robotic training.
             </h1>
             <p className="max-w-xl text-lg text-slate-600">
-              High-fidelity scenes, physics-clean assets, delivered fast. Every
-              procedural world we ship is authored from real kitchens,
-              warehouses, utilities, bedrooms, and other everyday locations so
-              your synthetic datasets reflect the variety your robots meet in
-              the field. Blueprint finishes procedural and real-world
-              environments so your robots can prove ROI in simulation before
-              hardware hits the floor. Engage on exclusive dataset programs or
-              license non-exclusive catalog scenes depending on your coverage
-              needs.
+              High-fidelity scenes, physics-clean assets, delivered fast. Pick
+              from our synthetic marketplace—new datasets publish daily with
+              variants, randomizers, and plug-and-play USD—or send us to your
+              actual site and we’ll return a SimReady digital twin tuned to your
+              deployment stack. Either path keeps labs out of DCC tools so they
+              can focus on training and proving ROI sooner.
             </p>
           </div>
           <CTAButtons
             primaryHref="/environments"
-            primaryLabel="Browse Environment Network"
+            primaryLabel="Browse Synthetic Marketplace"
             secondaryHref="/contact"
-            secondaryLabel="Request a Scene"
+            secondaryLabel="Book a Real-World Capture"
           />
           <LogoWall />
         </div>
@@ -75,17 +101,53 @@ export default function Home() {
             </p>
             <p>
               Kitchens, groceries, warehouse lanes, labs, offices, retail,
-              utility, and more. Our procedural sets are grounded in
-              photographic and scan references from active facilities so catalog
-              scenes mirror how real spaces are organized. Each environment
-              ships with articulated policy coverage, pickable props, semantic
-              labels, and simulation validation reports.
+              utility, and more. The synthetic marketplace blends scan-derived
+              references with procedural scale so you get the layouts, objects,
+              and articulation policies you actually deploy.
             </p>
             <p>
-              Add on our on-site capture service to transform your real facility
-              into a SimReady digital twin. Join the waitlist below.
+              Need something site-specific? Add on our capture service and the
+              same team will rebuild your exact facility with plugs for Isaac
+              and your QA stack.
             </p>
           </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-6xl px-4 sm:px-6">
+        <div className="grid gap-6 md:grid-cols-2">
+          {offeringCards.map((offering) => (
+            <article
+              key={offering.title}
+              className="flex h-full flex-col gap-4 rounded-3xl border border-slate-200 bg-white p-6"
+            >
+              <div className="space-y-2">
+                <p className="text-xs uppercase tracking-[0.3em] text-slate-400">
+                  {offering.title.includes("Synthetic") ? "Marketplace" : "Capture"}
+                </p>
+                <h3 className="text-2xl font-semibold text-slate-900">
+                  {offering.title}
+                </h3>
+                <p className="text-sm text-slate-600">{offering.description}</p>
+              </div>
+              <ul className="space-y-3 text-sm text-slate-600">
+                {offering.bullets.map((bullet) => (
+                  <li key={bullet} className="flex items-start gap-2">
+                    <span className="mt-1 h-2 w-2 rounded-full bg-emerald-500" />
+                    <span>{bullet}</span>
+                  </li>
+                ))}
+              </ul>
+              <div className="pt-2">
+                <a
+                  href={offering.ctaHref}
+                  className="inline-flex items-center text-sm font-semibold text-slate-900 underline-offset-4 hover:underline"
+                >
+                  {offering.ctaLabel}
+                </a>
+              </div>
+            </article>
+          ))}
         </div>
       </section>
 
@@ -110,20 +172,113 @@ export default function Home() {
         <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
           <div>
             <h2 className="text-3xl font-semibold text-slate-900">
-              Environment Network
+              Synthetic marketplace highlights
             </h2>
-            <p className="mt-2 max-w-xl text-sm text-slate-600">
-              60+ scene archetypes spanning robotic kitchens, warehouses,
-              retail, offices, and labs—each patterned after documented real
-              sites to preserve aisle widths, counter heights, and task
-              diversity. Browse categories below or jump into the full catalog.
+            <p className="mt-2 max-w-2xl text-sm text-slate-600">
+              Here’s a peek at today’s drops. Filter every dataset by policy,
+              location type, objects, variants, and cadence in the full
+              marketplace.
             </p>
           </div>
           <a
             href="/environments"
             className="text-sm font-semibold text-slate-900 underline-offset-4 hover:underline"
           >
-            View all scenes
+            Explore marketplace
+          </a>
+        </div>
+        <div className="grid gap-6 md:grid-cols-3">
+          {datasetPreview.map((dataset) => (
+            <article
+              key={dataset.slug}
+              className="flex h-full flex-col overflow-hidden rounded-3xl border border-slate-200 bg-white"
+            >
+              <div className="relative h-48 w-full">
+                <img
+                  src={dataset.heroImage}
+                  alt={dataset.title}
+                  className="h-full w-full object-cover"
+                  loading="lazy"
+                />
+                {dataset.isNew ? (
+                  <span className="absolute left-4 top-4 rounded-full bg-white/90 px-3 py-1 text-xs font-semibold text-slate-900">
+                    New drop
+                  </span>
+                ) : null}
+              </div>
+              <div className="flex flex-1 flex-col gap-4 p-5">
+                <div>
+                  <p className="text-xs uppercase tracking-[0.3em] text-slate-400">
+                    {dataset.locationType}
+                  </p>
+                  <h3 className="text-lg font-semibold text-slate-900">
+                    {dataset.title}
+                  </h3>
+                  <p className="mt-2 text-sm text-slate-600">
+                    {dataset.description}
+                  </p>
+                </div>
+                <dl className="grid grid-cols-3 gap-3 text-center text-xs text-slate-500">
+                  <div>
+                    <dt className="uppercase tracking-[0.2em]">$/scene</dt>
+                    <dd className="text-base font-semibold text-slate-900">
+                      ${dataset.pricePerScene}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="uppercase tracking-[0.2em]">Scenes</dt>
+                    <dd className="text-base font-semibold text-slate-900">
+                      {dataset.sceneCount}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="uppercase tracking-[0.2em]">Variants</dt>
+                    <dd className="text-base font-semibold text-slate-900">
+                      {dataset.variantCount}
+                    </dd>
+                  </div>
+                </dl>
+                <div className="flex flex-wrap gap-2 text-xs text-slate-500">
+                  {dataset.tags.map((tag) => (
+                    <span
+                      key={tag}
+                      className="rounded-full border border-slate-200 px-3 py-1"
+                    >
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+                <div className="mt-auto">
+                  <a
+                    href={`/environments?dataset=${dataset.slug}`}
+                    className="text-sm font-semibold text-slate-900 underline-offset-4 hover:underline"
+                  >
+                    See details
+                  </a>
+                </div>
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-6xl space-y-6 px-4 sm:px-6">
+        <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+          <div>
+            <h2 className="text-3xl font-semibold text-slate-900">
+              Environment families we cover daily
+            </h2>
+            <p className="mt-2 max-w-xl text-sm text-slate-600">
+              Use these archetypes to anchor your wishlist or capture brief.
+              We keep releasing variants that span aisle widths, heights, and
+              policy complexity so your models see the long tail.
+            </p>
+          </div>
+          <a
+            href="/environments"
+            className="text-sm font-semibold text-slate-900 underline-offset-4 hover:underline"
+          >
+            View full taxonomy
           </a>
         </div>
         <TileGrid
@@ -225,15 +380,15 @@ export default function Home() {
           <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
             <div>
               <p className="text-xs uppercase tracking-[0.3em] text-slate-400">
-                Coming soon
+                Real-world capture waitlist
               </p>
               <h3 className="mt-2 text-2xl font-semibold text-slate-900">
-                On-site capture → SimReady digital twin.
+                Turn any facility into a SimReady digital twin.
               </h3>
               <p className="mt-3 max-w-xl text-sm text-slate-600">
-                We scan your site-of-choice, rebuild it in USD, and return a validated
-                digital twin in days—not months. Join the waitlist to reserve an
-                on-site capture slot.
+                Share the address you care about and we’ll coordinate a capture
+                window. Expect delivery in days—not months—with USD, URDF, and
+                QA reports ready for your simulator.
               </p>
             </div>
             <WaitlistForm />


### PR DESCRIPTION
## Summary
- reposition the home page hero, cards, and highlights around the synthetic SimReady marketplace plus real-world capture services
- replace the Environments page with a proper dataset marketplace including new filters, dataset metadata, and contact CTAs powered by new catalog data
- refresh the contact page and form so the primary action is booking a real-world capture while still collecting wishlist data for synthetic drops

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b259a98848329aa95ce691e163357)