### PR TITLE
Replace variant terminology with frame

### DIFF
--- a/client/src/components/site/ContactForm.tsx
+++ b/client/src/components/site/ContactForm.tsx
@@ -421,7 +421,7 @@
 //               Wishlist scale
 //             </span>
 //             <p className="text-sm text-slate-600">
-//               Non-binding, but helps us size how many scenes/variants to line up
+//               Non-binding, but helps us size how many scenes/frames to line up
 //               when we drop the dataset you care about.
 //             </p>
 //           </div>

--- a/client/src/data/content.ts
+++ b/client/src/data/content.ts
@@ -65,7 +65,7 @@ export interface SyntheticDataset {
   objectTags: string[];
   pricePerScene: number;
   sceneCount: number;
-  variantCount: number;
+  frameCount: number;
   releaseDate: string;
   tags: string[];
   randomizerScripts: string[];
@@ -86,7 +86,7 @@ export interface MarketplaceScene {
   policySlugs: string[];
   objectTags: string[];
   price: number; // Individual scene price
-  variantCount?: number;
+  frameCount?: number;
   releaseDate: string;
   tags: string[];
   deliverables: string[];
@@ -306,7 +306,7 @@ export const syntheticDatasets: SyntheticDataset[] = [
     pricePerScene: 65,
     standardPricePerScene: 185,
     sceneCount: 150,
-    variantCount: 8,
+    frameCount: 8,
     releaseDate: "2024-12-12",
     tags: ["Articulated", "Plug & Play", "USD"],
     randomizerScripts: [
@@ -331,7 +331,7 @@ export const syntheticDatasets: SyntheticDataset[] = [
     pricePerScene: 58,
     standardPricePerScene: 175,
     sceneCount: 110,
-    variantCount: 6,
+    frameCount: 6,
     releaseDate: "2024-12-05",
     tags: ["Retail", "High SKU", "Randomized"],
     randomizerScripts: ["SKU swaps", "Cart clutter", "Lighting color temp"],
@@ -351,7 +351,7 @@ export const syntheticDatasets: SyntheticDataset[] = [
     pricePerScene: 72,
     standardPricePerScene: 195,
     sceneCount: 200,
-    variantCount: 10,
+    frameCount: 10,
     releaseDate: "2024-11-28",
     tags: ["Industrial", "Heavy lift", "Conveyor-ready"],
     randomizerScripts: [
@@ -379,7 +379,7 @@ export const syntheticDatasets: SyntheticDataset[] = [
     pricePerScene: 84,
     standardPricePerScene: 220,
     sceneCount: 65,
-    variantCount: 5,
+    frameCount: 5,
     releaseDate: "2024-11-22",
     tags: ["Cleanroom", "Controls", "QA"],
     randomizerScripts: ["Gauge offsets", "Cabinet wiring", "Consumable clutter"],
@@ -398,7 +398,7 @@ export const syntheticDatasets: SyntheticDataset[] = [
     pricePerScene: 52,
     standardPricePerScene: 150,
     sceneCount: 90,
-    variantCount: 4,
+    frameCount: 4,
     releaseDate: "2024-11-18",
     tags: ["Inspection", "Low light", "Compact"],
     randomizerScripts: ["Status LEDs", "Valve state", "Dust + grime"],
@@ -417,7 +417,7 @@ export const syntheticDatasets: SyntheticDataset[] = [
     pricePerScene: 50,
     standardPricePerScene: 165,
     sceneCount: 50,
-    variantCount: 3,
+    frameCount: 3,
     releaseDate: "2024-11-12",
     tags: ["Assistive", "Household", "Soft goods"],
     randomizerScripts: ["Fabric types", "Lighting temp", "Clutter"],
@@ -436,7 +436,7 @@ export const marketplaceScenes: MarketplaceScene[] = [
     policySlugs: ["dexterous-pick-place", "articulated-access-validation"],
     objectTags: ["dishwashers", "shelves", "utensils"],
     price: 185,
-    variantCount: 3,
+    frameCount: 3,
     releaseDate: "2024-12-01",
     tags: ["Articulated", "High-detail", "USD"],
     deliverables: ["USD / Isaac 4.x", "Replicator semantics"],
@@ -453,7 +453,7 @@ export const marketplaceScenes: MarketplaceScene[] = [
     policySlugs: ["dexterous-pick-place", "mixed-sku-logistics"],
     objectTags: ["coolers", "shelves", "totes"],
     price: 195,
-    variantCount: 2,
+    frameCount: 2,
     releaseDate: "2024-11-29",
     tags: ["Retail", "Cold storage", "Randomized"],
     deliverables: ["USD", "Synthetic sensor captures"],
@@ -484,7 +484,7 @@ export const marketplaceScenes: MarketplaceScene[] = [
     policySlugs: ["precision-insertion-assembly", "panel-interaction-suite"],
     objectTags: ["sample racks", "valves", "drawers"],
     price: 220,
-    variantCount: 2,
+    frameCount: 2,
     releaseDate: "2024-11-20",
     tags: ["Cleanroom", "Precision", "Controls"],
     deliverables: ["USD", "STEP", "Semantic layers"],
@@ -516,7 +516,7 @@ export const marketplaceScenes: MarketplaceScene[] = [
     policySlugs: ["laundry-folding-assist"],
     objectTags: ["washers", "dryers", "hampers"],
     price: 165,
-    variantCount: 2,
+    frameCount: 2,
     releaseDate: "2024-11-15",
     tags: ["Assistive", "Household"],
     deliverables: ["USD", "URDF"],
@@ -532,7 +532,7 @@ export const marketplaceScenes: MarketplaceScene[] = [
     policySlugs: ["dexterous-pick-place", "articulated-access-validation"],
     objectTags: ["drawers", "utensils", "appliances"],
     price: 170,
-    variantCount: 4,
+    frameCount: 4,
     releaseDate: "2024-12-08",
     tags: ["Articulated", "USD"],
     deliverables: ["USD / Isaac 4.x", "Isaac 5.x"],
@@ -579,7 +579,7 @@ export const marketplaceScenes: MarketplaceScene[] = [
     policySlugs: ["precision-insertion-assembly"],
     objectTags: ["sample racks", "drawers"],
     price: 210,
-    variantCount: 3,
+    frameCount: 3,
     releaseDate: "2024-11-19",
     tags: ["Precision", "Assembly"],
     deliverables: ["USD", "STEP"],
@@ -625,7 +625,7 @@ export const marketplaceScenes: MarketplaceScene[] = [
     policySlugs: ["dexterous-pick-place"],
     objectTags: ["shelves", "appliances"],
     price: 175,
-    variantCount: 2,
+    frameCount: 2,
     releaseDate: "2024-12-02",
     tags: ["Food service", "Articulated"],
     deliverables: ["USD / Isaac 4.x"],
@@ -641,7 +641,7 @@ export const marketplaceScenes: MarketplaceScene[] = [
     policySlugs: ["dexterous-pick-place", "precision-insertion-assembly"],
     objectTags: ["drawers", "shelves"],
     price: 225,
-    variantCount: 1,
+    frameCount: 1,
     releaseDate: "2024-11-30",
     tags: ["Healthcare", "Precision", "Secure"],
     deliverables: ["USD", "Semantic layers"],
@@ -673,7 +673,7 @@ export const marketplaceScenes: MarketplaceScene[] = [
     policySlugs: ["articulated-access-validation", "panel-interaction-suite"],
     objectTags: ["doors", "switches"],
     price: 200,
-    variantCount: 2,
+    frameCount: 2,
     releaseDate: "2024-11-21",
     tags: ["Cleanroom", "Safety"],
     deliverables: ["USD", "Event scripts"],
@@ -704,7 +704,7 @@ export const marketplaceScenes: MarketplaceScene[] = [
     policySlugs: ["laundry-folding-assist", "articulated-access-validation"],
     objectTags: ["drawers", "hampers"],
     price: 180,
-    variantCount: 3,
+    frameCount: 3,
     releaseDate: "2024-11-13",
     tags: ["Assistive", "Organization"],
     deliverables: ["USD"],
@@ -987,7 +987,7 @@ export const scenes: Scene[] = [
     ctaText: "Add to quote",
     seo: "Bulk dry goods aisle with articulated dispensers and scale for manipulation tasks.",
     highlights: [
-      "Seeded variations for dataset diversity",
+      "Seeded frames for dataset diversity",
       "Embedded signage metadata",
       "Material IDs for granular fill levels",
     ],
@@ -1078,7 +1078,7 @@ export const scenes: Scene[] = [
     ctaText: "Reserve",
     seo: "Cross-dock staging area with articulated dock lever and pallet handling assets.",
     highlights: [
-      "Rainy + sunny lighting variants",
+      "Rainy + sunny lighting frames",
       "Restraint sensors flagged as USD tokens",
       "Line markings exported as semantic layers",
     ],
@@ -1124,7 +1124,7 @@ export const scenes: Scene[] = [
     seo: "Pallet buffer zone tuned for palletizing and AMR handoff policies.",
     highlights: [
       "Fork pocket physics volumes",
-      "Dynamic signage variations",
+      "Dynamic signage frames",
       "Safety envelope markup",
     ],
   },
@@ -1168,7 +1168,7 @@ export const scenes: Scene[] = [
     ctaText: "Join waitlist",
     seo: "Dock-high bay environment with articulated leveler and vehicle restraint for automation pilots.",
     highlights: [
-      "Weather variants bundled",
+      "Weather frames bundled",
       "Truck approach spline annotated",
       "Collision proxies tuned for compliance",
     ],
@@ -1304,7 +1304,7 @@ export const scenes: Scene[] = [
     ctaText: "Book",
     seo: "Sample preparation lab with articulated fume hood and carousel.",
     highlights: [
-      "UV-safe texture variants",
+      "UV-safe texture frames",
       "Calibrated lighting for machine vision",
       "Semantic tags for reagents",
     ],
@@ -1441,7 +1441,7 @@ export const scenes: Scene[] = [
     highlights: [
       "Utility labels with text metadata",
       "Floor drain SDF",
-      "Hook height variations",
+      "Hook height frames",
     ],
   },
   {
@@ -1529,7 +1529,7 @@ export const scenes: Scene[] = [
     ctaText: "Request scene",
     seo: "Residential laundry alcove with articulated washer and dryer controls.",
     highlights: [
-      "Stacked + side-by-side variants",
+      "Stacked + side-by-side frames",
       "Laundry basket spawn points",
       "High-contrast textures for assistive research",
     ],
@@ -1563,7 +1563,7 @@ export const caseStudies: CaseStudy[] = [
     outcomes: [
       "Cut policy tuning time by 60%",
       "Validated AMR clearances before site visit",
-      "Delivered 4 scenario variants in under 10 days",
+      "Delivered 4 scenario frames in under 10 days",
     ],
     cta: "Book a warehouse walkthrough",
   },
@@ -1576,7 +1576,7 @@ export const caseStudies: CaseStudy[] = [
     body:
       "We rebuilt a flagship retail aisle with signage, price tags, and semantic IDs. Teams trained grasp-place behaviors, tuned suction compliance, and exported annotation-ready datasets.",
     outcomes: [
-      "8x shelf variations",
+      "8x shelf frames",
       "Product-level semantic metadata",
       "SLAM validation with synthetic-lidar",
     ],
@@ -2140,7 +2140,7 @@ export const jobs: Job[] = [
 //     ctaText: "Add to quote",
 //     seo: "Bulk dry goods aisle with articulated dispensers and scale for manipulation tasks.",
 //     highlights: [
-//       "Seeded variations for dataset diversity",
+//       "Seeded frames for dataset diversity",
 //       "Embedded signage metadata",
 //       "Material IDs for granular fill levels",
 //     ],
@@ -2233,7 +2233,7 @@ export const jobs: Job[] = [
 //     ctaText: "Reserve",
 //     seo: "Cross-dock staging area with articulated dock lever and pallet handling assets.",
 //     highlights: [
-//       "Rainy + sunny lighting variants",
+//       "Rainy + sunny lighting frames",
 //       "Restraint sensors flagged as USD tokens",
 //       "Line markings exported as semantic layers",
 //     ],
@@ -2280,7 +2280,7 @@ export const jobs: Job[] = [
 //     seo: "Pallet buffer zone tuned for palletizing and AMR handoff policies.",
 //     highlights: [
 //       "Fork pocket physics volumes",
-//       "Dynamic signage variations",
+//       "Dynamic signage frames",
 //       "Safety envelope markup",
 //     ],
 //   },
@@ -2325,7 +2325,7 @@ export const jobs: Job[] = [
 //     ctaText: "Join waitlist",
 //     seo: "Dock-high bay environment with articulated leveler and vehicle restraint for automation pilots.",
 //     highlights: [
-//       "Weather variants bundled",
+//       "Weather frames bundled",
 //       "Truck approach spline annotated",
 //       "Collision proxies tuned for compliance",
 //     ],
@@ -2464,7 +2464,7 @@ export const jobs: Job[] = [
 //     ctaText: "Book",
 //     seo: "Sample preparation lab with articulated fume hood and carousel.",
 //     highlights: [
-//       "UV-safe texture variants",
+//       "UV-safe texture frames",
 //       "Calibrated lighting for machine vision",
 //       "Semantic tags for reagents",
 //     ],
@@ -2604,7 +2604,7 @@ export const jobs: Job[] = [
 //     highlights: [
 //       "Utility labels with text metadata",
 //       "Floor drain SDF",
-//       "Hook height variations",
+//       "Hook height frames",
 //     ],
 //   },
 //   {
@@ -2694,7 +2694,7 @@ export const jobs: Job[] = [
 //     ctaText: "Request scene",
 //     seo: "Residential laundry alcove with articulated washer and dryer controls.",
 //     highlights: [
-//       "Stacked + side-by-side variants",
+//       "Stacked + side-by-side frames",
 //       "Laundry basket spawn points",
 //       "High-contrast textures for assistive research",
 //     ],
@@ -2726,7 +2726,7 @@ export const jobs: Job[] = [
 //     outcomes: [
 //       "Cut policy tuning time by 60%",
 //       "Validated AMR clearances before site visit",
-//       "Delivered 4 scenario variants in under 10 days",
+//       "Delivered 4 scenario frames in under 10 days",
 //     ],
 //     cta: "Book a warehouse walkthrough",
 //   },
@@ -2738,7 +2738,7 @@ export const jobs: Job[] = [
 //     hero: "https://images.unsplash.com/photo-1563013544-824ae1b704d3?auto=format&fit=crop&w=1200&q=80",
 //     body: "We rebuilt a flagship retail aisle with signage, price tags, and semantic IDs. Teams trained grasp-place behaviors, tuned suction compliance, and exported annotation-ready datasets.",
 //     outcomes: [
-//       "8x shelf variations",
+//       "8x shelf frames",
 //       "Product-level semantic metadata",
 //       "SLAM validation with synthetic-lidar",
 //     ],

--- a/client/src/pages/Docs.tsx
+++ b/client/src/pages/Docs.tsx
@@ -45,7 +45,7 @@
 //         <div className="space-y-3 text-sm text-slate-600">
 //           <p>• Semantic labels follow Blueprint’s ontology and map cleanly to class, instance, and SKU exports.</p>
 //           <p>• Scenes include optional CSV/JSON metadata for planograms, signage, and device IDs.</p>
-//           <p>• Ask for annotation bundles to receive camera rigs, lighting variants, and sensor trajectories.</p>
+//           <p>• Ask for annotation bundles to receive camera rigs, lighting frames, and sensor trajectories.</p>
 //         </div>
 //       </section>
 

--- a/client/src/pages/EnvironmentDetail.tsx
+++ b/client/src/pages/EnvironmentDetail.tsx
@@ -140,9 +140,9 @@ export default function EnvironmentDetail({ params }: EnvironmentDetailProps) {
     const heroImage = isDataset
       ? (marketplaceDataset as SyntheticDataset).heroImage
       : (marketplaceScene as MarketplaceScene).thumbnail;
-    const variantCount = isDataset
-      ? (marketplaceDataset as SyntheticDataset).variantCount
-      : (marketplaceScene as MarketplaceScene).variantCount;
+    const frameCount = isDataset
+      ? (marketplaceDataset as SyntheticDataset).frameCount
+      : (marketplaceScene as MarketplaceScene).frameCount;
     const deliverables = marketplaceItem.deliverables || [];
     const randomizers = (marketplaceDataset as SyntheticDataset | undefined)
       ?.randomizerScripts;
@@ -150,7 +150,7 @@ export default function EnvironmentDetail({ params }: EnvironmentDetailProps) {
       ?.interactions;
     const quantityLabel = isDataset
       ? `${(marketplaceDataset as SyntheticDataset).sceneCount} scenes`
-      : `${(variantCount ?? 1)} variants`;
+      : `${(frameCount ?? 1)} frames`;
     const priceLabel = isDataset ? "/scene" : "";
     const bundleTotal = isDataset
       ? ((marketplaceDataset as SyntheticDataset).pricePerScene || 0) *
@@ -224,8 +224,8 @@ export default function EnvironmentDetail({ params }: EnvironmentDetailProps) {
                 <div className="mt-2 text-sm font-medium text-zinc-900">
                   {quantityLabel}
                 </div>
-                {variantCount ? (
-                  <div className="text-xs text-zinc-500">{variantCount} variants</div>
+                {frameCount ? (
+                  <div className="text-xs text-zinc-500">{frameCount} frames</div>
                 ) : null}
               </div>
               <div className="rounded-2xl border border-zinc-200 bg-white p-4">

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -42,7 +42,7 @@
 //       "Daily synthetic dataset drops with plug-and-play USD, randomizer scripts, and policy validation notes.",
 //     bullets: [
 //       "Filter by policy, object coverage, and facility archetype",
-//       "Variants + scripting so labs can train without touching pipelines",
+//       "Frames + scripting so labs can train without touching pipelines",
 //       "Pricing starts around $50/scene depending on scale",
 //     ],
 //     ctaLabel: "Browse drops",
@@ -79,7 +79,7 @@
 //             <p className="max-w-xl text-lg text-slate-600">
 //               High-fidelity scenes, physics-clean assets, delivered fast. Pick
 //               from our synthetic marketplace—new datasets publish daily with
-//               variants, randomizers, and plug-and-play USD—or send us to your
+//               frames, randomizers, and plug-and-play USD—or send us to your
 //               actual site and we’ll return a SimReady digital twin tuned to your
 //               deployment stack. Either path keeps labs out of DCC tools so they
 //               can focus on training and proving ROI sooner.
@@ -178,7 +178,7 @@
 //             </h2>
 //             <p className="mt-2 max-w-2xl text-sm text-slate-600">
 //               Here’s a peek at today’s drops. Filter every dataset by policy,
-//               location type, objects, variants, and cadence in the full
+//               location type, objects, frames, and cadence in the full
 //               marketplace.
 //             </p>
 //           </div>
@@ -234,9 +234,9 @@
 //                     </dd>
 //                   </div>
 //                   <div>
-//                     <dt className="uppercase tracking-[0.2em]">Variants</dt>
+//                     <dt className="uppercase tracking-[0.2em]">Frames</dt>
 //                     <dd className="text-base font-semibold text-slate-900">
-//                       {dataset.variantCount}
+//                       {dataset.frameCount}
 //                     </dd>
 //                   </div>
 //                 </dl>
@@ -272,7 +272,7 @@
 //             </h2>
 //             <p className="mt-2 max-w-xl text-sm text-slate-600">
 //               Use these archetypes to anchor your wishlist or capture brief. We
-//               keep releasing variants that span aisle widths, heights, and
+//               keep releasing frames that span aisle widths, heights, and
 //               policy complexity so your models see the long tail.
 //             </p>
 //           </div>
@@ -464,7 +464,7 @@ const offeringCards = [
       "Daily synthetic dataset drops with plug-and-play USD, randomizer scripts, and policy validation notes.",
     bullets: [
       "Filter by policy, object coverage, and facility archetype",
-      "Variants + scripting so labs can train without touching pipelines",
+      "Frames + scripting so labs can train without touching pipelines",
       "Pricing starts around $50/scene depending on scale",
     ],
     ctaLabel: "Browse drops",
@@ -793,10 +793,10 @@ export default function Home() {
                   </div>
                   <div className="text-center border-l border-zinc-200">
                     <dt className="text-[10px] uppercase tracking-wider text-zinc-400">
-                      Vars
+                      Frames
                     </dt>
                     <dd className="font-mono text-sm font-semibold text-zinc-900">
-                      {dataset.variantCount}
+                      {dataset.frameCount}
                     </dd>
                   </div>
                 </div>
@@ -825,7 +825,7 @@ export default function Home() {
               Environment families
             </h2>
             <p className="mt-2 max-w-xl text-zinc-600">
-              Archetypes to anchor your wishlist. We keep releasing variants
+              Archetypes to anchor your wishlist. We keep releasing frames
               that span aisle widths, heights, and policy complexity.
             </p>
           </div>


### PR DESCRIPTION
Change user-facing copy to use the correct term 'frame(s)' instead of 'variant(s)' when referring to different scene scenarios/configurations per base scene. This aligns with the Replicator terminology where each frame represents a unique scene variation with different object positions, lighting, materials, etc.

Changes:
- Rename variantCount → frameCount in type definitions and data
- Update UI labels from "Vars" to "Frames"
- Update descriptive text (e.g., "releasing frames that span...")
- Update feature highlights (e.g., "lighting frames", "scenario frames")