### PR TITLE
Fix completeCheckout error in Blueprint WebApp

### DIFF
--- a/client/src/components/Analytics.tsx
+++ b/client/src/components/Analytics.tsx
@@ -106,6 +106,9 @@ export const analyticsEvents = {
   beginCheckout: (itemId: string, value: number) =>
     trackEvent("begin_checkout", { item_id: itemId, value, currency: "USD" }),
 
+  completeCheckout: (source: string, value: number) =>
+    trackEvent("checkout_complete", { source, value, currency: "USD" }),
+
   purchaseComplete: (transactionId: string, value: number) =>
     trackEvent("purchase", { transaction_id: transactionId, value, currency: "USD" }),
 


### PR DESCRIPTION
The Environments.tsx page was calling analyticsEvents.completeCheckout() to track successful checkout events, but this method didn't exist on the analyticsEvents object in Analytics.tsx. Added the method to fix the TypeScript build error.