### PR TITLE
Understand paper on scene generation output

### DIFF
--- a/client/src/components/site/MarketplaceCard.tsx
+++ b/client/src/components/site/MarketplaceCard.tsx
@@ -239,20 +239,20 @@ export function MarketplaceCard({ item, type }: MarketplaceCardProps) {
               </div>
               <div>
                 <div className="text-[10px] uppercase tracking-wider text-zinc-500">
-                  Variants
+                  Frames
                 </div>
                 <div className="font-mono text-sm font-semibold text-zinc-900">
-                  {dataset!.variantCount}
+                  {dataset!.frameCount?.toLocaleString()}
                 </div>
               </div>
             </>
           ) : (
             <div>
               <div className="text-[10px] uppercase tracking-wider text-zinc-500">
-                Variants
+                Frames
               </div>
               <div className="font-mono text-sm font-semibold text-zinc-900">
-                {scene!.variantCount || 1}
+                {(scene!.frameCount || 1000).toLocaleString()}
               </div>
             </div>
           )}

--- a/client/src/data/content.ts
+++ b/client/src/data/content.ts
@@ -66,7 +66,6 @@ export interface SyntheticDataset {
   pricePerScene: number;
   sceneCount: number;
   frameCount: number;
-  variantCount?: number;
   releaseDate: string;
   tags: string[];
   randomizerScripts: string[];
@@ -88,7 +87,6 @@ export interface MarketplaceScene {
   objectTags: string[];
   price: number; // Individual scene price
   frameCount?: number;
-  variantCount?: number;
   releaseDate: string;
   tags: string[];
   deliverables: string[];
@@ -111,7 +109,7 @@ export interface SceneRecipe {
   policySlugs: string[];
   requiredPacks: string[];
   usdLayers: string[];
-  variantCoverage: string[];
+  domainRandomization: string[];
   deliverables: string[];
   heroImage: string;
   tags: string[];
@@ -323,7 +321,7 @@ export const syntheticDatasets: SyntheticDataset[] = [
     pricePerScene: 65,
     standardPricePerScene: 185,
     sceneCount: 150,
-    frameCount: 8,
+    frameCount: 1500,
     releaseDate: "2024-12-12",
     tags: ["Articulated", "Plug & Play", "USD"],
     randomizerScripts: [
@@ -348,7 +346,7 @@ export const syntheticDatasets: SyntheticDataset[] = [
     pricePerScene: 58,
     standardPricePerScene: 175,
     sceneCount: 110,
-    frameCount: 6,
+    frameCount: 1200,
     releaseDate: "2024-12-05",
     tags: ["Retail", "High SKU", "Randomized"],
     randomizerScripts: ["SKU swaps", "Cart clutter", "Lighting color temp"],
@@ -368,7 +366,7 @@ export const syntheticDatasets: SyntheticDataset[] = [
     pricePerScene: 72,
     standardPricePerScene: 195,
     sceneCount: 200,
-    frameCount: 10,
+    frameCount: 2000,
     releaseDate: "2024-11-28",
     tags: ["Industrial", "Heavy lift", "Conveyor-ready"],
     randomizerScripts: [
@@ -396,7 +394,7 @@ export const syntheticDatasets: SyntheticDataset[] = [
     pricePerScene: 84,
     standardPricePerScene: 220,
     sceneCount: 65,
-    frameCount: 5,
+    frameCount: 1000,
     releaseDate: "2024-11-22",
     tags: ["Cleanroom", "Controls", "QA"],
     randomizerScripts: ["Gauge offsets", "Cabinet wiring", "Consumable clutter"],
@@ -415,7 +413,7 @@ export const syntheticDatasets: SyntheticDataset[] = [
     pricePerScene: 52,
     standardPricePerScene: 150,
     sceneCount: 90,
-    frameCount: 4,
+    frameCount: 800,
     releaseDate: "2024-11-18",
     tags: ["Inspection", "Low light", "Compact"],
     randomizerScripts: ["Status LEDs", "Valve state", "Dust + grime"],
@@ -434,7 +432,7 @@ export const syntheticDatasets: SyntheticDataset[] = [
     pricePerScene: 50,
     standardPricePerScene: 165,
     sceneCount: 50,
-    frameCount: 3,
+    frameCount: 600,
     releaseDate: "2024-11-12",
     tags: ["Assistive", "Household", "Soft goods"],
     randomizerScripts: ["Fabric types", "Lighting temp", "Clutter"],
@@ -453,7 +451,7 @@ export const marketplaceScenes: MarketplaceScene[] = [
     policySlugs: ["dexterous-pick-place", "articulated-access-validation"],
     objectTags: ["dishwashers", "shelves", "utensils"],
     price: 185,
-    frameCount: 3,
+    frameCount: 750,
     releaseDate: "2024-12-01",
     tags: ["Articulated", "High-detail", "USD"],
     deliverables: ["USD / Isaac 4.x", "Replicator semantics"],
@@ -470,7 +468,7 @@ export const marketplaceScenes: MarketplaceScene[] = [
     policySlugs: ["dexterous-pick-place", "mixed-sku-logistics"],
     objectTags: ["coolers", "shelves", "totes"],
     price: 195,
-    frameCount: 2,
+    frameCount: 600,
     releaseDate: "2024-11-29",
     tags: ["Retail", "Cold storage", "Randomized"],
     deliverables: ["USD", "Synthetic sensor captures"],
@@ -501,7 +499,7 @@ export const marketplaceScenes: MarketplaceScene[] = [
     policySlugs: ["precision-insertion-assembly", "panel-interaction-suite"],
     objectTags: ["sample racks", "valves", "drawers"],
     price: 220,
-    frameCount: 2,
+    frameCount: 500,
     releaseDate: "2024-11-20",
     tags: ["Cleanroom", "Precision", "Controls"],
     deliverables: ["USD", "STEP", "Semantic layers"],
@@ -533,7 +531,7 @@ export const marketplaceScenes: MarketplaceScene[] = [
     policySlugs: ["laundry-folding-assist"],
     objectTags: ["washers", "dryers", "hampers"],
     price: 165,
-    frameCount: 2,
+    frameCount: 500,
     releaseDate: "2024-11-15",
     tags: ["Assistive", "Household"],
     deliverables: ["USD", "URDF"],
@@ -549,7 +547,7 @@ export const marketplaceScenes: MarketplaceScene[] = [
     policySlugs: ["dexterous-pick-place", "articulated-access-validation"],
     objectTags: ["drawers", "utensils", "appliances"],
     price: 170,
-    frameCount: 4,
+    frameCount: 1000,
     releaseDate: "2024-12-08",
     tags: ["Articulated", "USD"],
     deliverables: ["USD / Isaac 4.x", "Isaac 5.x"],
@@ -596,7 +594,7 @@ export const marketplaceScenes: MarketplaceScene[] = [
     policySlugs: ["precision-insertion-assembly"],
     objectTags: ["sample racks", "drawers"],
     price: 210,
-    frameCount: 3,
+    frameCount: 750,
     releaseDate: "2024-11-19",
     tags: ["Precision", "Assembly"],
     deliverables: ["USD", "STEP"],
@@ -642,7 +640,7 @@ export const marketplaceScenes: MarketplaceScene[] = [
     policySlugs: ["dexterous-pick-place"],
     objectTags: ["shelves", "appliances"],
     price: 175,
-    frameCount: 2,
+    frameCount: 500,
     releaseDate: "2024-12-02",
     tags: ["Food service", "Articulated"],
     deliverables: ["USD / Isaac 4.x"],
@@ -658,7 +656,7 @@ export const marketplaceScenes: MarketplaceScene[] = [
     policySlugs: ["dexterous-pick-place", "precision-insertion-assembly"],
     objectTags: ["drawers", "shelves"],
     price: 225,
-    frameCount: 1,
+    frameCount: 500,
     releaseDate: "2024-11-30",
     tags: ["Healthcare", "Precision", "Secure"],
     deliverables: ["USD", "Semantic layers"],
@@ -690,7 +688,7 @@ export const marketplaceScenes: MarketplaceScene[] = [
     policySlugs: ["articulated-access-validation", "panel-interaction-suite"],
     objectTags: ["doors", "switches"],
     price: 200,
-    frameCount: 2,
+    frameCount: 500,
     releaseDate: "2024-11-21",
     tags: ["Cleanroom", "Safety"],
     deliverables: ["USD", "Event scripts"],
@@ -721,7 +719,7 @@ export const marketplaceScenes: MarketplaceScene[] = [
     policySlugs: ["laundry-folding-assist", "articulated-access-validation"],
     objectTags: ["drawers", "hampers"],
     price: 180,
-    frameCount: 3,
+    frameCount: 750,
     releaseDate: "2024-11-13",
     tags: ["Assistive", "Organization"],
     deliverables: ["USD"],
@@ -748,10 +746,10 @@ export const sceneRecipes: SceneRecipe[] = [
       "Prim hierarchy with shelf transforms",
       "USDPhysics defaults & materials",
     ],
-    variantCoverage: [
+    domainRandomization: [
       "SKU swaps + facing randomization",
       "Clutter permutations on support surfaces",
-      "HDRI + time-of-day lighting set",
+      "HDRI + time-of-day lighting (500–2,000 frames/scene)",
     ],
     deliverables: [
       "Lightweight .usda layout",
@@ -780,10 +778,10 @@ export const sceneRecipes: SceneRecipe[] = [
       "Prim hierarchy for totes + pallets",
       "Physics materials for skid/contact surfaces",
     ],
-    variantCoverage: [
+    domainRandomization: [
       "Tote + carton swaps with scale normalization",
       "Spawn density + aisle clutter controls",
-      "HDRI + area light profiles",
+      "HDRI + area light profiles (500–2,000 frames/scene)",
     ],
     deliverables: [
       ".usda lane scaffold",
@@ -812,10 +810,10 @@ export const sceneRecipes: SceneRecipe[] = [
       "Prim hierarchy for drawers/doors",
       "Semantic labels for appliances + props",
     ],
-    variantCoverage: [
+    domainRandomization: [
       "Utensil + smallware swaps",
       "Lighting temperature + intensity",
-      "Pose noise + articulation open/close states",
+      "Pose noise + articulation states (500–2,000 frames/scene)",
     ],
     deliverables: [
       ".usda layout layer",
@@ -844,10 +842,10 @@ export const sceneRecipes: SceneRecipe[] = [
       "Semantic prim graph for racks + valves",
       "USDPhysics colliders on instruments",
     ],
-    variantCoverage: [
+    domainRandomization: [
       "Rack + instrument swaps",
-      "Material swaps for benches + flooring",
-      "Light temperature + intensity sweeps",
+      "Material randomization for benches + flooring",
+      "Light temperature + intensity sweeps (500–2,000 frames/scene)",
     ],
     deliverables: [
       ".usda interface layer",
@@ -875,10 +873,10 @@ export const sceneRecipes: SceneRecipe[] = [
       "Prim hierarchy for breakers/valves",
       "Semantic labeling for components",
     ],
-    variantCoverage: [
+    domainRandomization: [
       "Switchgear + breaker swaps",
-      "Dust/wear material variants",
-      "Spotlight + area light rigs",
+      "Dust/wear material randomization",
+      "Spotlight + area light rigs (500–2,000 frames/scene)",
     ],
     deliverables: [
       ".usda layout",
@@ -907,10 +905,10 @@ export const sceneRecipes: SceneRecipe[] = [
       "Prim graph for hampers + shelving",
       "Physics defaults for cloth + rigid props",
     ],
-    variantCoverage: [
+    domainRandomization: [
       "Garment + hamper swaps",
       "Fold-surface clutter controls",
-      "HDRI + temperature shifts",
+      "HDRI + temperature shifts (500–2,000 frames/scene)",
     ],
     deliverables: [
       "Lightweight .usda layer",

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -474,14 +474,14 @@ const offeringCards = [
   },
   {
     title: "Scene Recipes",
-    badge: "Layouts + Variants",
+    badge: "Layouts + Frames",
     description:
       "Lightweight USD layers, manifests, and Replicator scripts that assemble NVIDIA SimReady packs without shipping assets.",
     bullets: [
       "Room shells, prim hierarchy, semantics, and physics defaults",
       "Manifest for SimReady packs + asset fallbacks you install locally",
       "Task logic scaffolds (actions, observations, rewards, resets) tuned for vectorized RL",
-      "Variant generator for swaps, clutter, lighting, and articulation states",
+      "Frame generator for swaps, clutter, lighting, and articulation states (500–2,000 frames/scene)",
     ],
     ctaLabel: "Request a recipe",
     ctaHref: "/recipes",

--- a/client/src/pages/Recipes.tsx
+++ b/client/src/pages/Recipes.tsx
@@ -231,10 +231,10 @@ export default function Recipes() {
                     </div>
                     <div className="rounded-xl border border-zinc-200 bg-white p-4">
                       <p className="text-xs font-bold uppercase tracking-[0.3em] text-zinc-500">
-                        Variant knobs
+                        Domain randomization
                       </p>
                       <ul className="mt-2 space-y-1 text-sm text-zinc-700">
-                        {recipe.variantCoverage.map((item) => (
+                        {recipe.domainRandomization.map((item) => (
                           <li key={item} className="flex items-start gap-2">
                             <span className="mt-1 h-1.5 w-1.5 rounded-full bg-emerald-600" />
                             <span>{item}</span>

--- a/client/src/pages/Solutions.tsx
+++ b/client/src/pages/Solutions.tsx
@@ -261,8 +261,8 @@ const recipeDeliverables = [
   },
   {
     icon: <Terminal className="h-5 w-5 text-indigo-600" />,
-    title: "Variant generator",
-    desc: "Omniverse Replicator scripts for swaps, clutter, lighting, material variants, and articulation state noise.",
+    title: "Frame generator",
+    desc: "Omniverse Replicator scripts for swaps, clutter, lighting, material randomization, and articulation state noise—typically 500–2,000 frames per scene.",
   },
 ];
 
@@ -488,7 +488,7 @@ export default function Solutions() {
                   <h2 className="text-3xl font-bold text-zinc-900 sm:text-4xl">Where labs plug SimReady packs.</h2>
                   <p className="text-zinc-600 leading-relaxed">
                     SimReady scenes power policy training, perception data engines, and industrial digital twins. The
-                    common thread: teams need consistent semantics, USDPhysics metadata, and stable variants to measure
+                    common thread: teams need consistent semantics, USDPhysics metadata, and stable frame generation to measure
                     generalization.
                   </p>
                   <div className="grid gap-4 sm:grid-cols-2">
@@ -724,13 +724,13 @@ export default function Solutions() {
                   <Terminal className="h-3 w-3" /> Scene Recipes
                 </div>
                 <h2 className="text-3xl font-bold text-zinc-900 sm:text-4xl">
-                  Layouts, manifests, and variants—BYO SimReady assets.
+                  Layouts, manifests, and frame generators—BYO SimReady assets.
                 </h2>
                 <p className="text-zinc-600 leading-relaxed">
                   We deliver a lightweight USD layer plus a manifest that references NVIDIA SimReady packs you install locally. Omniverse Replicator scripts handle swaps, clutter, lighting, and articulation state randomization without us shipping the source assets.
                 </p>
                 <ul className="grid gap-3 text-sm text-zinc-700 sm:grid-cols-2">
-                  {["No asset redistribution—packs stay on your Nucleus/local disk", "Semantics + USDPhysics defaults aligned to SimReady best practices", "Variant generator tuned for RL-friendly randomization", "Reusable integration snippets for Isaac Lab / Isaac Sim"].map(
+                  {["No asset redistribution—packs stay on your Nucleus/local disk", "Semantics + USDPhysics defaults aligned to SimReady best practices", "Frame generator tuned for RL-friendly randomization (500–2,000 frames/scene)", "Reusable integration snippets for Isaac Lab / Isaac Sim"].map(
                     (item) => (
                       <li
                         key={item}
@@ -775,9 +775,9 @@ export default function Solutions() {
                   </div>
                 ))}
                 <div className="col-span-full rounded-xl border border-emerald-100 bg-white p-5">
-                  <p className="text-xs font-bold uppercase tracking-[0.25em] text-emerald-700">Variant knobs</p>
+                  <p className="text-xs font-bold uppercase tracking-[0.25em] text-emerald-700">Frame randomization</p>
                   <p className="mt-2 text-sm text-zinc-700">
-                    Replicator randomizes object swaps, clutter placement, HDRI/time-of-day, material variants, and pose noise. We keep USD writes optional for RL loops.
+                    Replicator randomizes object swaps, clutter placement, HDRI/time-of-day, materials, and pose noise across hundreds of frames. We keep USD writes optional for RL loops.
                   </p>
                 </div>
               </div>


### PR DESCRIPTION
- Update Solutions.tsx: Replace "Variant generator" with "Frame generator", add realistic frame counts (500-2,000 frames/scene)
- Update Home.tsx: Change badge from "Layouts + Variants" to "Layouts + Frames"
- Update content.ts: Rename variantCoverage to domainRandomization, remove unused variantCount field
- Update Recipes.tsx: Change "Variant knobs" label to "Domain randomization"
- Update MarketplaceCard.tsx: Display "Frames" instead of "Variants"
- Update all frame counts to realistic values (500-2,000 per scene)

The term "frames" is the correct robotics industry term for the variations/configurations generated by Omniverse Replicator scripts.