### PR TITLE
Add task logic coverage across SimReady offerings

### DIFF
--- a/client/src/pages/Environments.tsx
+++ b/client/src/pages/Environments.tsx
@@ -284,8 +284,9 @@ export default function Environments() {
               <p className="mt-6 max-w-2xl text-lg text-zinc-600">
                 Daily drops of synthetic scenes authored for Isaac-ready
                 training. Each dataset includes randomizer scripts, USD
-                packages, and validation notes so you can train without touching
-                the pipeline.
+                packages, task logic (actions, observations, rewards, resets,
+                parallel env defaults), and validation notes so you can train
+                without touching the pipeline.
               </p>
             </div>
           </div>

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -465,6 +465,7 @@ const offeringCards = [
     bullets: [
       "Filter by policy, object coverage, and facility archetype",
       "Frames + scripting so labs can train without touching pipelines",
+      "Task logic included: actions, observations, rewards, resets, and parallel env configs",
       "Pricing starts around $50/scene depending on scale",
     ],
     ctaLabel: "Browse drops",
@@ -479,6 +480,7 @@ const offeringCards = [
     bullets: [
       "Room shells, prim hierarchy, semantics, and physics defaults",
       "Manifest for SimReady packs + asset fallbacks you install locally",
+      "Task logic scaffolds (actions, observations, rewards, resets) tuned for vectorized RL",
       "Variant generator for swaps, clutter, lighting, and articulation states",
     ],
     ctaLabel: "Request a recipe",
@@ -493,6 +495,7 @@ const offeringCards = [
     bullets: [
       "Submit a kitchen, aisle, lab, or other covered archetype",
       "We author USD/URDF handoff with QA against your use cases",
+      "Task logic delivered alongside geometry so your policy can train immediately",
       "Exclusive access by default; opt into open catalog if you prefer",
     ],
     ctaLabel: "Upload a photo",

--- a/client/src/pages/Recipes.tsx
+++ b/client/src/pages/Recipes.tsx
@@ -65,6 +65,9 @@ export default function Recipes() {
             <p className="text-lg leading-relaxed text-zinc-600">
               Browse base layouts that ship as <code className="rounded bg-zinc-100 px-1.5 py-0.5 text-sm font-semibold text-zinc-800">.usda</code> layers, dependency manifests, and Omniverse Replicator randomizers. Labs install NVIDIA SimReady packs locally—we only deliver the recipe, semantics, and QA harness.
             </p>
+            <p className="text-base leading-relaxed text-zinc-700">
+              Task logic ships with every recipe: action/observation wiring, reward terms, termination + reset rules, and default parallel env counts so you get a trainable MDP alongside the geometry.
+            </p>
             <div className="flex flex-wrap gap-3 text-sm text-zinc-700">
               <span className="inline-flex items-center gap-2 rounded-full bg-white px-3 py-2 shadow-sm ring-1 ring-zinc-200">
                 <Package className="h-4 w-4 text-emerald-600" /> BYO SimReady asset packs


### PR DESCRIPTION
## Summary
- highlight included task-logic components (actions, observations, rewards, resets) on marketplace datasets
- call out task-logic scaffolding on scene recipes
- clarify reference photo reconstructions also ship with trainable task logic

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693885312c64832989321e4aa6e0a63e)