### PR TITLE
Switch from Gemini 2.0 Flash to correct model

### DIFF
--- a/client/src/contexts/LiveAPIContext.jsx
+++ b/client/src/contexts/LiveAPIContext.jsx
@@ -52,7 +52,7 @@ class MultimodalLiveClient extends EventEmitter {
 
         const setupMessage = {
           setup: {
-            model: "models/gemini-2.0-flash-exp",
+            model: "models/gemini-3-flash-preview",
             stream: true,
             generationConfig: {
               responseModalities: ["TEXT", "SPEECH"],

--- a/scripts/match-thumbnails.ts
+++ b/scripts/match-thumbnails.ts
@@ -92,7 +92,7 @@ Respond in this EXACT JSON format:
 }`;
 
   try {
-    const model = genAI.getGenerativeModel({ model: 'gemini-2.0-flash-exp' });
+    const model = genAI.getGenerativeModel({ model: 'gemini-3-flash-preview' });
 
     const result = await model.generateContent([
       prompt,

--- a/server/routes/ai-studio.ts
+++ b/server/routes/ai-studio.ts
@@ -23,7 +23,7 @@ const router = express.Router();
 const DEFAULT_MODEL =
   process.env.GEMINI_STUDIO_MODEL ||
   process.env.GEMINI_FLASH_MODEL ||
-  "gemini-2.5-flash";
+  "gemini-3-flash-preview";
 const FALLBACK_MODEL =
   process.env.GEMINI_STUDIO_FALLBACK_MODEL ||
   process.env.GEMINI_FLASH_FALLBACK_MODEL;


### PR DESCRIPTION
- Update thumbnail matching script to use Gemini 3 Flash
- Update LiveAPIContext WebSocket model to Gemini 3 Flash
- Update AI Studio default model to Gemini 3 Flash

All instances now correctly use gemini-3-flash-preview instead of gemini-2.0-flash-exp or gemini-2.5-flash.