### PR TITLE
Remove pricing page from footer

### DIFF
--- a/client/src/components/site/Footer.tsx
+++ b/client/src/components/site/Footer.tsx
@@ -3,7 +3,6 @@ const footerLinks = [
   { label: "Solutions", href: "/solutions" },
   { label: "Docs", href: "/docs" },
 //  { label: "Case Studies", href: "/case-studies" },
-  { label: "Pricing", href: "/solutions#pricing" },
   { label: "Careers", href: "/careers" },
   { label: "Contact", href: "/contact" },
   { label: "Privacy", href: "/privacy" },


### PR DESCRIPTION
Pricing information is already displayed on each card/SKU, making a separate pricing page redundant.