### PR TITLE
Temporarily hide real-world capture offering

### DIFF
--- a/client/src/components/site/ContactForm.tsx
+++ b/client/src/components/site/ContactForm.tsx
@@ -979,6 +979,8 @@ import { SUPPORT } from "../pilotCopy";
 
 // --- Configuration ---
 
+const SHOW_REAL_WORLD_CAPTURE = false;
+
 const requestOptions = [
   {
     value: "scene" as const,
@@ -1005,6 +1007,10 @@ const requestOptions = [
     recommended: false,
   },
 ];
+
+const visibleRequestOptions = SHOW_REAL_WORLD_CAPTURE
+  ? requestOptions
+  : requestOptions.filter((option) => option.value !== "scene");
 
 const datasetTiers = [
   {
@@ -1115,6 +1121,8 @@ const deriveQuote = (analysis: SnapshotAnalysis | null) => {
   return clampQuote(analysis.suggestedQuote ?? inferred);
 };
 
+const defaultRequestType = SHOW_REAL_WORLD_CAPTURE ? "scene" : "dataset";
+
 export function ContactForm() {
   // --- State ---
   const [status, setStatus] = useState<
@@ -1123,7 +1131,7 @@ export function ContactForm() {
   const [message, setMessage] = useState("");
   const [requestType, setRequestType] = useState<
     "dataset" | "scene" | "snapshot"
-  >("scene");
+  >(defaultRequestType);
 
   // Form Data
   const [datasetTier, setDatasetTier] = useState<string>(datasetTiers[0].value);
@@ -1475,7 +1483,7 @@ export function ContactForm() {
       setStatus("success");
       form.reset();
       // Reset State
-      setRequestType("scene");
+      setRequestType(defaultRequestType);
       setDatasetTier(datasetTiers[0].value);
       setSelectedUseCases([]);
       setSelectedEnvironments([]);
@@ -1525,7 +1533,7 @@ export function ContactForm() {
     <form onSubmit={handleSubmit} className="space-y-8">
       {/* 1. Path Selection */}
       <div className="grid gap-4 md:grid-cols-2">
-        {requestOptions.map((option) => (
+        {visibleRequestOptions.map((option) => (
           <div
             key={option.value}
             onClick={() => setRequestType(option.value)}

--- a/client/src/pages/Contact.tsx
+++ b/client/src/pages/Contact.tsx
@@ -26,6 +26,24 @@
 import { ContactForm } from "@/components/site/ContactForm";
 import { MessageSquare } from "lucide-react";
 
+const SHOW_REAL_WORLD_CAPTURE = false;
+
+const badgeLabel = SHOW_REAL_WORLD_CAPTURE
+  ? "Capture & Marketplace Requests"
+  : "Marketplace & Photo Rebuild Requests";
+
+const headingLead = SHOW_REAL_WORLD_CAPTURE
+  ? "Scan a site, upload a photo, or"
+  : "Upload a photo or";
+
+const headingEmphasis = "steer the roadmap.";
+
+const descriptionWithCapture =
+  "Book a real-world SimReady capture, upload a single wide photo of a supported archetype for an exclusive reconstruction (default—you can opt into open catalog), or steer the synthetic marketplace roadmap. Tell us which policy, object, or location types you need most—the signal helps decide our next drops.";
+
+const descriptionWithoutCapture =
+  "Upload a single wide photo of a supported archetype for an exclusive reconstruction (default—you can opt into open catalog), or steer the synthetic marketplace roadmap. Tell us which policy, object, or location types you need most—the signal helps decide our next drops.";
+
 // --- Visual Helper ---
 function DotPattern() {
   return (
@@ -65,22 +83,20 @@ export default function Contact() {
         <header className="mb-16 space-y-6 text-center sm:text-left">
           <div className="inline-flex items-center gap-2 rounded-full border border-zinc-200 bg-white px-3 py-1 text-xs font-bold uppercase tracking-wider text-zinc-500 shadow-sm">
             <MessageSquare className="h-3 w-3" />
-            Capture & Marketplace Requests
+            {badgeLabel}
           </div>
 
           <h1 className="text-4xl font-bold tracking-tight text-zinc-950 sm:text-5xl">
-            Scan a site, upload a photo, or <br />
+            {headingLead} <br />
             <span className="text-4xl font-bold tracking-tight text-zinc-950 sm:text-5xl">
-              steer the roadmap.
+              {headingEmphasis}
             </span>
           </h1>
 
           <p className="max-w-2xl text-lg leading-relaxed text-zinc-600 sm:mx-0">
-            Book a real-world SimReady capture, upload a single wide photo of a
-            supported archetype for an exclusive reconstruction (default—you can
-            opt into open catalog), or steer the synthetic marketplace roadmap.
-            Tell us which policy, object, or location types you need most—the
-            signal helps decide our next drops.
+            {SHOW_REAL_WORLD_CAPTURE
+              ? descriptionWithCapture
+              : descriptionWithoutCapture}
           </p>
         </header>
 

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -454,6 +454,8 @@ const artistBullets = [
   "Paid per scene, bonuses for articulation coverage",
 ];
 
+const SHOW_REAL_WORLD_CAPTURE = false;
+
 const offeringCards = [
   {
     title: "Synthetic SimReady Scenes",
@@ -499,6 +501,10 @@ const offeringCards = [
   },
 ];
 
+const visibleOfferingCards = SHOW_REAL_WORLD_CAPTURE
+  ? offeringCards
+  : offeringCards.filter((card) => card.title !== "Real-world Capture");
+
 // --- Helper Components ---
 
 function DotPattern() {
@@ -529,6 +535,16 @@ function DotPattern() {
   );
 }
 
+const heroDescriptionWithCapture =
+  "High-fidelity scenes, physics-clean assets, delivered fast. Pick from our synthetic marketplace or send us to your actual site for a digital twin tuned to your deployment stack.";
+
+const heroDescriptionWithoutCapture =
+  "High-fidelity scenes, physics-clean assets, delivered fast. Pick from our synthetic marketplace or upload a reference photo for an exclusive reconstruction.";
+
+const facilitySupportCopy = SHOW_REAL_WORLD_CAPTURE
+  ? "Need exact facility matching? Add on our capture service or upload one reference photo for an exclusive reconstruction. We rebuild your facility with plugs for Isaac and your QA stack."
+  : "Need exact facility matching? Upload one reference photo for an exclusive reconstruction. We’ll return a SimReady scene with plugs for Isaac and your QA stack.";
+
 export default function Home() {
   const datasetPreview = syntheticDatasets.slice(0, 3);
 
@@ -551,9 +567,9 @@ export default function Home() {
                   SimReady worlds for robotic training.
                 </h1>
                 <p className="max-w-xl text-lg leading-relaxed text-zinc-600">
-                  High-fidelity scenes, physics-clean assets, delivered fast.
-                  Pick from our synthetic marketplace or send us to your actual
-                  site for a digital twin tuned to your deployment stack.
+                  {SHOW_REAL_WORLD_CAPTURE
+                    ? heroDescriptionWithCapture
+                    : heroDescriptionWithoutCapture}
                 </p>
               </div>
 
@@ -605,10 +621,7 @@ export default function Home() {
                     <span className="block font-mono text-indigo-600 mb-1">
                       $ system_check --site-specific
                     </span>
-                    Need exact facility matching? Add on our capture service or
-                    upload one reference photo for an exclusive reconstruction.
-                    We rebuild your facility with plugs for Isaac and your QA
-                    stack.
+                    {facilitySupportCopy}
                   </div>
                 </div>
               </div>
@@ -621,7 +634,7 @@ export default function Home() {
       {/* --- Offering Cards --- */}
       <section className="mx-auto max-w-7xl px-4 pb-24 sm:px-6 lg:px-8">
         <div className="grid gap-8 md:grid-cols-2">
-          {offeringCards.map((offering) => (
+          {visibleOfferingCards.map((offering) => (
             <article
               key={offering.title}
               className="group relative flex h-full flex-col gap-6 rounded-3xl border border-zinc-200 bg-white p-8 shadow-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-md hover:border-indigo-200"

--- a/client/src/pages/Solutions.tsx
+++ b/client/src/pages/Solutions.tsx
@@ -199,6 +199,8 @@ import {
 
 // --- Configuration ---
 
+const SHOW_REAL_WORLD_CAPTURE = false;
+
 const proceduralSteps = [
   {
     title: "Author",
@@ -515,8 +517,9 @@ export default function Solutions() {
             </div>
           </section>
 
-          {/* --- Section 2: On-Site (Dark/Premium Theme) --- */}
-          <section
+          {SHOW_REAL_WORLD_CAPTURE && (
+            /* --- Section 2: On-Site (Dark/Premium Theme) --- */
+            <section
             id="pricing"
             className="relative overflow-hidden rounded-[2.5rem] bg-zinc-900 p-8 text-zinc-300 sm:p-12 lg:p-16 shadow-2xl"
           >
@@ -622,7 +625,8 @@ export default function Solutions() {
                 </div>
               </div>
             </div>
-          </section>
+            </section>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- gate real-world capture messaging behind a flag and hide it from home, contact, and solutions pages
- keep capture copy in code while showing only marketplace wishlist and reference rebuild paths
- default the contact form to marketplace/reference requests and remove capture option from UI

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924c2dc5ab88329aac5ad338c0dd8d0)