### PR TITLE
Add authentication provider to router

### DIFF
--- a/client/src/contexts/AuthContext.tsx
+++ b/client/src/contexts/AuthContext.tsx
@@ -376,7 +376,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   return (
     <AuthContext.Provider value={value}>
-      {!loading && children}
+      {children}
+      {loading && (
+        <div className="pointer-events-none fixed inset-0 z-50 flex items-center justify-center bg-background/60 backdrop-blur-sm">
+          <div className="h-10 w-10 animate-spin rounded-full border-4 border-primary/30 border-t-primary" />
+        </div>
+      )}
     </AuthContext.Provider>
   );
 }

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -7,6 +7,7 @@ import { queryClient } from "./lib/queryClient";
 import { Toaster } from "@/components/ui/toaster";
 import { SiteLayout } from "./components/site/SiteLayout";
 import { LoadingScreen } from "./components/site/LoadingScreen";
+import { AuthProvider } from "./contexts/AuthContext";
 
 const Home = lazy(() => import("./pages/Home"));
 const Environments = lazy(() => import("./pages/Environments"));
@@ -59,8 +60,10 @@ function Router() {
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
-      <Router />
-      <Toaster />
+      <AuthProvider>
+        <Router />
+        <Toaster />
+      </AuthProvider>
     </QueryClientProvider>
   </StrictMode>,
 );


### PR DESCRIPTION
- Wrap Router and Toaster in AuthProvider to ensure auth context is always available for hooks
- Update AuthProvider to render children immediately with lightweight loading overlay instead of conditional rendering
- Redirect-after-auth logic continues to use sessionStorage.redirectAfterAuth