### PR TITLE
Prefill reference photo request from home upload CTA

### DIFF
--- a/client/src/components/site/ContactForm.tsx
+++ b/client/src/components/site/ContactForm.tsx
@@ -1121,7 +1121,31 @@ const deriveQuote = (analysis: SnapshotAnalysis | null) => {
   return clampQuote(analysis.suggestedQuote ?? inferred);
 };
 
-const defaultRequestType = SHOW_REAL_WORLD_CAPTURE ? "scene" : "dataset";
+type RequestType = "dataset" | "scene" | "snapshot";
+
+const defaultRequestType: RequestType = SHOW_REAL_WORLD_CAPTURE
+  ? "scene"
+  : "dataset";
+
+const getInitialRequestType = (): RequestType => {
+  if (typeof window === "undefined") {
+    return defaultRequestType;
+  }
+
+  const params = new URLSearchParams(window.location.search);
+  const requested = params.get("request");
+  const allowedRequests: RequestType[] = ["dataset", "scene", "snapshot"];
+
+  if (requested && allowedRequests.includes(requested as RequestType)) {
+    if (!SHOW_REAL_WORLD_CAPTURE && requested === "scene") {
+      return defaultRequestType;
+    }
+
+    return requested as RequestType;
+  }
+
+  return defaultRequestType;
+};
 
 export function ContactForm() {
   // --- State ---
@@ -1129,9 +1153,9 @@ export function ContactForm() {
     "idle" | "loading" | "success" | "error"
   >("idle");
   const [message, setMessage] = useState("");
-  const [requestType, setRequestType] = useState<
-    "dataset" | "scene" | "snapshot"
-  >(defaultRequestType);
+  const [requestType, setRequestType] = useState<RequestType>(
+    getInitialRequestType,
+  );
 
   // Form Data
   const [datasetTier, setDatasetTier] = useState<string>(datasetTiers[0].value);

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -482,7 +482,7 @@ const offeringCards = [
       "Exclusive delivery by default; opt into open catalog if you prefer",
     ],
     ctaLabel: "Upload a photo",
-    ctaHref: "/contact",
+    ctaHref: "/contact?request=snapshot",
     icon: <Camera className="h-8 w-8 text-zinc-900" />,
   },
   {


### PR DESCRIPTION
## Summary
- route the Home page reference photo CTA to include a snapshot request parameter
- read the contact page request type from the URL so reference photo rebuild is preselected when linked

## Testing
- npm run check

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929dd7f3eb0832984091619c8937e41)