### PR TITLE
Fix login page not displaying content

### DIFF
--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -7,6 +7,7 @@ import { queryClient } from "./lib/queryClient";
 import { Toaster } from "@/components/ui/toaster";
 import { SiteLayout } from "./components/site/SiteLayout";
 import { LoadingScreen } from "./components/site/LoadingScreen";
+import { AuthProvider } from "./contexts/AuthContext";
 
 const Home = lazy(() => import("./pages/Home"));
 const Environments = lazy(() => import("./pages/Environments"));
@@ -59,8 +60,10 @@ function Router() {
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
-      <Router />
-      <Toaster />
+      <AuthProvider>
+        <Router />
+        <Toaster />
+      </AuthProvider>
     </QueryClientProvider>
   </StrictMode>,
 );


### PR DESCRIPTION
The Login page uses useAuth() hook which requires AuthProvider context. Without it, the component throws an error and renders nothing.