### PR TITLE
Remove em-dashes from website copy

### DIFF
--- a/client/src/components/Footer.jsx
+++ b/client/src/components/Footer.jsx
@@ -46,7 +46,7 @@ export default function Footer() {
             </div>
             <p className="text-slate-400 max-w-xl">
               Transforming physical spaces with AI glasses that deliver
-              instant guidance, answers, and service—no custom app required.
+              instant guidance, answers, and service. No custom app required.
             </p>
             <div className="flex items-center gap-4 mt-5 text-slate-400">
               <a

--- a/client/src/components/sections/Benefits.tsx
+++ b/client/src/components/sections/Benefits.tsx
@@ -22,7 +22,7 @@ const benefits = [
   {
     title: "Effortless Integration",
     description:
-      "Implement Blueprint seamlessly—no custom development required.",
+      "Implement Blueprint seamlessly. No custom development required.",
     icon: TrendingUpIcon,
   },
 ];

--- a/client/src/components/sections/ComingSoon.tsx
+++ b/client/src/components/sections/ComingSoon.tsx
@@ -5,7 +5,7 @@ const comingSoonFeatures = [
     icon: <Video className="h-6 w-6" />,
     title: "First-Person Manipulation Videos",
     description:
-      "Photorealistic egocentric footage of hands interacting with objects in your scenes—grasping, opening, sliding, placing.",
+      "Photorealistic egocentric footage of hands interacting with objects in your scenes: grasping, opening, sliding, placing.",
   },
   {
     icon: <Database className="h-6 w-6" />,
@@ -42,7 +42,7 @@ export default function ComingSoon() {
                 Future Offerings
               </h2>
               <p className="max-w-2xl text-lg text-zinc-600">
-                Extending our SimReady catalog with egocentric video datasets—generated
+                Extending our SimReady catalog with egocentric video datasets, generated
                 from every scene using dynamic world models.
               </p>
             </div>
@@ -74,7 +74,7 @@ export default function ComingSoon() {
                 <p className="text-zinc-600 leading-relaxed">
                   We're using Dynamic World Models to generate first-person manipulation
                   video from each SimReady scene in our catalog. Buy the scene for Isaac Sim
-                  training and evaluation—or add egocentric video datasets for pretraining
+                  training and evaluation, or add egocentric video datasets for pretraining
                   your vision-language-action models.
                 </p>
                 <div className="rounded-xl border border-zinc-200 bg-white p-4">

--- a/client/src/components/sections/ContactForm.tsx
+++ b/client/src/components/sections/ContactForm.tsx
@@ -376,7 +376,7 @@ export default function ContactForm() {
                   Be Among the First to Deploy AI Glasses Experiences
                 </h3>
                 <p className="mb-6 text-sm md:text-base text-slate-300">
-                  Blueprint readies your space for the AI wearables wave—across
+                  Blueprint readies your space for the AI wearables wave, across
                   retail, hospitality, workplaces, and venues. Join the free
                   pilot to feel how on-site AI guidance works.
                 </p>

--- a/client/src/components/sections/Features.tsx
+++ b/client/src/components/sections/Features.tsx
@@ -21,7 +21,7 @@ export default function Features() {
       icon: BoltIcon,
       title: "No App Required",
       description:
-        "Guests launch the AI glasses flow with a QR code—no custom app build or installs needed.",
+        "Guests launch the AI glasses flow with a QR code. No custom app build or installs needed.",
       color: "from-emerald-400 to-teal-500",
     },
     {

--- a/client/src/components/sections/WearableAIDemos.tsx
+++ b/client/src/components/sections/WearableAIDemos.tsx
@@ -291,7 +291,7 @@ export default function WearableAIDemos() {
                 We curate the best examples from the new wearable device access
                 toolkits so your team can see what is possible for retail
                 floors, cultural venues, and guest-driven destinations. No
-                vendor lock-in—use any smart glasses launching this year.
+                vendor lock-in. Use any smart glasses launching this year.
               </p>
             </div>
             <div className="space-y-3 text-sm text-slate-300">

--- a/client/src/pages/Blog.tsx
+++ b/client/src/pages/Blog.tsx
@@ -26,7 +26,7 @@ export default function Blog() {
     {
       title: "workplaceOS – our seventh phase",
       description:
-        "AI glasses + AI for offices and frontline hubs—live KPIs for managers, guided work and instant answers for teams.",
+        "AI glasses + AI for offices and frontline hubs: live KPIs for managers, guided work and instant answers for teams.",
       href: "/blog/workplace-os",
     },
     {
@@ -38,7 +38,7 @@ export default function Blog() {
     {
       title: "hospitalityOS – our fifth vertical",
       description:
-        "Wayfinding, amenity cues, and in-room overlays for guests—plus staff tools that lift satisfaction and service efficiency.",
+        "Wayfinding, amenity cues, and in-room overlays for guests, plus staff tools that lift satisfaction and service efficiency.",
       href: "/blog/hospitality-os",
     },
     {

--- a/client/src/pages/Capture.tsx
+++ b/client/src/pages/Capture.tsx
@@ -118,7 +118,7 @@ const howItWorksSteps = [
 const whyItMatters = [
   {
     title: "Location-Specific Training",
-    description: "Train robots on the exact environment they'll deploy in—not generic datasets.",
+    description: "Train robots on the exact environment they'll deploy in, not generic datasets.",
   },
   {
     title: "Scalable Collection",
@@ -1299,7 +1299,7 @@ export default function Capture() {
             Need a specific location captured?
           </h2>
           <p className="text-lg text-zinc-600 max-w-2xl mx-auto mb-8">
-            Whether it's a warehouse, retail floor, hospital, or campus—tell us what you need and
+            Whether it's a warehouse, retail floor, hospital, or campus, tell us what you need and
             we'll match you with a capture provider in your area.
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">

--- a/client/src/pages/CaseStudies.tsx
+++ b/client/src/pages/CaseStudies.tsx
@@ -11,7 +11,7 @@ export default function CaseStudies() {
           SimReady scenes powering robotic wins.
         </h1>
         <p className="max-w-3xl text-sm text-slate-600">
-          Explore how Blueprint scenes accelerate robotics R&D—from manipulation policies to AMR workflows. Each example below shipped with simulation validation and articulation coverage tuned to the customer’s tasks.
+          Explore how Blueprint scenes accelerate robotics R&D, from manipulation policies to AMR workflows. Each example below shipped with simulation validation and articulation coverage tuned to the customer's tasks.
         </p>
       </header>
 

--- a/client/src/pages/Contact.tsx
+++ b/client/src/pages/Contact.tsx
@@ -39,10 +39,10 @@ const headingLead = SHOW_REAL_WORLD_CAPTURE
 const headingEmphasis = "steer the roadmap.";
 
 const descriptionWithCapture =
-  "Book a real-world SimReady capture, upload a single wide photo of a supported archetype for an exclusive reconstruction (default—you can opt into open catalog), or steer the synthetic marketplace roadmap. Tell us which policy, object, or location types you need most—the signal helps decide our next drops.";
+  "Book a real-world SimReady capture, upload a single wide photo of a supported archetype for an exclusive reconstruction (default; you can opt into open catalog), or steer the synthetic marketplace roadmap. Tell us which policy, object, or location types you need most. The signal helps decide our next drops.";
 
 const descriptionWithoutCapture =
-  "Upload a single wide photo of a supported archetype for an exclusive reconstruction (default—you can opt into open catalog), or steer the synthetic marketplace roadmap. Tell us which policy, object, or location types you need most—the signal helps decide our next drops.";
+  "Upload a single wide photo of a supported archetype for an exclusive reconstruction (default; you can opt into open catalog), or steer the synthetic marketplace roadmap. Tell us which policy, object, or location types you need most. The signal helps decide our next drops.";
 
 // --- Visual Helper ---
 function DotPattern() {

--- a/client/src/pages/Go.tsx
+++ b/client/src/pages/Go.tsx
@@ -359,7 +359,7 @@ export default function Go() {
         };
         setCoordinates(coords);
         setPhase("locating");
-        setStatusMessage("Found you—connecting to the nearest Blueprint…");
+        setStatusMessage("Found you. Connecting to the nearest Blueprint...");
         void loadVenues(coords);
       },
       (error) => {

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -31,7 +31,7 @@
 
 // const artistBullets = [
 //   "Join a network shipping scenes to leading labs",
-//   "Focus on fidelity—we’ll handle the pipeline",
+//   "Focus on fidelity: we'll handle the pipeline",
 //   "Paid per scene, bonuses for articulation coverage",
 // ];
 
@@ -389,7 +389,7 @@
 //               </h3>
 //               <p className="mt-3 max-w-xl text-sm text-slate-600">
 //                 Share the address you care about and we’ll coordinate a capture
-//                 window. Expect delivery in days—not months—with USD, URDF, and
+//                 window. Expect delivery in days (not months) with USD, URDF, and
 //                 QA reports ready for your simulator.
 //               </p>
 //             </div>
@@ -451,7 +451,7 @@ const labBullets = [
 
 const artistBullets = [
   "Join a network shipping scenes to leading labs",
-  "Focus on fidelity—we’ll handle the pipeline",
+  "Focus on fidelity: we'll handle the pipeline",
   "Project-based pay with bonuses for articulation coverage",
 ];
 
@@ -720,7 +720,7 @@ export default function Home() {
             </h2>
             <p className="mt-4 text-lg text-zinc-600">
               We solve the sim-to-real gap by engineering physics-accurate assets
-              for robotic perception and manipulation—not just visual fidelity.
+              for robotic perception and manipulation, not just visual fidelity.
             </p>
           </div>
 
@@ -885,7 +885,7 @@ export default function Home() {
             </h2>
             <p className="text-zinc-600">
               Our pipeline creates digital twins that aren't just visual
-              copies—they are functional simulation environments.
+              copies. They are functional simulation environments.
             </p>
           </div>
 
@@ -1019,7 +1019,7 @@ export default function Home() {
               </h3>
               <p className="mt-4 text-lg text-zinc-400">
                 Share the address you care about and we’ll coordinate a capture
-                window. Expect delivery in days—not months—with USD, URDF, and
+                window. Expect delivery in days (not months) with USD, URDF, and
                 QA reports.
               </p>
             </div>

--- a/client/src/pages/HowItWorks.tsx
+++ b/client/src/pages/HowItWorks.tsx
@@ -24,7 +24,7 @@ const steps = [
   {
     icon: <Building className="w-10 h-10" />,
     title: "Create Your Digital Space",
-    description: "Start fresh or claim an existing location Blueprint. Simply enter your business details and location—no technical skills required.",
+    description: "Start fresh or claim an existing location Blueprint. Simply enter your business details and location. No technical skills required.",
     highlight: "30 seconds",
     details: ["Business information", "Location mapping", "Industry templates"]
   },
@@ -110,7 +110,7 @@ function HeroSection() {
             </h1>
 
             <p className="text-xl text-gray-600 mb-8 leading-relaxed">
-              Blueprint lets businesses create stunning AI glasses experiences that customers can access instantly through their phones—no app downloads required.
+              Blueprint lets businesses create stunning AI glasses experiences that customers can access instantly through their phones. No app downloads required.
             </p>
 
             <div className="flex flex-col sm:flex-row gap-4 mb-8">

--- a/client/src/pages/OffWaitlistSignUpFlow.tsx
+++ b/client/src/pages/OffWaitlistSignUpFlow.tsx
@@ -951,7 +951,7 @@ export default function OffWaitlistSignUpFlow() {
           Welcome off the waitlist
         </h2>
         <p className="text-slate-300 mt-2">
-          Durham/Triangle pilot — set up your account to book mapping & demo.
+          Durham/Triangle pilot: set up your account to book mapping & demo.
           This takes ~2 minutes.
         </p>
       </div>
@@ -1724,7 +1724,7 @@ export default function OffWaitlistSignUpFlow() {
             Plan & Payment (Optional)
           </h2>
           <p className="text-slate-300 mt-2">
-            Secure your onboarding with a one-time payment or skip for now—your
+            Secure your onboarding with a one-time payment or skip for now. Your
             monthly plan only begins once Blueprint is live on-site.
           </p>
         </div>
@@ -1781,7 +1781,7 @@ export default function OffWaitlistSignUpFlow() {
                   <span className="text-sm text-slate-300">per month</span>
                 </div>
                 <p className="text-sm text-slate-300 mt-2">
-                  Starts {billingDisplay} — 24 hours after your onboarding
+                  Starts {billingDisplay}, 24 hours after your onboarding
                   wraps.
                 </p>
               </div>
@@ -1794,8 +1794,8 @@ export default function OffWaitlistSignUpFlow() {
               </div>
               <div className="flex items-start gap-2 text-slate-200 text-sm">
                 <Clock3 className="w-4 h-4 text-cyan-200 mt-0.5" />
-                Extra hours billed at ${EXTRA_HOURLY_RATE.toFixed(2)} / hr —
-                matches your Blueprint rate.
+                Extra hours billed at ${EXTRA_HOURLY_RATE.toFixed(2)} / hr.
+                Matches your Blueprint rate.
               </div>
             </div>
           </div>
@@ -1815,7 +1815,7 @@ export default function OffWaitlistSignUpFlow() {
 
         {paymentStatus === "canceled" && (
           <div className="rounded-xl border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-100">
-            Checkout was canceled. You can try again below or skip for now—your
+            Checkout was canceled. You can try again below or skip for now. Your
             spot is still saved.
           </div>
         )}
@@ -1884,12 +1884,12 @@ export default function OffWaitlistSignUpFlow() {
         )}
         {paymentStatus === "skipped" && (
           <div className="rounded-xl border border-cyan-400/30 bg-cyan-500/10 px-4 py-3 text-sm text-cyan-100">
-            You can take care of the $499.99 onboarding invoice later—your
+            You can take care of the $499.99 onboarding invoice later. Your
             account access is fully unlocked in the meantime.
           </div>
         )}
         <p className="text-xs text-slate-400">
-          Thanks for choosing Blueprint — we can’t wait to bring your space to
+          Thanks for choosing Blueprint. We can't wait to bring your space to
           life.
         </p>
         <Button
@@ -1951,7 +1951,7 @@ export default function OffWaitlistSignUpFlow() {
               <div>
                 <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full border border-emerald-400/30 bg-emerald-400/10 text-emerald-200 mb-3">
                   <MapPin className="w-4 h-4" />
-                  Durham & Triangle — Pilot Access
+                  Durham & Triangle: Pilot Access
                 </div>
                 <h1 className="text-3xl md:text-4xl font-black leading-tight text-white">
                   Join the Blueprint Pilot
@@ -2026,7 +2026,7 @@ export default function OffWaitlistSignUpFlow() {
                         </li>
                         <li className="flex items-start gap-2">
                           <CheckCircle2 className="w-4 h-4 text-emerald-300 mt-0.5" />
-                          <span>No app downloads—instant access via QR</span>
+                          <span>No app downloads, instant access via QR</span>
                         </li>
                         <li className="flex items-start gap-2">
                           <CheckCircle2 className="w-4 h-4 text-emerald-300 mt-0.5" />

--- a/client/src/pages/Onboarding.tsx
+++ b/client/src/pages/Onboarding.tsx
@@ -1428,7 +1428,7 @@ export default function Onboarding() {
               </>
             ) : (
               <>
-                You can skip mapping now—ideal if you're piloting in a single
+                You can skip mapping now. This is ideal if you're piloting in a single
                 room. Turn it on anytime from the dashboard.
               </>
             )}

--- a/client/src/pages/OutboundSignUpFlow.tsx
+++ b/client/src/pages/OutboundSignUpFlow.tsx
@@ -830,7 +830,7 @@ export default function OutboundSignUpFlow() {
           Create your Blueprint account
         </h2>
         <p className="text-slate-300 mt-2">
-          Durham/Triangle pilot — invite-only access for local venues. This
+          Durham/Triangle pilot: invite-only access for local venues. This
           takes ~2 minutes.
         </p>
       </div>
@@ -1596,8 +1596,8 @@ export default function OutboundSignUpFlow() {
             Plan & Payment (Optional)
           </h2>
           <p className="text-slate-300 mt-2">
-            Lock in onboarding now or handle it later—either way, your Blueprint
-            Care plan only starts once we’re live on site.
+            Lock in onboarding now or handle it later. Either way, your Blueprint
+            Care plan only starts once we're live on site.
           </p>
         </div>
 
@@ -1651,7 +1651,7 @@ export default function OutboundSignUpFlow() {
                   <span className="text-sm text-slate-300">per month</span>
                 </div>
                 <p className="text-sm text-slate-300 mt-2">
-                  Starts {billingDisplay} — 24 hours after onboarding is
+                  Starts {billingDisplay}, 24 hours after onboarding is
                   complete.
                 </p>
               </div>
@@ -1665,7 +1665,7 @@ export default function OutboundSignUpFlow() {
               <div className="flex items-start gap-2 text-slate-200 text-sm">
                 <Clock3 className="w-4 h-4 text-cyan-200 mt-0.5" />
                 Extra hours billed at ${EXTRA_HOURLY_RATE.toFixed(2)} /
-                hr—matches your Blueprint rate.
+                hr. Matches your Blueprint rate.
               </div>
             </div>
           </div>
@@ -1685,7 +1685,7 @@ export default function OutboundSignUpFlow() {
 
         {paymentStatus === "canceled" && (
           <div className="rounded-xl border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-100">
-            Checkout was canceled. You can try again below or skip for now—your
+            Checkout was canceled. You can try again below or skip for now. Your
             pilot slot remains saved.
           </div>
         )}
@@ -1754,12 +1754,12 @@ export default function OutboundSignUpFlow() {
         )}
         {paymentStatus === "skipped" && (
           <div className="rounded-xl border border-cyan-400/30 bg-cyan-500/10 px-4 py-3 text-sm text-cyan-100">
-            You can settle the $499.99 onboarding invoice later—your pilot
+            You can settle the $499.99 onboarding invoice later. Your pilot
             access is fully unlocked.
           </div>
         )}
         <p className="text-xs text-slate-400">
-          Thanks for choosing Blueprint — we can’t wait to bring your space to
+          Thanks for choosing Blueprint. We can't wait to bring your space to
           life.
         </p>
         <Button
@@ -1821,7 +1821,7 @@ export default function OutboundSignUpFlow() {
               <div>
                 <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full border border-emerald-400/30 bg-emerald-400/10 text-emerald-200 mb-3">
                   <MapPin className="w-4 h-4" />
-                  Durham & Triangle — Pilot Access
+                  Durham & Triangle: Pilot Access
                 </div>
                 <h1 className="text-3xl md:text-4xl font-black leading-tight text-white">
                   Join the Blueprint Pilot

--- a/client/src/pages/Pricing.tsx
+++ b/client/src/pages/Pricing.tsx
@@ -235,7 +235,7 @@ const takeaways = [
 
 const scenarioData: { name: string; subtitle: string; bullets: string[] }[] = [
   {
-    name: "Scenario A — Small pilot",
+    name: "Scenario A: Small pilot",
     subtitle: "3 stores, 1,000 sessions/store/month, 50 MB initial asset load.",
     bullets: [
       "VPS: 3,000 calls/mo → $0 (under 10k free).",
@@ -247,7 +247,7 @@ const scenarioData: { name: string; subtitle: string; bullets: string[] }[] = [
     ],
   },
   {
-    name: "Scenario B — Heavier usage",
+    name: "Scenario B: Heavier usage",
     subtitle: "10 stores, 10,000 sessions/store/month; 40 MB cached load.",
     bullets: [
       "VPS: 100k calls/mo → first 10k free; 90k × $10/1k ≈ $900/mo (if all sessions call VPS once).",
@@ -298,7 +298,7 @@ const planTiers: PlanTier[] = [
     features: [
       "Free onboarding + instant App Clip entry",
       "“Ask-Where?” voice concierge (aisle/bay + quick follow-ups)",
-      "SOP checklists & tours — audio-first with tap/voice advance",
+      "SOP checklists & tours: audio-first with tap/voice advance",
       "Context nudges by zone (rate-limited to avoid spam)",
       "Session logging with baseline analytics",
     ],
@@ -408,7 +408,7 @@ function PriceHero() {
       </motion.h1>
 
       <p className="mt-4 max-w-3xl mx-auto text-lg text-slate-300">
-        Launch with guided scans, then pick the MAU tier that matches your foot traffic—no surprise platform fees.
+        Launch with guided scans, then pick the MAU tier that matches your foot traffic. No surprise platform fees.
       </p>
     </section>
   );
@@ -575,7 +575,7 @@ function KitFulfillmentCallout() {
             How kit fulfillment works
           </CardTitle>
           <CardDescription className="text-slate-300">
-            All plans include a FREE Starter Kit (4 QR codes). If you need more, choose 8 or 16 QR codes at onboarding for a one-time fee—the monthly subscription price stays the same.
+            All plans include a FREE Starter Kit (4 QR codes). If you need more, choose 8 or 16 QR codes at onboarding for a one-time fee. The monthly subscription price stays the same.
           </CardDescription>
         </CardHeader>
         <CardContent className="pt-0">
@@ -584,7 +584,7 @@ function KitFulfillmentCallout() {
               <Box className="mt-0.5 h-5 w-5 text-emerald-300" />
               <div className="text-sm text-slate-200">
                 <span className="font-semibold text-white">Shipped during onboarding.</span>{" "}
-                Your QR kit ships immediately after signup. If you choose an upgrade (8 or 16 QR codes), the one-time charge is applied at shipping—your monthly subscription price remains unchanged.
+                Your QR kit ships immediately after signup. If you choose an upgrade (8 or 16 QR codes), the one-time charge is applied at shipping. Your monthly subscription price remains unchanged.
               </div>
             </li>
             <li className="flex items-start gap-3">
@@ -598,7 +598,7 @@ function KitFulfillmentCallout() {
               <Gift className="mt-0.5 h-5 w-5 text-emerald-300" />
               <div className="text-sm text-slate-200">
                 <span className="font-semibold text-white">QR kit options.</span>{" "}
-                Every plan includes a FREE Starter Kit (4 QR codes). Optionally upgrade to 8 QR codes (+$15 one-time) or 16 QR codes (+$45 one-time)—charged at shipping, not monthly.
+                Every plan includes a FREE Starter Kit (4 QR codes). Optionally upgrade to 8 QR codes (+$15 one-time) or 16 QR codes (+$45 one-time), charged at shipping, not monthly.
               </div>
             </li>
           </ul>
@@ -2689,7 +2689,7 @@ export default function PricingPage() {
 
 // const scenarioData: { name: string; subtitle: string; bullets: string[] }[] = [
 //   {
-//     name: "Scenario A — Small pilot",
+//     name: "Scenario A: Small pilot",
 //     subtitle: "3 stores, 1,000 sessions/store/month, 50 MB initial asset load.",
 //     bullets: [
 //       "VPS: 3,000 calls/mo → $0 (under 10k free).",
@@ -2701,7 +2701,7 @@ export default function PricingPage() {
 //     ],
 //   },
 //   {
-//     name: "Scenario B — Heavier usage",
+//     name: "Scenario B: Heavier usage",
 //     subtitle: "10 stores, 10,000 sessions/store/month; 40 MB cached load.",
 //     bullets: [
 //       "VPS: 100k calls/mo → first 10k free; 90k × $10/1k ≈ $900/mo (if all sessions call VPS once).",

--- a/client/src/pages/Recipes.tsx
+++ b/client/src/pages/Recipes.tsx
@@ -63,7 +63,7 @@ export default function Recipes() {
               Lightweight USD "recipes" that assemble SimReady packs.
             </h1>
             <p className="text-lg leading-relaxed text-zinc-600">
-              Browse base layouts that ship as <code className="rounded bg-zinc-100 px-1.5 py-0.5 text-sm font-semibold text-zinc-800">.usda</code> layers, dependency manifests, and Omniverse Replicator randomizers. Labs install NVIDIA SimReady packs locally—we only deliver the recipe, semantics, and QA harness.
+              Browse base layouts that ship as <code className="rounded bg-zinc-100 px-1.5 py-0.5 text-sm font-semibold text-zinc-800">.usda</code> layers, dependency manifests, and Omniverse Replicator randomizers. Labs install NVIDIA SimReady packs locally. We only deliver the recipe, semantics, and QA harness.
             </p>
             <p className="text-base leading-relaxed text-zinc-700">
               Task logic ships with every recipe: action/observation wiring, reward terms, termination + reset rules, and default parallel env counts so you get a trainable MDP alongside the geometry.

--- a/client/src/pages/Solutions.tsx
+++ b/client/src/pages/Solutions.tsx
@@ -265,7 +265,7 @@ const recipeDeliverables = [
   {
     icon: <Terminal className="h-5 w-5 text-indigo-600" />,
     title: "Frame generator",
-    desc: "Omniverse Replicator scripts for swaps, clutter, lighting, material randomization, and articulation state noise—typically 500–2,000 frames per scene.",
+    desc: "Omniverse Replicator scripts for swaps, clutter, lighting, material randomization, and articulation state noise. Typically 500–2,000 frames per scene.",
   },
 ];
 
@@ -296,7 +296,7 @@ const hardParts = [
   {
     title: "Scene assembly & references",
     icon: <Layers className="h-5 w-5 text-emerald-600" />,
-    desc: "Pull assets from Nucleus or local paths, place them, and keep prim paths and references stable—dependency and repathing issues are common.",
+    desc: "Pull assets from Nucleus or local paths, place them, and keep prim paths and references stable. Dependency and repathing issues are common.",
   },
   {
     title: "Physics correctness",
@@ -348,7 +348,7 @@ const labWorkflow = [
   },
   {
     title: "Split train/eval and package",
-    detail: "Hold out layouts or seeds, then collect/share scenes—where path/material issues often appear.",
+    detail: "Hold out layouts or seeds, then collect/share scenes. This is where path/material issues often appear.",
   },
 ];
 
@@ -390,7 +390,7 @@ function DataPipelineSection() {
             Image to SimReady Scene
           </h2>
           <p className="max-w-3xl mx-auto text-zinc-400 leading-relaxed">
-            Upload a reference photo and receive a fully articulated, physics-accurate 3D scene ready for Isaac Sim—complete with domain randomization scripts and RL training configs.
+            Upload a reference photo and receive a fully articulated, physics-accurate 3D scene ready for Isaac Sim, complete with domain randomization scripts and RL training configs.
           </p>
         </div>
 
@@ -580,7 +580,7 @@ export default function Solutions() {
               <p className="max-w-2xl text-lg leading-relaxed text-zinc-600">
                 Whether you need procedural synthetic data with domain randomization,
                 an exclusive physics-accurate reconstruction, or a sim2real-validated
-                digital twin—we deliver environments engineered for manipulation,
+                digital twin, we deliver environments engineered for manipulation,
                 perception, and policy transfer.
               </p>
             </div>
@@ -674,7 +674,7 @@ export default function Solutions() {
                   <p className="text-sm text-zinc-700 leading-relaxed">
                     NVIDIA’s own SimReady docs frame packs as the bridge between robot/autonomy training and industrial
                     digital twins, emphasizing the extra metadata beyond visuals. Position papers in RL call "environment
-                    shaping" the main bottleneck—exactly the gap we close.
+                    shaping" the main bottleneck, exactly the gap we close.
                   </p>
                   <div className="rounded-xl bg-white p-4 text-xs text-zinc-600 ring-1 ring-indigo-100">
                     <p className="font-semibold text-zinc-900">Important nuance</p>
@@ -884,13 +884,13 @@ export default function Solutions() {
                   <Terminal className="h-3 w-3" /> Scene Recipes
                 </div>
                 <h2 className="text-3xl font-bold text-zinc-900 sm:text-4xl">
-                  Layouts, manifests, and frame generators—BYO SimReady assets.
+                  Layouts, manifests, and frame generators. BYO SimReady assets.
                 </h2>
                 <p className="text-zinc-600 leading-relaxed">
                   We deliver a lightweight USD layer plus a manifest that references NVIDIA SimReady packs you install locally. Omniverse Replicator scripts handle swaps, clutter, lighting, and articulation state randomization without us shipping the source assets.
                 </p>
                 <ul className="grid gap-3 text-sm text-zinc-700 sm:grid-cols-2">
-                  {["No asset redistribution—packs stay on your Nucleus/local disk", "Semantics + USDPhysics defaults aligned to SimReady best practices", "Frame generator tuned for RL-friendly randomization (500–2,000 frames/scene)", "Reusable integration snippets for Isaac Lab / Isaac Sim"].map(
+                  {["No asset redistribution: packs stay on your Nucleus/local disk", "Semantics + USDPhysics defaults aligned to SimReady best practices", "Frame generator tuned for RL-friendly randomization (500–2,000 frames/scene)", "Reusable integration snippets for Isaac Lab / Isaac Sim"].map(
                     (item) => (
                       <li
                         key={item}
@@ -964,7 +964,7 @@ export default function Solutions() {
                 </p>
 
                 <ul className="grid gap-3 text-sm text-zinc-700 sm:grid-cols-2">
-                  {["Budget averages around $1k per environment", "Exclusive access by default—opt into open catalog if you want", "Includes authored colliders, pivots, and materials", "Submit use cases so we validate against your policies"].map(
+                  {["Budget averages around $1k per environment", "Exclusive access by default (opt into open catalog if you want)", "Includes authored colliders, pivots, and materials", "Submit use cases so we validate against your policies"].map(
                     (item) => (
                       <li
                         key={item}

--- a/client/src/pages/Terms.tsx
+++ b/client/src/pages/Terms.tsx
@@ -14,8 +14,8 @@ export default function Terms() {
         <h2 className="text-lg font-semibold text-slate-900">1. Services</h2>
         <p>Blueprint provides procedural/synthetic scene data, SimReady finishing, and on-site capture services as described in project agreements.</p>
         <p>
-          Procedural deliverables are derived from real-world references—such as kitchens, warehouses, utility rooms, and
-          residential settings—to maintain the spatial fidelity and diversity required for robotics training datasets.
+          Procedural deliverables are derived from real-world references (such as kitchens, warehouses, utility rooms, and
+          residential settings) to maintain the spatial fidelity and diversity required for robotics training datasets.
         </p>
         <p>Deliverables include USD assets, textures, documentation, and related metadata as specified in the SOW.</p>
       </section>

--- a/client/src/pages/VenueMaterials.tsx
+++ b/client/src/pages/VenueMaterials.tsx
@@ -127,7 +127,7 @@ export default function VenueMaterials() {
       name: 'Floor Decals (12" × 12", 2-pack)',
       price: "$24",
       blurb:
-        "Slip-resistant decals for queue zones — ‘Stand here & scan’. Removable adhesive.",
+        "Slip-resistant decals for queue zones: 'Stand here & scan'. Removable adhesive.",
       bestFor: "Queues & lobbies",
       icon: <ScanLine className="w-4 h-4" />,
     },
@@ -178,7 +178,7 @@ export default function VenueMaterials() {
     {
       title: "We generate your dynamic QR",
       blurb:
-        "Each code is unique per placement, so you can track scans and update destinations later — no reprints.",
+        "Each code is unique per placement, so you can track scans and update destinations later. No reprints.",
       icon: <QrCode className="w-5 h-5 text-cyan-300" />,
     },
     {
@@ -199,7 +199,7 @@ export default function VenueMaterials() {
     () => [
       {
         q: "Is the Starter Kit really free?",
-        a: "Yes — your first kit per activated location is included. Re-orders or additional kits are billed at the prices below.",
+        a: "Yes, your first kit per activated location is included. Re-orders or additional kits are billed at the prices below.",
       },
       {
         q: "How do the QR codes work?",
@@ -219,7 +219,7 @@ export default function VenueMaterials() {
       },
       {
         q: "Can we customize the art?",
-        a: "Yes — co-branding and translated variants are available. Talk to us for templates and print specs.",
+        a: "Yes, co-branding and translated variants are available. Talk to us for templates and print specs.",
       },
     ],
     [],
@@ -255,7 +255,7 @@ export default function VenueMaterials() {
               </span>
             </h1>
             <p className="mt-3 text-slate-300 max-w-2xl mx-auto">
-              Everything you need to launch and promote your Blueprint on-site —
+              Everything you need to launch and promote your Blueprint on-site:
               QR codes that just work, clear signage, and a simple install flow.
               Your first Starter Kit is{" "}
               <span className="text-emerald-300 font-semibold">free</span>.
@@ -304,7 +304,7 @@ export default function VenueMaterials() {
                   Starter Kit
                 </CardTitle>
                 <CardDescription className="text-slate-300">
-                  Ships free on your first location — or delivered and installed
+                  Ships free on your first location, or delivered and installed
                   by your mapper.
                 </CardDescription>
               </div>
@@ -436,7 +436,7 @@ export default function VenueMaterials() {
                   </h3>
                 </div>
                 <p className="text-sm text-slate-300">
-                  Guests and staff scan once and land in your Blueprint — no app
+                  Guests and staff scan once and land in your Blueprint. No app
                   download required. Dynamic links route to the best experience
                   for each device.
                 </p>
@@ -450,7 +450,7 @@ export default function VenueMaterials() {
                 </div>
                 <p className="text-sm text-slate-300">
                   Each QR is unique. See which doors, counters, or exhibits
-                  drive the most entries — and optimize where you place signage.
+                  drive the most entries, and optimize where you place signage.
                 </p>
               </div>
               <div className="rounded-2xl border border-white/10 bg-white/[0.05] p-6">
@@ -494,7 +494,7 @@ export default function VenueMaterials() {
               </h3>
               <p className="mt-3 text-slate-300 max-w-2xl mx-auto">
                 Claim your free Starter Kit at signup, or re-order materials
-                anytime. We’ll ship it or bring it with your mapper — whatever
+                anytime. We'll ship it or bring it with your mapper, whatever
                 gets you live fastest.
               </p>
               <div className="mt-6 flex flex-wrap items-center justify-center gap-3">

--- a/client/src/pages/blog/HospitalityOS.tsx
+++ b/client/src/pages/blog/HospitalityOS.tsx
@@ -35,11 +35,11 @@ export default function HospitalityOS() {
 
               <p>
                 Blueprint is building the operating system for physical
-                spaces—our motto is{" "}
-                <strong>“know the place to serve the person.”</strong>{" "}
+                spaces. Our motto is{" "}
+                <strong>"know the place to serve the person."</strong>{" "}
                 hospitalityOS brings that vision to hotels, resorts, and
                 short-stays. It blends AR and AI with your property systems so
-                <em> people</em>—both staff and guests—get what they need
+                <em> people</em>, both staff and guests, get what they need
                 faster, with less friction and more delight.
               </p>
 
@@ -61,7 +61,7 @@ export default function HospitalityOS() {
                 </li>
                 <li>
                   <strong>Maintenance in place:</strong> Overlay work orders on
-                  the exact unit—HVAC, elevators, pool systems—with part IDs,
+                  the exact unit (HVAC, elevators, pool systems) with part IDs,
                   history, and safety checks.
                 </li>
                 <li>
@@ -91,7 +91,7 @@ export default function HospitalityOS() {
                 <li>
                   <strong>AI concierge:</strong> A multilingual, on-site guide
                   answers questions about amenities, neighborhood tips, transit,
-                  and policies—and can place requests on your behalf.
+                  and policies, and can place requests on your behalf.
                 </li>
                 <li>
                   <strong>Moments that matter:</strong> Contextual upsells (spa,
@@ -132,7 +132,7 @@ export default function HospitalityOS() {
                   <strong>Immersive content boosts engagement:</strong>{" "}
                   AR/VR-style experiences in hospitality/tourism are linked to
                   higher learning, satisfaction, and revisit intention in
-                  peer-reviewed studies—useful for tours, brand storytelling,
+                  peer-reviewed studies, useful for tours, brand storytelling,
                   and venue orientation.{" "}
                   <sup>
                     <a href="#src-4">[4]</a>
@@ -210,7 +210,7 @@ export default function HospitalityOS() {
               </ol>
 
               <p>
-                hospitalityOS turns place into the interface—helping teams work
+                hospitalityOS turns place into the interface, helping teams work
                 smarter while guests feel more informed, more in control, and
                 more at home.
               </p>

--- a/client/src/pages/blog/MuseumOS.tsx
+++ b/client/src/pages/blog/MuseumOS.tsx
@@ -33,7 +33,7 @@ export default function MuseumOS() {
 
               <p>
                 Blueprint is building the operating system for physical
-                spaces—our motto is{" "}
+                spaces. Our motto is{" "}
                 <strong>“know the place to serve the person.”</strong> museumOS
                 brings that vision to museums and cultural sites, turning
                 galleries and grounds into living, adaptive layers. It blends AR
@@ -60,12 +60,12 @@ export default function MuseumOS() {
                 <li>
                   <strong>Instant labels &amp; accessibility:</strong> One tap
                   to publish translations, captions, large-type labels, and
-                  audio descriptions—anchored right where they’re needed.
+                  audio descriptions, anchored right where they're needed.
                 </li>
                 <li>
                   <strong>Impact analytics:</strong> Exhibit- and object-level
                   engagement reports (views, dwell, completion) and sentiment
-                  from on-device prompts—no emails required.
+                  from on-device prompts (no emails required).
                 </li>
                 <li>
                   <strong>Rapid content swaps:</strong> Safe “what-if” modes to
@@ -84,8 +84,8 @@ export default function MuseumOS() {
                 </li>
                 <li>
                   <strong>Time-Shift storytelling:</strong> See reconstructions
-                  “appear” in place—missing frescoes, ancient colors, or
-                  original facades—then scrub between eras to understand change.
+                  "appear" in place (missing frescoes, ancient colors, or
+                  original facades), then scrub between eras to understand change.
                 </li>
                 <li>
                   <strong>Follow-your-curiosity paths:</strong> Adaptive routes
@@ -100,7 +100,7 @@ export default function MuseumOS() {
                 <li>
                   <strong>Moments that matter:</strong> Contextual membership,
                   program sign-ups, and shop tie-ins appear at natural decision
-                  points—never interrupting the visit.
+                  points, never interrupting the visit.
                 </li>
               </ul>
 
@@ -235,7 +235,7 @@ export default function MuseumOS() {
               </ol>
 
               <p>
-                museumOS turns place into a first-class interface—helping teams
+                museumOS turns place into a first-class interface, helping teams
                 iterate with data and giving visitors stories they’ll remember.
               </p>
 

--- a/client/src/pages/blog/PropertyOS.tsx
+++ b/client/src/pages/blog/PropertyOS.tsx
@@ -33,7 +33,7 @@ export default function PropertyOS() {
 
               <p>
                 Blueprint is building the operating system for physical
-                spaces—our motto is{" "}
+                spaces. Our motto is{" "}
                 <strong>“know the place to serve the person.”</strong>{" "}
                 propertyOS brings that vision to real estate. For{" "}
                 <em>listings</em>, it delivers immersive, on-site AR staging and
@@ -58,12 +58,12 @@ export default function PropertyOS() {
                 <li>
                   <strong>AR staging overlays:</strong> Instantly furnish vacant
                   or dated rooms with lifelike layouts, finishes, and
-                  lighting—toggled live during showings or captured in 3D tours.
+                  lighting, toggled live during showings or captured in 3D tours.
                 </li>
                 <li>
                   <strong>Design “switchers”:</strong> One tap to preview styles
                   (modern, cozy, minimalist), flooring/paint swaps, or
-                  kitchen/bath variations—without moving a single couch.
+                  kitchen/bath variations, without moving a single couch.
                 </li>
                 <li>
                   <strong>Guided tours + hotspots:</strong> Visitors follow
@@ -92,7 +92,7 @@ export default function PropertyOS() {
                 <li>
                   <strong>Household access, like Wi-Fi:</strong> Anyone you
                   invite (roommates, family, guests) can “join” your home’s AR
-                  layer on any supported device—no need for a specific host to
+                  layer on any supported device. No need for a specific host to
                   be present.
                 </li>
                 <li>
@@ -102,7 +102,7 @@ export default function PropertyOS() {
                 </li>
                 <li>
                   <strong>Cross-platform by design:</strong> Works across
-                  headsets, glasses, and phones—so visitors always get the
+                  headsets, glasses, and phones, so visitors always get the
                   experience you set up.
                 </li>
                 <li>
@@ -162,7 +162,7 @@ export default function PropertyOS() {
                 <li>
                   <strong>Reality check:</strong> Some analysts note ROI varies
                   by market; staging costs can rise, and not every uplift is
-                  guaranteed—transparent expectations and quality execution
+                  guaranteed. Transparent expectations and quality execution
                   still matter.{" "}
                   <sup>
                     <a href="#src-7">[7]</a>
@@ -242,7 +242,7 @@ export default function PropertyOS() {
               </ol>
 
               <p>
-                propertyOS uses place as the interface—elevating the listing,
+                propertyOS uses place as the interface, elevating the listing,
                 accelerating decisions, and giving residents a canvas to make
                 their homes truly theirs.
               </p>

--- a/client/src/pages/blog/RestaurantOS.tsx
+++ b/client/src/pages/blog/RestaurantOS.tsx
@@ -37,12 +37,12 @@ export default function RestaurantOS() {
 
               <p>
                 Blueprint is building the operating system for physical
-                spaces—our motto is{" "}
-                <strong>“know the place to serve the person.”</strong>{" "}
+                spaces. Our motto is{" "}
+                <strong>"know the place to serve the person."</strong>{" "}
                 restaurantOS brings that vision to bistros, cafés and dining
                 rooms. It blends AR and AI to understand the table, the menu and
                 the flow of service so <em>guests</em> feel informed, delighted
-                and taken care of—without adding strain to the floor.
+                and taken care of, without adding strain to the floor.
               </p>
 
               <h2>Guest Experience Suite</h2>
@@ -67,7 +67,7 @@ export default function RestaurantOS() {
                 <li>
                   <strong>Chef’s notes &amp; story bites:</strong> Lightweight
                   “hologram” moments convey provenance, technique, wine pairings
-                  and brand lore at the exact point of decision—no app install.
+                  and brand lore at the exact point of decision. No app install.
                 </li>
                 <li>
                   <strong>Dietary &amp; allergen guardrails:</strong> Toggle
@@ -81,7 +81,7 @@ export default function RestaurantOS() {
                 <li>
                   <strong>Smart recommendations:</strong> AI suggests pairings,
                   limited-run specials and table-share items based on party
-                  size, time of day and inventory—guests stay in control.
+                  size, time of day and inventory. Guests stay in control.
                 </li>
                 <li>
                   <strong>Wayfinding &amp; amenity cues:</strong> Discreet AR
@@ -105,7 +105,7 @@ export default function RestaurantOS() {
                   <strong>Higher purchase intent:</strong> Field and lab studies
                   show AR food presentation increases mental simulation and{" "}
                   <em>raises desire and purchase likelihood</em> versus
-                  photos—an effect demonstrated in real restaurants.{" "}
+                  photos, an effect demonstrated in real restaurants.{" "}
                   <sup>
                     <a href="#src-1">[1]</a>
                   </sup>
@@ -123,7 +123,7 @@ export default function RestaurantOS() {
                 <li>
                   <strong>Service efficiency:</strong> Digital ordering and
                   contactless flows can improve order accuracy and service time,
-                  especially during peaks—used selectively to complement
+                  especially during peaks, used selectively to complement
                   hospitality.{" "}
                   <sup>
                     <a href="#src-3">[3]</a>
@@ -248,7 +248,7 @@ export default function RestaurantOS() {
               </ol>
 
               <p>
-                restaurantOS treats place as the interface—helping guests choose
+                restaurantOS treats place as the interface, helping guests choose
                 confidently, learn the story behind the food, and enjoy a
                 smoother service flow from hello to check.
               </p>

--- a/client/src/pages/blog/RetailOS.tsx
+++ b/client/src/pages/blog/RetailOS.tsx
@@ -33,11 +33,11 @@ export default function RetailOS() {
 
               <p>
                 Blueprint is building the operating system for physical
-                spaces—our motto is{" "}
+                spaces. Our motto is{" "}
                 <strong>"know the place to serve the person."</strong> retailOS
                 brings that vision to stores and showrooms. It blends AR and AI
                 to understand every aisle, bay and product so
-                <em> people</em>—both associates and shoppers—get exactly what
+                <em> people</em>, both associates and shoppers, get exactly what
                 they need faster and more confidently.
               </p>
 
@@ -55,7 +55,7 @@ export default function RetailOS() {
               <ul>
                 <li>
                   <strong>Guided tasks:</strong> AR paths for BOPIS pick/pack,
-                  restock, and facing—hands-free confirmations to cut walking
+                  restock, and facing. Hands-free confirmations cut walking
                   and errors.
                 </li>
                 <li>
@@ -82,7 +82,7 @@ export default function RetailOS() {
                 </li>
                 <li>
                   <strong>Try-before-you-buy:</strong> 3D/AR try-ons and
-                  “see-in-your-space” for size, fit, and finish—reducing
+                  "see-in-your-space" for size, fit, and finish, reducing
                   uncertainty and returns.
                 </li>
                 <li>
@@ -92,7 +92,7 @@ export default function RetailOS() {
                 </li>
                 <li>
                   <strong>Delight &amp; dwell:</strong> Lightweight, purposeful
-                  interactions—no app install required—keep shoppers engaged
+                  interactions (no app install required) keep shoppers engaged
                   without slowing the trip.
                 </li>
               </ul>
@@ -121,7 +121,7 @@ export default function RetailOS() {
                 <li>
                   <strong>Dwell &amp; engagement:</strong> AR experiences often
                   sustain <strong>~75s average dwell</strong> in campaigns, and
-                  minute-plus sessions are common in retail case studies—far
+                  minute-plus sessions are common in retail case studies, far
                   above typical ad interactions.{" "}
                   <sup>
                     <a href="#src-3">[3]</a>
@@ -200,7 +200,7 @@ export default function RetailOS() {
 
               <p>
                 retailOS turns location into a first-class interface for both
-                sides of the counter—elevating service, speeding work, and
+                sides of the counter, elevating service, speeding work, and
                 making stores more personal and more profitable.
               </p>
 

--- a/client/src/pages/blog/RoboticsOS.tsx
+++ b/client/src/pages/blog/RoboticsOS.tsx
@@ -87,7 +87,7 @@ export default function RoboticsOS() {
 
               <h2>Living digital twins that stay accurate</h2>
               <p>
-                Blueprint’s digital twins are not dusty scans—they are living
+                Blueprint's digital twins are not dusty scans. They are living
                 systems co-authored by staff and robots. Every shelf, piece of
                 equipment, sensor, and policy is structured, versioned, and tied
                 to permissions. Updates flow bidirectionally so data stays fresh
@@ -196,7 +196,7 @@ export default function RoboticsOS() {
                   <strong>Billing model:</strong>{" "}
                   <span className="whitespace-nowrap">$0.20 per API call</span>,
                   billed to the <strong>location operator</strong> for every
-                  roboticsOS request (sessions, navigation, lookups)—whether the
+                  roboticsOS request (sessions, navigation, lookups), whether the
                   robot belongs to the site’s crew or is a visiting consumer
                   robot.
                 </p>
@@ -209,8 +209,8 @@ export default function RoboticsOS() {
               <p>
                 Most teams fold usage into the{" "}
                 <strong>location operator’s Blueprint license</strong> or
-                pre-purchased credits, so any approved robot—owned by the brand,
-                a contractor, or a robot OEM—can plug in without friction. OEMs
+                pre-purchased credits, so any approved robot (owned by the brand,
+                a contractor, or a robot OEM) can plug in without friction. OEMs
                 can also buy <strong>usage-based passes</strong> on behalf of
                 their customers.{" "}
                 <em>Consumer end-users never pay Blueprint at the site:</em> the

--- a/client/src/pages/blog/WarehouseOS.tsx
+++ b/client/src/pages/blog/WarehouseOS.tsx
@@ -30,7 +30,7 @@ export default function WarehouseOS() {
               </h1>
               <p>
                 Blueprint is building the operating system for physical
-                spaces—our motto is
+                spaces. Our motto is
                 <strong>"know the place to serve the person."</strong>{" "}
                 warehouseOS brings that vision to distribution centers and
                 fulfillment sites, blending AR and AI to understand every aisle,

--- a/client/src/pages/blog/WorkplaceOS.tsx
+++ b/client/src/pages/blog/WorkplaceOS.tsx
@@ -33,12 +33,12 @@ export default function WorkplaceOS() {
 
               <p>
                 Blueprint is building the operating system for physical
-                spaces—our motto is{" "}
+                spaces. Our motto is{" "}
                 <strong>"know the place to serve the person."</strong>{" "}
                 workplaceOS brings that vision to offices, labs, and frontline
                 hubs. It blends AR and AI so <em>people</em> see the right data
-                in the right place—KPIs on a production cell, SLA health at a
-                help desk, context from docs right on the machine—turning every
+                in the right place: KPIs on a production cell, SLA health at a
+                help desk, and context from docs right on the machine. This turns every
                 workspace into a live, spatial dashboard.{" "}
                 <sup>
                   <a href="#src-1">[1]</a>
@@ -58,7 +58,7 @@ export default function WorkplaceOS() {
               <ul>
                 <li>
                   <strong>Walk-around dashboards:</strong> Live KPIs anchored to
-                  zones—capacity, cycle time, queue depth, SLA risk—fed by your
+                  zones (capacity, cycle time, queue depth, SLA risk) fed by your
                   existing tools (BI, IoT, ITSM).
                 </li>
                 <li>
@@ -73,8 +73,8 @@ export default function WorkplaceOS() {
                   routes appear where they matter.
                 </li>
                 <li>
-                  <strong>Scenario previews:</strong> Try “what-ifs” in AR—new
-                  seating plan, line balance, or shift mix—then commit with one
+                  <strong>Scenario previews:</strong> Try "what-ifs" in AR: new
+                  seating plan, line balance, or shift mix. Then commit with one
                   tap.
                 </li>
               </ul>
@@ -84,14 +84,14 @@ export default function WorkplaceOS() {
                 <li>
                   <strong>Guided work:</strong> Step-by-step AR instructions and
                   checklists attached to the exact station, tool, or
-                  rack—hands-free confirmations reduce rework.{" "}
+                  rack. Hands-free confirmations reduce rework.{" "}
                   <sup>
                     <a href="#src-5">[5]</a>
                   </sup>
                 </li>
                 <li>
                   <strong>Instant answers:</strong> Ask natural
-                  questions—“Torque spec for pump A?” “Latest SOP?”—and get
+                  questions ("Torque spec for pump A?" "Latest SOP?") and get
                   verified answers from connected sources (Confluence, Drive,
                   SharePoint, Jira, GitHub).
                 </li>
@@ -112,7 +112,7 @@ export default function WorkplaceOS() {
                 </li>
                 <li>
                   <strong>Cross-system actions:</strong> Open a ticket, update a
-                  task, start a runbook, or log a defect—without breaking flow.
+                  task, start a runbook, or log a defect without breaking flow.
                 </li>
               </ul>
 
@@ -158,7 +158,7 @@ export default function WorkplaceOS() {
                   <strong>Immersive learning (VR baseline):</strong> Learners
                   were <strong>4× faster</strong> to train and up to{" "}
                   <strong>~275% more confident</strong> than classroom in PwC’s
-                  study—evidence that spatial learning lifts speed and
+                  study, evidence that spatial learning lifts speed and
                   retention.{" "}
                   <sup>
                     <a href="#src-6">[6]</a>
@@ -232,7 +232,7 @@ export default function WorkplaceOS() {
               </ol>
 
               <p>
-                workplaceOS uses <em>place as the interface</em>—so leaders can
+                workplaceOS uses <em>place as the interface</em>, so leaders can
                 steer with live context and teams can do their best work with
                 the right guidance, right where the work happens.
               </p>


### PR DESCRIPTION
Replace em-dashes with proper punctuation (periods, commas, colons, parentheses) throughout the site copy to improve readability and avoid AI-writing markers.