### PR TITLE
Capture contact form requests and document Firebase configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+VITE_FIREBASE_API_KEY=AIzaSyAbIZbjsG9daPQYfpTFCUHWSzqHAfgjI
+VITE_FIREBASE_AUTH_DOMAIN=blueprint-8c1ca.firebaseapp.com
+VITE_FIREBASE_PROJECT_ID=blueprint-8c1ca
+VITE_FIREBASE_STORAGE_BUCKET=blueprint-8c1ca.appspot.com
+VITE_FIREBASE_MESSAGING_SENDER_ID=744608654760
+VITE_FIREBASE_APP_ID=1:744608654760:web:5b697e80345ac2b0f4a99d
+VITE_FIREBASE_DATABASE_URL=https://blueprint-8c1ca-default-rtdb.firebaseio.com
+VITE_FIREBASE_MEASUREMENT_ID=G-7LHTQSRF9L
+
+# Service account configuration for server-side Firebase Admin access.
+# Provide either the JSON stringified credentials or a path to the key file.
+# FIREBASE_SERVICE_ACCOUNT_JSON='{"type":"service_account","project_id":"..."}'
+# GOOGLE_APPLICATION_CREDENTIALS=/absolute/path/to/service-account.json

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -2,6 +2,24 @@
 
 There is an issue with the default build script in `package.json` that contains an invalid esbuild flag `--no-check`. This flag is causing deployment failures. We've provided several solutions to fix this issue.
 
+## Firebase configuration (frontend + server)
+
+Set the Firebase web config and Admin credentials in your deployment secrets before building:
+
+- Copy the values from `.env.example` into your hosting/CI secrets using the exact Vite keys expected by `client/src/lib/firebase.ts`:
+  - `VITE_FIREBASE_API_KEY`
+  - `VITE_FIREBASE_AUTH_DOMAIN`
+  - `VITE_FIREBASE_PROJECT_ID`
+  - `VITE_FIREBASE_STORAGE_BUCKET`
+  - `VITE_FIREBASE_MESSAGING_SENDER_ID`
+  - `VITE_FIREBASE_APP_ID`
+  - Optional: `VITE_FIREBASE_DATABASE_URL`, `VITE_FIREBASE_MEASUREMENT_ID`
+- Provide Admin credentials for server routes that use `client/src/lib/firebaseAdmin.ts`:
+  - `FIREBASE_SERVICE_ACCOUNT_JSON` (stringified JSON) **or**
+  - `GOOGLE_APPLICATION_CREDENTIALS` (absolute path to the service account JSON in the runtime environment).
+
+These variables must be available in the build/runtime environment (Replit secrets, hosting console, or CI) so both the Vite build and Express routes can initialize Firebase.
+
 ## Method 1: Pre-Deployment Script (Recommended)
 
 This method fixes the package.json file before deployment:

--- a/client/src/components/sections/ContactForm.tsx
+++ b/client/src/components/sections/ContactForm.tsx
@@ -213,6 +213,19 @@ export default function ContactForm() {
         createdAt: serverTimestamp(),
       });
 
