### PR TITLE
Add Scene Recipes offering and request handling

### DIFF
--- a/client/src/components/site/ContactForm.tsx
+++ b/client/src/components/site/ContactForm.tsx
@@ -999,6 +999,14 @@ const requestOptions = [
     recommended: false,
   },
   {
+    value: "recipe" as const,
+    label: "Scene Recipes",
+    icon: <Layers className="h-6 w-6" />,
+    description:
+      "USD layer + manifest + Replicator randomizer that assembles NVIDIA SimReady packs you install locally.",
+    recommended: false,
+  },
+  {
     value: "snapshot" as const,
     label: "Reference Photo Rebuild",
     icon: <Camera className="h-6 w-6" />,
@@ -1121,7 +1129,7 @@ const deriveQuote = (analysis: SnapshotAnalysis | null) => {
   return clampQuote(analysis.suggestedQuote ?? inferred);
 };
 
-type RequestType = "dataset" | "scene" | "snapshot";
+type RequestType = "dataset" | "scene" | "snapshot" | "recipe";
 
 const defaultRequestType: RequestType = SHOW_REAL_WORLD_CAPTURE
   ? "scene"
@@ -1134,7 +1142,12 @@ const getInitialRequestType = (): RequestType => {
 
   const params = new URLSearchParams(window.location.search);
   const requested = params.get("request");
-  const allowedRequests: RequestType[] = ["dataset", "scene", "snapshot"];
+  const allowedRequests: RequestType[] = [
+    "dataset",
+    "scene",
+    "snapshot",
+    "recipe",
+  ];
 
   if (requested && allowedRequests.includes(requested as RequestType)) {
     if (!SHOW_REAL_WORLD_CAPTURE && requested === "scene") {
@@ -1656,6 +1669,96 @@ export function ContactForm() {
               />
             </div>
           </section>
+        ) : requestType === "recipe" ? (
+          <section className="mb-12 space-y-6 animate-in fade-in slide-in-from-bottom-4 duration-500">
+            <div className="flex flex-col gap-3 border-b border-zinc-100 pb-4">
+              <div className="flex items-center gap-3">
+                <div className="flex h-10 w-10 items-center justify-center rounded-full bg-emerald-100 text-emerald-700">
+                  <Layers className="h-4 w-4" />
+                </div>
+                <div>
+                  <h4 className="text-xs font-bold uppercase tracking-[0.35em] text-emerald-700">
+                    Scene Recipe Brief
+                  </h4>
+                  <p className="text-sm text-zinc-600">
+                    Tell us which SimReady packs you have and the layout + semantics you need. We ship a USD layer, manifest, and Replicator variants.
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            <div className="grid gap-6 md:grid-cols-2">
+              <div className="space-y-2">
+                <label className="text-xs font-bold text-zinc-500 uppercase tracking-wider">
+                  SimReady packs on hand
+                </label>
+                <input
+                  name="recipePacks"
+                  placeholder="e.g. Furniture & Misc, Containers, Warehouse"
+                  className="w-full rounded-xl border border-zinc-200 bg-zinc-50 px-4 py-3 text-sm focus:border-emerald-500 focus:ring-emerald-500/20"
+                />
+              </div>
+              <div className="space-y-2">
+                <label className="text-xs font-bold text-zinc-500 uppercase tracking-wider">
+                  Asset root paths
+                </label>
+                <input
+                  name="recipeAssetRoots"
+                  placeholder="Local/Nucleus mount paths we should reference"
+                  className="w-full rounded-xl border border-zinc-200 bg-zinc-50 px-4 py-3 text-sm focus:border-emerald-500 focus:ring-emerald-500/20"
+                />
+              </div>
+            </div>
+
+            <div className="grid gap-6 md:grid-cols-2">
+              <div className="space-y-2">
+                <label className="text-xs font-bold text-zinc-500 uppercase tracking-wider">
+                  Layout + semantics to cover
+                </label>
+                <textarea
+                  name="recipeBrief"
+                  rows={3}
+                  placeholder="Describe the room shell, prim hierarchy expectations, labels, and physics requirements."
+                  className="w-full rounded-xl border border-zinc-200 bg-zinc-50 px-4 py-3 text-sm focus:border-emerald-500 focus:ring-emerald-500/20"
+                />
+              </div>
+              <div className="space-y-2">
+                <label className="text-xs font-bold text-zinc-500 uppercase tracking-wider">
+                  Variant generator needs
+                </label>
+                <textarea
+                  name="recipeVariants"
+                  rows={3}
+                  placeholder="Object swaps, clutter placement, HDRI/time-of-day, material variants, articulation states, etc."
+                  className="w-full rounded-xl border border-zinc-200 bg-zinc-50 px-4 py-3 text-sm focus:border-emerald-500 focus:ring-emerald-500/20"
+                />
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <span className="text-xs font-bold text-emerald-700 uppercase tracking-wider">
+                Delivery expectation
+              </span>
+              <div className="grid gap-3 sm:grid-cols-2">
+                <div className="rounded-xl border border-emerald-100 bg-emerald-50 p-4 text-sm text-zinc-700">
+                  <p className="font-semibold text-zinc-900">We ship:</p>
+                  <ul className="mt-2 space-y-1 list-disc pl-4">
+                    <li>USD layer (.usda recommended)</li>
+                    <li>Manifest (JSON/YAML)</li>
+                    <li>Replicator randomizer</li>
+                  </ul>
+                </div>
+                <div className="rounded-xl border border-emerald-100 bg-white p-4 text-sm text-zinc-700">
+                  <p className="font-semibold text-zinc-900">You provide:</p>
+                  <ul className="mt-2 space-y-1 list-disc pl-4">
+                    <li>SimReady packs + asset roots</li>
+                    <li>Integration target (Isaac Lab/Sim)</li>
+                    <li>Any QA constraints</li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </section>
         ) : requestType === "snapshot" ? (
           <section className="mb-12 space-y-6 animate-in fade-in slide-in-from-bottom-4 duration-500">
             <div className="flex flex-col gap-3 border-b border-zinc-100 pb-4">
@@ -2069,7 +2172,7 @@ export function ContactForm() {
             </div>
           </div>
 
-          {requestType === "dataset" && (
+          {(requestType === "dataset" || requestType === "recipe") && (
             <div className="space-y-3">
               <span className="text-xs font-bold text-zinc-500 uppercase tracking-wider">
                 Environment Types

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -472,6 +472,20 @@ const offeringCards = [
     icon: <LayoutGrid className="h-8 w-8 text-zinc-900" />,
   },
   {
+    title: "Scene Recipes",
+    badge: "Layouts + Variants",
+    description:
+      "Lightweight USD layers, manifests, and Replicator scripts that assemble NVIDIA SimReady packs without shipping assets.",
+    bullets: [
+      "Room shells, prim hierarchy, semantics, and physics defaults",
+      "Manifest for SimReady packs + asset fallbacks you install locally",
+      "Variant generator for swaps, clutter, lighting, and articulation states",
+    ],
+    ctaLabel: "Request a recipe",
+    ctaHref: "/contact?request=recipe",
+    icon: <Terminal className="h-8 w-8 text-zinc-900" />,
+  },
+  {
     title: "Reference Photo Reconstruction",
     badge: "Exclusive",
     description:

--- a/client/src/pages/Solutions.tsx
+++ b/client/src/pages/Solutions.tsx
@@ -243,6 +243,24 @@ const onsiteSteps = [
   },
 ];
 
+const recipeDeliverables = [
+  {
+    icon: <FileCode className="h-5 w-5 text-indigo-600" />,
+    title: "USD recipe layer",
+    desc: "Room shell, prim hierarchy, transforms, semantics, and physics defaults in a lightweight .usda layer.",
+  },
+  {
+    icon: <FileJson className="h-5 w-5 text-indigo-600" />,
+    title: "Dependency manifest",
+    desc: "References to required NVIDIA SimReady packs, expected root paths, and fallbacks so you install assets locally.",
+  },
+  {
+    icon: <Terminal className="h-5 w-5 text-indigo-600" />,
+    title: "Variant generator",
+    desc: "Omniverse Replicator scripts for swaps, clutter, lighting, material variants, and articulation state noise.",
+  },
+];
+
 // --- Visual Helpers ---
 
 function DotPattern() {
@@ -431,6 +449,69 @@ export default function Solutions() {
                     </div>
                   </div>
                 ))}
+              </div>
+            </div>
+          </section>
+
+          {/* --- Section: Scene Recipes --- */}
+          <section className="relative overflow-hidden rounded-[2.5rem] border border-emerald-100 bg-white p-8 shadow-sm sm:p-12 lg:p-16">
+            <div className="absolute -right-16 -bottom-16 h-64 w-64 rounded-full bg-emerald-100/60 blur-3xl" />
+            <div className="relative z-10 grid gap-12 lg:grid-cols-[1.1fr_0.9fr] lg:items-center">
+              <div className="space-y-6">
+                <div className="inline-flex items-center gap-2 rounded-md bg-emerald-50 px-2 py-1 text-xs font-bold uppercase tracking-wider text-emerald-700">
+                  <Terminal className="h-3 w-3" /> Scene Recipes
+                </div>
+                <h2 className="text-3xl font-bold text-zinc-900 sm:text-4xl">
+                  Layouts, manifests, and variants—BYO SimReady assets.
+                </h2>
+                <p className="text-zinc-600 leading-relaxed">
+                  We deliver a lightweight USD layer plus a manifest that references NVIDIA SimReady packs you install locally. Omniverse Replicator scripts handle swaps, clutter, lighting, and articulation state randomization without us shipping the source assets.
+                </p>
+                <ul className="grid gap-3 text-sm text-zinc-700 sm:grid-cols-2">
+                  {["No asset redistribution—packs stay on your Nucleus/local disk", "Semantics + USDPhysics defaults aligned to SimReady best practices", "Variant generator tuned for RL-friendly randomization", "Reusable integration snippets for Isaac Lab / Isaac Sim"].map(
+                    (item) => (
+                      <li
+                        key={item}
+                        className="flex items-start gap-2 rounded-xl bg-emerald-50/80 p-3 ring-1 ring-emerald-100"
+                      >
+                        <span className="mt-1 h-2 w-2 rounded-full bg-emerald-500" />
+                        <span>{item}</span>
+                      </li>
+                    ),
+                  )}
+                </ul>
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+                  <a
+                    href="/contact?request=recipe"
+                    className="inline-flex items-center justify-center rounded-full bg-emerald-600 px-5 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-700"
+                  >
+                    Request a scene recipe
+                  </a>
+                  <span className="text-xs uppercase tracking-[0.2em] text-emerald-600">
+                    BYO SimReady packs
+                  </span>
+                </div>
+              </div>
+
+              <div className="grid gap-4 rounded-2xl border border-emerald-100 bg-emerald-50/60 p-6 sm:grid-cols-2">
+                {recipeDeliverables.map((item) => (
+                  <div
+                    key={item.title}
+                    className="flex h-full flex-col gap-2 rounded-xl border border-emerald-100 bg-white p-4 shadow-sm"
+                  >
+                    <div className="flex items-center gap-2 text-emerald-700">
+                      {item.icon}
+                      <span className="text-sm font-bold uppercase tracking-wider">{item.title}</span>
+                    </div>
+                    <p className="text-sm text-zinc-600 leading-relaxed">{item.desc}</p>
+                  </div>
+                ))}
+                <div className="col-span-full rounded-xl border border-emerald-100 bg-white p-5">
+                  <p className="text-xs font-bold uppercase tracking-[0.25em] text-emerald-700">Variant knobs</p>
+                  <p className="mt-2 text-sm text-zinc-700">
+                    Replicator randomizes object swaps, clutter placement, HDRI/time-of-day, material variants, and pose noise. We keep USD writes optional for RL loops.
+                  </p>
+                </div>
               </div>
             </div>
           </section>

--- a/server/routes/contact.ts
+++ b/server/routes/contact.ts
@@ -20,6 +20,10 @@ export default async function contactHandler(req: Request, res: Response) {
     sceneQuantity,
     sceneDeliveryDate,
     isaacVersion,
+    recipePacks,
+    recipeAssetRoots,
+    recipeBrief,
+    recipeVariants,
     useCases,
     robotPlatform,
     requiredSemantics,
@@ -72,9 +76,15 @@ export default async function contactHandler(req: Request, res: Response) {
   ];
 
   if (requestType) {
-    summaryLines.push(
-      `Request type: ${requestType === "scene" ? "Specific scene" : "Dataset program"}`,
-    );
+    const requestLabel =
+      requestType === "scene"
+        ? "Specific scene"
+        : requestType === "dataset"
+          ? "Dataset program"
+          : requestType === "recipe"
+            ? "Scene recipe"
+            : "Reference photo rebuild";
+    summaryLines.push(`Request type: ${requestLabel}`);
   }
 
   if (requestType === "dataset") {
@@ -97,6 +107,21 @@ export default async function contactHandler(req: Request, res: Response) {
     }
     if (isaacVersion) {
       summaryLines.push(`Isaac version: ${isaacVersion}`);
+    }
+  }
+
+  if (requestType === "recipe") {
+    if (recipePacks) {
+      summaryLines.push(`SimReady packs: ${recipePacks}`);
+    }
+    if (recipeAssetRoots) {
+      summaryLines.push(`Asset roots: ${recipeAssetRoots}`);
+    }
+    if (recipeBrief) {
+      summaryLines.push(`Layout + semantics: ${recipeBrief}`);
+    }
+    if (recipeVariants) {
+      summaryLines.push(`Variant generator: ${recipeVariants}`);
     }
   }
 


### PR DESCRIPTION
## Summary
- add Scene Recipes as a core offering across the home and solutions pages with clear deliverables and CTA
- introduce Scene Recipes as a contact form option with tailored brief fields and routing support
- extend contact email handler to capture Scene Recipes-specific details

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69386583dee88329b960cf3634d7a970)