### PR TITLE
Fix scroll position when opening scene details

### DIFF
--- a/client/src/pages/EnvironmentDetail.tsx
+++ b/client/src/pages/EnvironmentDetail.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Helmet } from "react-helmet";
 import { loadStripe } from "@stripe/stripe-js";
 import {
@@ -32,6 +32,11 @@ interface EnvironmentDetailProps {
 
 export default function EnvironmentDetail({ params }: EnvironmentDetailProps) {
   const [isRedirecting, setIsRedirecting] = useState(false);
+
+  // Scroll to top when navigating to this page
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
 
   const marketplaceDataset = syntheticDatasets.find(
     (item) => item.slug === params.slug,


### PR DESCRIPTION
When navigating from the environments list to a scene detail page, the scroll position was preserved from the previous page. Added a useEffect hook to scroll to the top when the EnvironmentDetail component mounts.