+      await addDoc(collection(db, "contactRequests"), {
+        name: formData.name,
+        email: formData.email,
+        company: formData.company,
+        city: formData.city,
+        state: formData.state,
+        message: formData.message,
+        companyWebsite,
+        token,
+        offWaitlistUrl,
+        createdAt: serverTimestamp(),
+      });
+
       // Send notification via backend API (secure)
       fetch("/api/contact-webhook", {
         method: "POST",

--- a/docs/firestore-rules.md
+++ b/docs/firestore-rules.md
@@ -1,0 +1,32 @@
+# Firestore rules, schemas, and indexing
+
+## Collections
+
+### `contactRequests`
+- **Fields:** `name`, `email`, `company`, `city`, `state`, `message`, `companyWebsite`, `token`, `offWaitlistUrl`, `createdAt (server timestamp)`.
+- **Purpose:** Captures the full payload from the public contact form, including the generated waitlist token and off-waitlist URL for follow-up.
+
+### `waitlistTokens`
+- **Fields (create):** `token`, `email`, `company`, `status`, `createdAt (server timestamp)`.
+- **Additional fields (update):** `usedAt`, `usedBy` (when redeemed).
+- **Purpose:** Tracks the lifecycle of outbound waitlist invitations.
+
+## Security rules
+Deploy `firestore.rules` to your Firebase project to enable the new collection and keep unauthenticated writes scoped to validated payloads:
+
+```bash
+firebase deploy --only firestore:rules
+```
+
+Key behaviors:
+- `contactRequests`: unauthenticated users can **create** records with the validated payload; reads are restricted to authenticated users; updates/deletes are blocked.
+- `waitlistTokens`: unauthenticated users can **create** tokens (for the contact form) and **read** tokens (for off-waitlist validation); updates/deletes require authentication.
+- `users`: authenticated users can create/read/update their own documents.
+
+See [`firestore.rules`](../firestore.rules) for the full rule set.
+
+## Indexing
+- If you plan to review contact requests by time or email, add a composite index on `contactRequests` with `email ASC, createdAt DESC`.
+- The existing `waitlistTokens` queries filter on `token` and `status` with equality clauses only, so no composite index is required. Add one if you later sort or filter by timestamp.
+
+Create indexes in the Firebase console (Firestore Database → Indexes) or via `firebase firestore:indexes` if you keep index configs alongside rules.

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,53 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    function isAuthenticated() {
+      return request.auth != null;
+    }
+
+    function isStringField(field) {
+      return field is string;
+    }
+
+    function hasValidContactRequestPayload() {
+      return isStringField(request.resource.data.name)
+        && isStringField(request.resource.data.email)
+        && isStringField(request.resource.data.company)
+        && isStringField(request.resource.data.city)
+        && isStringField(request.resource.data.state)
+        && isStringField(request.resource.data.message)
+        && isStringField(request.resource.data.companyWebsite)
+        && isStringField(request.resource.data.token)
+        && isStringField(request.resource.data.offWaitlistUrl)
+        && request.resource.data.createdAt is timestamp;
+    }
+
+    function hasValidWaitlistTokenCreatePayload() {
+      return isStringField(request.resource.data.token)
+        && isStringField(request.resource.data.email)
+        && isStringField(request.resource.data.company)
+        && isStringField(request.resource.data.status)
+        && request.resource.data.createdAt is timestamp;
+    }
+
+    match /contactRequests/{id} {
+      allow create: if hasValidContactRequestPayload();
+      allow read: if isAuthenticated();
+      allow update, delete: if false;
+    }
+
+    match /waitlistTokens/{id} {
+      allow create: if hasValidWaitlistTokenCreatePayload();
+      allow get, list: if true;
+      allow update, delete: if isAuthenticated();
+    }
+
+    match /users/{userId} {
+      allow create, read, update: if isAuthenticated() && request.auth.uid == userId;
+    }
+
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}

--- a/scripts/admin-smoke-ai-studio.ts
+++ b/scripts/admin-smoke-ai-studio.ts
@@ -1,0 +1,34 @@
+import router from "../server/routes/ai-studio";
+import { dbAdmin } from "../client/src/lib/firebaseAdmin";
+
+async function main() {
+  if (!dbAdmin) {
+    throw new Error("dbAdmin is null. Ensure Firebase Admin credentials are configured.");
+  }
+
+  // Ensure the route can be imported without crashing (sanity check).
+  if (!router) {
+    throw new Error("ai-studio router failed to import.");
+  }
+
+  const testRef = dbAdmin
+    .collection("__adminSmokeTests")
+    .doc("aiStudioRouteHealthcheck");
+
+  await testRef.set({
+    status: "ok",
+    checkedAt: new Date().toISOString(),
+    note: "admin-smoke-ai-studio.ts",
+  });
+
+  const snapshot = await testRef.get();
+
+  console.log("dbAdmin available:", Boolean(dbAdmin));
+  console.log("ai-studio router loaded:", Boolean(router));
+  console.log("Firestore write succeeded:", snapshot.exists, snapshot.data());
+}
+
+main().catch((error) => {
+  console.error("Admin smoke test failed:", error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add contactRequests Firestore logging from the contact form while preserving waitlist token creation
- provide sample Firebase web config/env secrets and deployment guidance for Vite and admin credentials
- introduce Firestore rules/index documentation and an admin smoke-test script for the ai-studio route

## Testing
- ⚠️ `GOOGLE_APPLICATION_CREDENTIALS=$(pwd)/blueprint-8c1ca-firebase-adminsdk-yu1gh-5992fcf620.json npx tsx scripts/admin-smoke-ai-studio.ts` *(fails with UNAUTHENTICATED; service account/Firestore permissions need to be updated in the target environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951a46fa5088329abfd1a5fc9cd57f7)