### PR TITLE
Fix missing Recipes references in ContactForm

### DIFF
--- a/client/src/components/site/ContactForm.tsx
+++ b/client/src/components/site/ContactForm.tsx
@@ -1018,8 +1018,8 @@ const requestOptions = [
 ];
 
 const visibleRequestOptions = SHOW_REAL_WORLD_CAPTURE
-  ? requestOptions
-  : requestOptions.filter((option) => option.value !== "scene");
+  ? requestOptions.filter((option) => option.value !== "recipe")
+  : requestOptions.filter((option) => option.value !== "scene" && option.value !== "recipe");
 
 const datasetTiers = [
   {


### PR DESCRIPTION
Filter out the "recipe" option from visibleRequestOptions to hide the Scene Recipes card from the contact form, consistent with the previous PR that hid Recipes references elsewhere.