### PR TITLE
Remove delivery language for digital access

### DIFF
--- a/client/src/data/content.ts
+++ b/client/src/data/content.ts
@@ -802,7 +802,7 @@ export const scenes: Scene[] = [
     replicator: "Surface class + SKU tags",
     testedWith: "Simulation QA suite",
     leadTime: "7 business days",
-    ctaText: "Book delivery",
+    ctaText: "Book a build",
     seo: "SimReady dishroom with revolute doors and prismatic racks for articulated policy training.",
     highlights: [
       "High-gloss stainless with baked AO",
@@ -939,7 +939,7 @@ export const scenes: Scene[] = [
     colliders: "Convex decomp with door sweep volumes",
     testedWith: "Simulation QA suite",
     leadTime: "6 business days",
-    ctaText: "Schedule delivery",
+    ctaText: "Schedule a build",
     seo: "SimReady refrigerated grocery aisle with articulated doors and shelf slides.",
     highlights: [
       "Thermal gradients for sensor testing",
@@ -1589,9 +1589,9 @@ export const jobs: Job[] = [
     title: "3D Artist",
     type: "Contract",
     location: "Remote",
-    summary: "Create high-fidelity assets with watertight topology and clean UVs for SimReady delivery.",
+    summary: "Create high-fidelity assets with watertight topology and clean UVs for SimReady handoff.",
     description:
-      "You will translate capture outputs and kitbashed assets into polished simulation-ready geometry. Expect to iterate with our robotics specialists on articulation coverage, pivots, and collider tuning. Compensation is per scene annotated or edited and averages approximately $50 per hour.",
+      "You will translate capture outputs and kitbashed assets into polished simulation-ready geometry. Expect to iterate with our robotics specialists on articulation coverage, pivots, and collider tuning. Compensation is scoped to each project and averages approximately $50 per hour.",
     applyEmail: "apply+artist@tryblueprint.io",
   },
   {
@@ -1600,7 +1600,7 @@ export const jobs: Job[] = [
     location: "Remote",
     summary: "Build the authoring tools that automate SimReady finishing across our environment network.",
     description:
-      "Design and ship USD pipelines that enforce our SimReady spec, from collider validation to articulation presets. You'll collaborate with artists and robotics teams to accelerate delivery.",
+      "Design and ship USD pipelines that enforce our SimReady spec, from collider validation to articulation presets. You'll collaborate with artists and robotics teams to accelerate turnaround.",
     applyEmail: "apply+usd@tryblueprint.io",
   },
 ];

--- a/client/src/pages/EnvironmentDetail.tsx
+++ b/client/src/pages/EnvironmentDetail.tsx
@@ -151,7 +151,7 @@ export default function EnvironmentDetail({ params }: EnvironmentDetailProps) {
     const quantityLabel = isDataset
       ? `${(marketplaceDataset as SyntheticDataset).sceneCount} scenes`
       : `${(variantCount ?? 1)} variants`;
-    const priceLabel = isDataset ? "/scene" : "per scene";
+    const priceLabel = isDataset ? "/scene" : "";
     const bundleTotal = isDataset
       ? ((marketplaceDataset as SyntheticDataset).pricePerScene || 0) *
         ((marketplaceDataset as SyntheticDataset).sceneCount || 1)
@@ -250,7 +250,9 @@ export default function EnvironmentDetail({ params }: EnvironmentDetailProps) {
                         ? (marketplaceDataset as SyntheticDataset).pricePerScene
                         : (marketplaceScene as MarketplaceScene).price}
                     </span>
-                    <span className="text-sm text-zinc-500">{priceLabel}</span>
+                    {priceLabel ? (
+                      <span className="text-sm text-zinc-500">{priceLabel}</span>
+                    ) : null}
                     {isDataset && (marketplaceDataset as SyntheticDataset).standardPricePerScene ? (
                       <span className="text-xs text-zinc-400 line-through">
                         ${(marketplaceDataset as SyntheticDataset).standardPricePerScene}
@@ -264,9 +266,11 @@ export default function EnvironmentDetail({ params }: EnvironmentDetailProps) {
                     }`}
                   </p>
                 ) : (
-                    <p className="mt-1 text-xs text-emerald-600">
-                      {(marketplaceScene as MarketplaceScene).inStock ? "In stock for immediate delivery" : "Pre-order"}
-                    </p>
+                  <p className="mt-1 text-xs text-emerald-600">
+                    {(marketplaceScene as MarketplaceScene).inStock
+                      ? "Available for immediate access"
+                      : "Join the waitlist"}
+                  </p>
                   )}
                 </div>
                 <span className="rounded-full bg-zinc-100 px-3 py-1 text-xs font-semibold text-zinc-700">
@@ -524,9 +528,9 @@ export default function EnvironmentDetail({ params }: EnvironmentDetailProps) {
             <li>Optional annotation bundles: {scene.replicator ?? "available on request"}.</li>
           </ul>
           <div className="rounded-3xl border border-slate-200 bg-slate-50 p-6 text-sm text-slate-600">
-            <h3 className="text-sm font-semibold text-slate-900">Delivery</h3>
+            <h3 className="text-sm font-semibold text-slate-900">Access</h3>
             <p className="mt-2">
-              Standard lead time: {scene.leadTime}. Rush delivery available pending scope. Scenes are shipped via secure link with release notes and simulation validation checklists.
+              Standard lead time: {scene.leadTime}. Expedited turnaround is available pending scope. Scenes are provided via secure download with release notes and simulation validation checklists.
             </p>
           </div>
         </div>

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -451,7 +451,7 @@ const labBullets = [
 const artistBullets = [
   "Join a network shipping scenes to leading labs",
   "Focus on fidelity—we’ll handle the pipeline",
-  "Paid per scene, bonuses for articulation coverage",
+  "Project-based pay with bonuses for articulation coverage",
 ];
 
 const SHOW_REAL_WORLD_CAPTURE = false;
@@ -479,7 +479,7 @@ const offeringCards = [
     bullets: [
       "Submit a kitchen, aisle, lab, or other covered archetype",
       "We author USD/URDF handoff with QA against your use cases",
-      "Exclusive delivery by default; opt into open catalog if you prefer",
+      "Exclusive access by default; opt into open catalog if you prefer",
     ],
     ctaLabel: "Upload a photo",
     ctaHref: "/contact?request=snapshot",

--- a/client/src/pages/Solutions.tsx
+++ b/client/src/pages/Solutions.tsx
@@ -217,7 +217,7 @@ const proceduralSteps = [
   {
     title: "Validate",
     description:
-      "Every delivery ships with simulation QA runs, semantic labels on request, and annotation-ready metadata.",
+      "Every release includes simulation QA runs, semantic labels on request, and annotation-ready metadata.",
     icon: <CheckCircle2 className="h-6 w-6 text-indigo-600" />,
   },
 ];
@@ -323,7 +323,7 @@ export default function Solutions() {
                     The SimReady Standard
                   </h2>
                   <p className="text-xs text-zinc-500">
-                    Guaranteed on every delivery
+                    Guaranteed in every release
                   </p>
                 </div>
               </div>
@@ -454,7 +454,7 @@ export default function Solutions() {
                 </p>
 
                 <ul className="grid gap-3 text-sm text-zinc-700 sm:grid-cols-2">
-                  {["Budget averages around $1k per scene", "Exclusive delivery by default—opt into open catalog if you want", "Includes authored colliders, pivots, and materials", "Submit use cases so we validate against your policies"].map(
+                  {["Budget averages around $1k per environment", "Exclusive access by default—opt into open catalog if you want", "Includes authored colliders, pivots, and materials", "Submit use cases so we validate against your policies"].map(
                     (item) => (
                       <li
                         key={item}
@@ -487,7 +487,7 @@ export default function Solutions() {
                   </div>
                   <div>
                     <p className="text-xs font-bold uppercase tracking-widest text-indigo-500">
-                      Delivery Checklist
+                      Release Checklist
                     </p>
                     <p className="text-sm text-zinc-700">
                       Built for labs that need a specific, exclusive layout.

--- a/client/src/pages/Terms.tsx
+++ b/client/src/pages/Terms.tsx
@@ -7,7 +7,7 @@ export default function Terms() {
         </p>
         <h1 className="text-4xl font-semibold text-slate-900">Terms of Service</h1>
         <p className="text-sm text-slate-600">
-          Updated December 2024. These terms govern your access to and use of Blueprint’s services, including environment delivery, on-site capture, and supporting software.
+          Updated December 2024. These terms govern your access to and use of Blueprint’s services, including environment access, on-site capture, and supporting software.
         </p>
       </header>
       <section className="space-y-3 text-sm text-slate-600">


### PR DESCRIPTION
## Summary
- remove per-scene pricing wording and delivery-style availability labels on environment detail pages
- update marketing and job copy to emphasize digital access instead of physical delivery
- refresh CTA labels and terms of service language to align with the new positioning

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f867ce32083298eab968cc95f25ec)