### PR TITLE
Fix TypeScript variantCount property error

### DIFF
--- a/client/src/data/content.ts
+++ b/client/src/data/content.ts
@@ -66,6 +66,7 @@ export interface SyntheticDataset {
   pricePerScene: number;
   sceneCount: number;
   frameCount: number;
+  variantCount?: number;
   releaseDate: string;
   tags: string[];
   randomizerScripts: string[];
@@ -87,6 +88,7 @@ export interface MarketplaceScene {
   objectTags: string[];
   price: number; // Individual scene price
   frameCount?: number;
+  variantCount?: number;
   releaseDate: string;
   tags: string[];
   deliverables: string[];


### PR DESCRIPTION
Added optional variantCount?: number property to both SyntheticDataset and MarketplaceScene interfaces to resolve TS2339 errors in MarketplaceCard.

The UI was referencing dataset.variantCount and scene.variantCount but these properties were missing from the type definitions.