### PR TITLE
Require login before purchase and requests

### DIFF
--- a/client/src/components/site/ContactForm.tsx
+++ b/client/src/components/site/ContactForm.tsx
@@ -977,6 +977,7 @@ import {
   MessageCircle,
 } from "lucide-react";
 import { SUPPORT } from "../pilotCopy";
+import { useRequireAuth } from "@/hooks/useRequireAuth";
 
 // --- Configuration ---
 
@@ -1172,6 +1173,9 @@ const getInitialRequestType = (): RequestType => {
 };
 
 export function ContactForm() {
+  // --- Auth ---
+  const requireAuth = useRequireAuth();
+
   // --- State ---
   const [status, setStatus] = useState<
     "idle" | "loading" | "success" | "error"
@@ -1483,6 +1487,12 @@ export function ContactForm() {
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+
+    // Require authentication before submitting requests
+    if (!requireAuth({ pendingAction: "contact-form-submit" })) {
+      return; // User redirected to login
+    }
+
     const form = event.currentTarget;
 
     const data = new FormData(form);

--- a/client/src/components/site/MarketplaceCard.tsx
+++ b/client/src/components/site/MarketplaceCard.tsx
@@ -4,6 +4,7 @@ import { loadStripe } from "@stripe/stripe-js";
 import { Shield, Package, Sparkles, TrendingUp, ShoppingCart } from "lucide-react";
 import type { SyntheticDataset, MarketplaceScene } from "@/data/content";
 import { useLocation } from "wouter";
+import { useRequireAuth } from "@/hooks/useRequireAuth";
 
 interface MarketplaceCardProps {
   item: SyntheticDataset | MarketplaceScene;
@@ -13,6 +14,7 @@ interface MarketplaceCardProps {
 export function MarketplaceCard({ item, type }: MarketplaceCardProps) {
   const [isRedirecting, setIsRedirecting] = useState(false);
   const [, navigate] = useLocation();
+  const requireAuth = useRequireAuth();
   const isDataset = type === "dataset";
   const dataset = isDataset ? (item as SyntheticDataset) : null;
   const scene = !isDataset ? (item as MarketplaceScene) : null;
@@ -41,6 +43,11 @@ export function MarketplaceCard({ item, type }: MarketplaceCardProps) {
     async (event?: MouseEvent<HTMLButtonElement>) => {
       event?.stopPropagation();
       if (isRedirecting) return;
+
+      // Require authentication before checkout
+      if (!requireAuth({ pendingAction: "marketplace-checkout" })) {
+        return; // User redirected to login
+      }
 
       const checkoutItem = isDataset
         ? {
@@ -120,7 +127,7 @@ export function MarketplaceCard({ item, type }: MarketplaceCardProps) {
         setIsRedirecting(false);
       }
     },
-    [dataset, isDataset, isRedirecting, scene, slug],
+    [dataset, isDataset, isRedirecting, requireAuth, scene, slug],
   );
 
   const handleCardClick = () => {

--- a/client/src/hooks/useRequireAuth.ts
+++ b/client/src/hooks/useRequireAuth.ts
@@ -1,0 +1,114 @@
+import { useCallback } from "react";
+import { useLocation } from "wouter";
+import { useAuth } from "@/contexts/AuthContext";
+
+interface RequireAuthOptions {
+  /** Custom redirect path after login (defaults to current path) */
+  returnTo?: string;
+  /** Action identifier to store for post-login handling */
+  pendingAction?: string;
+  /** Any data to preserve across the auth flow */
+  pendingData?: Record<string, unknown>;
+}
+
+/**
+ * Hook for requiring authentication before performing an action.
+ *
+ * Returns a function that checks if the user is logged in.
+ * If not logged in, it stores the current location and any pending action/data,
+ * then redirects to the login page. After successful login, the user is
+ * redirected back to where they were.
+ *
+ * @example
+ * const requireAuth = useRequireAuth();
+ *
+ * const handleBuy = () => {
+ *   if (!requireAuth({ pendingAction: 'checkout' })) {
+ *     return; // User was redirected to login
+ *   }
+ *   // User is authenticated, proceed with purchase
+ *   processCheckout();
+ * };
+ */
+export function useRequireAuth() {
+  const { currentUser, loading } = useAuth();
+  const [location, setLocation] = useLocation();
+
+  const requireAuth = useCallback(
+    (options: RequireAuthOptions = {}): boolean => {
+      // Still loading auth state - assume not authenticated yet
+      if (loading) {
+        return false;
+      }
+
+      // User is authenticated
+      if (currentUser) {
+        return true;
+      }
+
+      // User is not authenticated - store redirect info and navigate to login
+      const returnPath = options.returnTo || location;
+
+      try {
+        sessionStorage.setItem("redirectAfterAuth", returnPath);
+
+        if (options.pendingAction) {
+          sessionStorage.setItem("pendingAction", options.pendingAction);
+        }
+
+        if (options.pendingData) {
+          sessionStorage.setItem(
+            "pendingData",
+            JSON.stringify(options.pendingData)
+          );
+        }
+      } catch (error) {
+        console.error("Failed to store auth redirect info:", error);
+      }
+
+      // Redirect to login
+      setLocation("/login");
+      return false;
+    },
+    [currentUser, loading, location, setLocation]
+  );
+
+  return requireAuth;
+}
+
+/**
+ * Retrieves and clears any pending action/data stored before auth redirect.
+ * Call this after successful login to resume the user's intended action.
+ */
+export function getPendingAuthAction(): {
+  action: string | null;
+  data: Record<string, unknown> | null;
+} {
+  let action: string | null = null;
+  let data: Record<string, unknown> | null = null;
+
+  try {
+    action = sessionStorage.getItem("pendingAction");
+    const dataStr = sessionStorage.getItem("pendingData");
+    if (dataStr) {
+      data = JSON.parse(dataStr);
+    }
+
+    // Clear after reading
+    sessionStorage.removeItem("pendingAction");
+    sessionStorage.removeItem("pendingData");
+  } catch (error) {
+    console.error("Failed to retrieve pending auth action:", error);
+  }
+
+  return { action, data };
+}
+
+/**
+ * Check if user is authenticated (non-hook version for use in callbacks)
+ */
+export function isAuthenticated(
+  currentUser: ReturnType<typeof useAuth>["currentUser"]
+): boolean {
+  return currentUser !== null;
+}

--- a/client/src/pages/EnvironmentDetail.tsx
+++ b/client/src/pages/EnvironmentDetail.tsx
@@ -10,6 +10,7 @@ import {
 import { InteractionBadges } from "@/components/site/InteractionBadges";
 import { SpecList } from "@/components/site/SpecList";
 import { SceneCard } from "@/components/site/SceneCard";
+import { useRequireAuth } from "@/hooks/useRequireAuth";
 import {
   ArrowLeft,
   Box,
@@ -31,6 +32,7 @@ interface EnvironmentDetailProps {
 
 export default function EnvironmentDetail({ params }: EnvironmentDetailProps) {
   const [isRedirecting, setIsRedirecting] = useState(false);
+  const requireAuth = useRequireAuth();
 
   const marketplaceDataset = syntheticDatasets.find(
     (item) => item.slug === params.slug,
@@ -56,6 +58,11 @@ export default function EnvironmentDetail({ params }: EnvironmentDetailProps) {
 
   const handleCheckout = useCallback(async () => {
     if (!marketplaceItem || isRedirecting) return;
+
+    // Require authentication before checkout
+    if (!requireAuth({ pendingAction: "marketplace-checkout" })) {
+      return; // User redirected to login
+    }
 
     const checkoutItem = isDataset
       ? {
@@ -134,7 +141,7 @@ export default function EnvironmentDetail({ params }: EnvironmentDetailProps) {
     } finally {
       setIsRedirecting(false);
     }
-  }, [detailSlug, isDataset, isRedirecting, marketplaceDataset, marketplaceItem, marketplaceScene]);
+  }, [detailSlug, isDataset, isRedirecting, marketplaceDataset, marketplaceItem, marketplaceScene, requireAuth]);
 
   if (marketplaceItem) {
     const heroImage = isDataset


### PR DESCRIPTION
Add useRequireAuth hook that checks if user is logged in before performing protected actions. When user is not authenticated:
- Stores current location for redirect after login
- Stores pending action identifier in sessionStorage
- Redirects to /login page

Applied to:
- ContactForm: Submit Request requires login
- MarketplaceCard: Buy Bundle/Buy Now requires login
- EnvironmentDetail: Checkout requires login

Users can still browse freely but must sign in to complete purchases or submit requests.