### PR TITLE
Hide recipes from solutions and offerings

### DIFF
--- a/client/src/components/site/Header.tsx
+++ b/client/src/components/site/Header.tsx
@@ -4,7 +4,7 @@ import { Menu, X } from "lucide-react";
 
 const navLinks = [
   { href: "/environments", label: "Environments" },
-  { href: "/recipes", label: "Scene Recipes" },
+  // { href: "/recipes", label: "Scene Recipes" }, // Hidden: recipes temporarily removed from offerings
   { href: "/solutions", label: "Solutions" },
   { href: "/docs", label: "Docs" },
   { href: "/portal", label: "Portal" },

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -10,7 +10,7 @@ import { LoadingScreen } from "./components/site/LoadingScreen";
 
 const Home = lazy(() => import("./pages/Home"));
 const Environments = lazy(() => import("./pages/Environments"));
-const Recipes = lazy(() => import("./pages/Recipes"));
+// const Recipes = lazy(() => import("./pages/Recipes")); // Hidden: recipes temporarily removed from offerings
 const EnvironmentDetail = lazy(() => import("./pages/EnvironmentDetail"));
 const Solutions = lazy(() => import("./pages/Solutions"));
 const Docs = lazy(() => import("./pages/Docs"));
@@ -36,7 +36,7 @@ function Router() {
       <Switch>
         <Route path="/" component={withLayout(Home)} />
         <Route path="/environments" component={withLayout(Environments)} />
-        <Route path="/recipes" component={withLayout(Recipes)} />
+        {/* <Route path="/recipes" component={withLayout(Recipes)} /> */}{/* Hidden: recipes temporarily removed from offerings */}
         <Route
           path="/environments/:slug"
           component={withLayout(EnvironmentDetail)}

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -518,9 +518,14 @@ const offeringCards = [
   },
 ];
 
-const visibleOfferingCards = SHOW_REAL_WORLD_CAPTURE
-  ? offeringCards
-  : offeringCards.filter((card) => card.title !== "Real-world Capture");
+// Hidden: Scene Recipes temporarily removed from offerings (will be added back later)
+const SHOW_SCENE_RECIPES = false;
+
+const visibleOfferingCards = offeringCards.filter((card) => {
+  if (!SHOW_REAL_WORLD_CAPTURE && card.title === "Real-world Capture") return false;
+  if (!SHOW_SCENE_RECIPES && card.title === "Scene Recipes") return false;
+  return true;
+});
 
 // --- Helper Components ---
 

--- a/client/src/pages/Solutions.tsx
+++ b/client/src/pages/Solutions.tsx
@@ -207,6 +207,7 @@ import {
 // --- Configuration ---
 
 const SHOW_REAL_WORLD_CAPTURE = false;
+const SHOW_SCENE_RECIPES = false; // Hidden: recipes temporarily removed from offerings (will be added back later)
 
 const proceduralSteps = [
   {
@@ -865,6 +866,7 @@ export default function Solutions() {
           </section>
 
           {/* --- Section: Scene Recipes --- */}
+          {SHOW_SCENE_RECIPES && (
           <section className="relative overflow-hidden rounded-[2.5rem] border border-emerald-100 bg-white p-8 shadow-sm sm:p-12 lg:p-16">
             <div className="absolute -right-16 -bottom-16 h-64 w-64 rounded-full bg-emerald-100/60 blur-3xl" />
             <div className="relative z-10 grid gap-12 lg:grid-cols-[1.1fr_0.9fr] lg:items-center">
@@ -932,6 +934,7 @@ export default function Solutions() {
               </div>
             </div>
           </section>
+          )}
 
           {/* --- Section: Reference Photo Reconstruction --- */}
           <section className="relative overflow-hidden rounded-[2.5rem] border border-indigo-100 bg-white p-8 shadow-sm sm:p-12 lg:p-16">


### PR DESCRIPTION
Temporarily remove recipes from offerings while keeping the code for later re-enablement:
- Remove Scene Recipes from header navigation
- Filter out Scene Recipes card from Home page offerings
- Wrap Scene Recipes section in Solutions page with conditional
- Comment out /recipes route in main.tsx

All changes use feature flags (SHOW_SCENE_RECIPES) for easy re-enablement.