### PR TITLE
Debug website not displaying after recent changes

### DIFF
--- a/client/src/contexts/AuthContext.tsx
+++ b/client/src/contexts/AuthContext.tsx
@@ -375,8 +375,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   };
 
   return (
-    <AuthContext.Provider value={value}>
-      {!loading && children}
-    </AuthContext.Provider>
+    <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
   );
 }


### PR DESCRIPTION
The AuthProvider was blocking all children from rendering until Firebase auth finished initializing with `{!loading && children}`. This caused the entire site to be blank during auth loading. Components that need auth state can handle loading individually via useAuth().