### PR TITLE
Clarify frames versus episodes terminology

### DIFF
--- a/client/src/components/site/MarketplaceCard.tsx
+++ b/client/src/components/site/MarketplaceCard.tsx
@@ -1,7 +1,7 @@
 import type { MouseEvent } from "react";
 import { useState, useCallback } from "react";
 import { loadStripe } from "@stripe/stripe-js";
-import { Shield, Package, Sparkles, TrendingUp, ShoppingCart, Loader2 } from "lucide-react";
+import { Shield, Package, Sparkles, TrendingUp, ShoppingCart, Loader2, Play, Layers } from "lucide-react";
 import type { SyntheticDataset, MarketplaceScene } from "@/data/content";
 import { useLocation } from "wouter";
 
@@ -178,10 +178,14 @@ export function MarketplaceCard({ item, type }: MarketplaceCardProps) {
         )}
 
         {/* Type badge */}
-        <div className="absolute bottom-3 left-3">
+        <div className="absolute bottom-3 left-3 flex gap-2">
           <span className="inline-flex items-center gap-1.5 rounded-full border border-white/30 bg-black/60 px-2.5 py-1 text-xs font-semibold text-white backdrop-blur-sm">
             <Package className="h-3 w-3" />
             {isDataset ? "Dataset Bundle" : "Single Scene"}
+          </span>
+          <span className="inline-flex items-center gap-1 rounded-full border border-emerald-400/30 bg-emerald-500/80 px-2 py-1 text-[10px] font-bold text-white backdrop-blur-sm">
+            <Play className="h-2.5 w-2.5" />
+            + Episodes
           </span>
         </div>
       </div>
@@ -209,60 +213,79 @@ export function MarketplaceCard({ item, type }: MarketplaceCardProps) {
             <>
               <div className="flex items-baseline gap-2">
                 <span className="text-2xl font-bold text-zinc-900">
-                  ${mainPrice}
+                  ${dataset!.bundlePrice?.toLocaleString()}
                 </span>
-                <span className="text-sm text-zinc-500">/scene</span>
-                {dataset!.standardPricePerScene && (
-                  <span className="text-sm text-zinc-400 line-through">
-                    ${dataset!.standardPricePerScene}
-                  </span>
-                )}
+                <span className="text-xs font-medium text-emerald-600 bg-emerald-50 px-1.5 py-0.5 rounded">
+                  Scene + Episodes
+                </span>
               </div>
               <div className="text-xs text-zinc-500">
-                Total bundle: ${totalBundlePrice.toLocaleString()} ({dataset!.sceneCount} scenes)
+                {dataset!.sceneCount} scenes • {dataset!.variationCount?.toLocaleString()} variations • {dataset!.episodeCount?.toLocaleString()} episodes
               </div>
             </>
           ) : (
-            <div className="flex items-baseline gap-2">
-              <span className="text-2xl font-bold text-zinc-900">
-                ${mainPrice}
-              </span>
-            </div>
+            <>
+              <div className="flex items-baseline gap-2">
+                <span className="text-2xl font-bold text-zinc-900">
+                  ${scene!.bundlePrice || scene!.price}
+                </span>
+                <span className="text-xs font-medium text-emerald-600 bg-emerald-50 px-1.5 py-0.5 rounded">
+                  Scene + Episodes
+                </span>
+              </div>
+              <div className="text-xs text-zinc-500">
+                {(scene!.variationCount || 500).toLocaleString()} variations • {(scene!.episodeCount || 5000).toLocaleString()} AI-generated episodes
+              </div>
+            </>
           )}
         </div>
 
         {/* Stats Grid */}
         <div
-          className={`mb-4 grid ${isDataset ? "grid-cols-2" : "grid-cols-1"} gap-2 rounded-lg border border-zinc-100 bg-zinc-50 p-3`}
+          className={`mb-4 grid ${isDataset ? "grid-cols-2" : "grid-cols-2"} gap-2 rounded-lg border border-zinc-100 bg-zinc-50 p-3`}
         >
           {isDataset ? (
             <>
               <div>
-                <div className="text-[10px] uppercase tracking-wider text-zinc-500">
-                  Scenes
+                <div className="flex items-center gap-1 text-[10px] uppercase tracking-wider text-zinc-500">
+                  <Layers className="h-3 w-3" />
+                  Variations
                 </div>
                 <div className="font-mono text-sm font-semibold text-zinc-900">
-                  {dataset!.sceneCount}
+                  {dataset!.variationCount?.toLocaleString()}
                 </div>
               </div>
               <div>
-                <div className="text-[10px] uppercase tracking-wider text-zinc-500">
-                  Frames
+                <div className="flex items-center gap-1 text-[10px] uppercase tracking-wider text-zinc-500">
+                  <Play className="h-3 w-3" />
+                  Episodes
                 </div>
                 <div className="font-mono text-sm font-semibold text-zinc-900">
-                  {dataset!.frameCount?.toLocaleString()}
+                  {dataset!.episodeCount?.toLocaleString()}
                 </div>
               </div>
             </>
           ) : (
-            <div>
-              <div className="text-[10px] uppercase tracking-wider text-zinc-500">
-                Frames
+            <>
+              <div>
+                <div className="flex items-center gap-1 text-[10px] uppercase tracking-wider text-zinc-500">
+                  <Layers className="h-3 w-3" />
+                  Variations
+                </div>
+                <div className="font-mono text-sm font-semibold text-zinc-900">
+                  {(scene!.variationCount || 500).toLocaleString()}
+                </div>
               </div>
-              <div className="font-mono text-sm font-semibold text-zinc-900">
-                {(scene!.frameCount || 1000).toLocaleString()}
+              <div>
+                <div className="flex items-center gap-1 text-[10px] uppercase tracking-wider text-zinc-500">
+                  <Play className="h-3 w-3" />
+                  Episodes
+                </div>
+                <div className="font-mono text-sm font-semibold text-zinc-900">
+                  {(scene!.episodeCount || 5000).toLocaleString()}
+                </div>
               </div>
-            </div>
+            </>
           )}
         </div>
 

--- a/client/src/data/content.ts
+++ b/client/src/data/content.ts
@@ -65,7 +65,14 @@ export interface SyntheticDataset {
   objectTags: string[];
   pricePerScene: number;
   sceneCount: number;
-  frameCount: number;
+  variationCount: number;
+  // Episode data - AI-generated trajectories for each variation
+  episodeCount: number;
+  episodesPerVariation: number;
+  // Pricing options
+  sceneOnlyPrice: number; // Price for just scene + variations (no episodes)
+  episodesOnlyPrice: number; // Price for just episodes (requires owning scene)
+  bundlePrice: number; // Discounted price for scene + episodes together
   releaseDate: string;
   tags: string[];
   randomizerScripts: string[];
@@ -85,8 +92,15 @@ export interface MarketplaceScene {
   locationType: string;
   policySlugs: string[];
   objectTags: string[];
-  price: number; // Individual scene price
-  frameCount?: number;
+  price: number; // Individual scene price (legacy, use sceneOnlyPrice for new pricing)
+  variationCount?: number;
+  // Episode data - AI-generated trajectories for each variation
+  episodeCount?: number;
+  episodesPerVariation?: number;
+  // Pricing options
+  sceneOnlyPrice?: number; // Price for just scene + variations (no episodes)
+  episodesOnlyPrice?: number; // Price for just episodes (requires owning scene)
+  bundlePrice?: number; // Discounted price for scene + episodes together
   releaseDate: string;
   tags: string[];
   deliverables: string[];
@@ -321,7 +335,12 @@ export const syntheticDatasets: SyntheticDataset[] = [
     pricePerScene: 65,
     standardPricePerScene: 185,
     sceneCount: 150,
-    frameCount: 1500,
+    variationCount: 1500,
+    episodeCount: 15000,
+    episodesPerVariation: 10,
+    sceneOnlyPrice: 4500,
+    episodesOnlyPrice: 6500,
+    bundlePrice: 9750,
     releaseDate: "2024-12-12",
     tags: ["Articulated", "Plug & Play", "USD"],
     randomizerScripts: [
@@ -346,7 +365,12 @@ export const syntheticDatasets: SyntheticDataset[] = [
     pricePerScene: 58,
     standardPricePerScene: 175,
     sceneCount: 110,
-    frameCount: 1200,
+    variationCount: 1200,
+    episodeCount: 12000,
+    episodesPerVariation: 10,
+    sceneOnlyPrice: 3500,
+    episodesOnlyPrice: 5000,
+    bundlePrice: 7500,
     releaseDate: "2024-12-05",
     tags: ["Retail", "High SKU", "Randomized"],
     randomizerScripts: ["SKU swaps", "Cart clutter", "Lighting color temp"],
@@ -365,7 +389,12 @@ export const syntheticDatasets: SyntheticDataset[] = [
     pricePerScene: 72,
     standardPricePerScene: 195,
     sceneCount: 200,
-    frameCount: 2000,
+    variationCount: 2000,
+    episodeCount: 20000,
+    episodesPerVariation: 10,
+    sceneOnlyPrice: 6000,
+    episodesOnlyPrice: 9000,
+    bundlePrice: 13500,
     releaseDate: "2024-11-28",
     tags: ["Industrial", "Heavy lift", "Conveyor-ready"],
     randomizerScripts: [
@@ -392,7 +421,12 @@ export const syntheticDatasets: SyntheticDataset[] = [
     pricePerScene: 84,
     standardPricePerScene: 220,
     sceneCount: 65,
-    frameCount: 1000,
+    variationCount: 1000,
+    episodeCount: 10000,
+    episodesPerVariation: 10,
+    sceneOnlyPrice: 3000,
+    episodesOnlyPrice: 4500,
+    bundlePrice: 6500,
     releaseDate: "2024-11-22",
     tags: ["Cleanroom", "Controls", "QA"],
     randomizerScripts: ["Gauge offsets", "Cabinet wiring", "Consumable clutter"],
@@ -411,7 +445,12 @@ export const syntheticDatasets: SyntheticDataset[] = [
     pricePerScene: 52,
     standardPricePerScene: 150,
     sceneCount: 90,
-    frameCount: 800,
+    variationCount: 800,
+    episodeCount: 8000,
+    episodesPerVariation: 10,
+    sceneOnlyPrice: 2500,
+    episodesOnlyPrice: 3500,
+    bundlePrice: 5200,
     releaseDate: "2024-11-18",
     tags: ["Inspection", "Low light", "Compact"],
     randomizerScripts: ["Status LEDs", "Valve state", "Dust + grime"],
@@ -429,7 +468,12 @@ export const syntheticDatasets: SyntheticDataset[] = [
     pricePerScene: 50,
     standardPricePerScene: 165,
     sceneCount: 50,
-    frameCount: 600,
+    variationCount: 600,
+    episodeCount: 6000,
+    episodesPerVariation: 10,
+    sceneOnlyPrice: 1800,
+    episodesOnlyPrice: 2700,
+    bundlePrice: 3900,
     releaseDate: "2024-11-12",
     tags: ["Assistive", "Household", "Soft goods"],
     randomizerScripts: ["Fabric types", "Lighting temp", "Clutter"],
@@ -448,7 +492,12 @@ export const marketplaceScenes: MarketplaceScene[] = [
     policySlugs: ["dexterous-pick-place", "articulated-access-validation"],
     objectTags: ["dishwashers", "shelves", "utensils"],
     price: 185,
-    frameCount: 750,
+    variationCount: 750,
+    episodeCount: 7500,
+    episodesPerVariation: 10,
+    sceneOnlyPrice: 85,
+    episodesOnlyPrice: 125,
+    bundlePrice: 185,
     releaseDate: "2024-12-01",
     tags: ["Articulated", "High-detail", "USD"],
     deliverables: ["USD / Isaac 4.x", "Replicator semantics"],
@@ -465,7 +514,12 @@ export const marketplaceScenes: MarketplaceScene[] = [
     policySlugs: ["dexterous-pick-place", "mixed-sku-logistics"],
     objectTags: ["coolers", "shelves", "totes"],
     price: 195,
-    frameCount: 600,
+    variationCount: 600,
+    episodeCount: 6000,
+    episodesPerVariation: 10,
+    sceneOnlyPrice: 90,
+    episodesOnlyPrice: 130,
+    bundlePrice: 195,
     releaseDate: "2024-11-29",
     tags: ["Retail", "Cold storage", "Randomized"],
     deliverables: ["USD", "Synthetic sensor captures"],
@@ -481,6 +535,12 @@ export const marketplaceScenes: MarketplaceScene[] = [
     policySlugs: ["mixed-sku-logistics"],
     objectTags: ["pallets", "cartons", "racking"],
     price: 175,
+    variationCount: 500,
+    episodeCount: 5000,
+    episodesPerVariation: 10,
+    sceneOnlyPrice: 80,
+    episodesOnlyPrice: 115,
+    bundlePrice: 175,
     releaseDate: "2024-11-25",
     tags: ["Industrial", "Heavy lift"],
     deliverables: ["USD", "URDF"],
@@ -496,7 +556,12 @@ export const marketplaceScenes: MarketplaceScene[] = [
     policySlugs: ["precision-insertion-assembly", "panel-interaction-suite"],
     objectTags: ["sample racks", "valves", "drawers"],
     price: 220,
-    frameCount: 500,
+    variationCount: 500,
+    episodeCount: 5000,
+    episodesPerVariation: 10,
+    sceneOnlyPrice: 100,
+    episodesOnlyPrice: 145,
+    bundlePrice: 220,
     releaseDate: "2024-11-20",
     tags: ["Cleanroom", "Precision", "Controls"],
     deliverables: ["USD", "STEP", "Semantic layers"],
@@ -513,6 +578,12 @@ export const marketplaceScenes: MarketplaceScene[] = [
     policySlugs: ["panel-interaction-suite"],
     objectTags: ["breakers", "switches", "knobs"],
     price: 150,
+    variationCount: 400,
+    episodeCount: 4000,
+    episodesPerVariation: 10,
+    sceneOnlyPrice: 70,
+    episodesOnlyPrice: 100,
+    bundlePrice: 150,
     releaseDate: "2024-11-18",
     tags: ["Inspection", "Controls", "Compact"],
     deliverables: ["USD", "Event scripts"],
@@ -528,7 +599,12 @@ export const marketplaceScenes: MarketplaceScene[] = [
     policySlugs: ["laundry-folding-assist"],
     objectTags: ["washers", "dryers", "hampers"],
     price: 165,
-    frameCount: 500,
+    variationCount: 500,
+    episodeCount: 5000,
+    episodesPerVariation: 10,
+    sceneOnlyPrice: 75,
+    episodesOnlyPrice: 110,
+    bundlePrice: 165,
     releaseDate: "2024-11-15",
     tags: ["Assistive", "Household"],
     deliverables: ["USD", "URDF"],
@@ -544,7 +620,12 @@ export const marketplaceScenes: MarketplaceScene[] = [
     policySlugs: ["dexterous-pick-place", "articulated-access-validation"],
     objectTags: ["drawers", "utensils", "appliances"],
     price: 170,
-    frameCount: 1000,
+    variationCount: 1000,
+    episodeCount: 10000,
+    episodesPerVariation: 10,
+    sceneOnlyPrice: 80,
+    episodesOnlyPrice: 115,
+    bundlePrice: 170,
     releaseDate: "2024-12-08",
     tags: ["Articulated", "USD"],
     deliverables: ["USD / Isaac 4.x", "Isaac 5.x"],
@@ -561,6 +642,12 @@ export const marketplaceScenes: MarketplaceScene[] = [
     policySlugs: ["dexterous-pick-place", "panel-interaction-suite"],
     objectTags: ["drawers", "shelves"],
     price: 190,
+    variationCount: 600,
+    episodeCount: 6000,
+    episodesPerVariation: 10,
+    sceneOnlyPrice: 85,
+    episodesOnlyPrice: 130,
+    bundlePrice: 190,
     releaseDate: "2024-11-27",
     tags: ["Retail", "POS", "Articulated"],
     deliverables: ["USD", "Synthetic sensor captures"],
@@ -576,6 +663,12 @@ export const marketplaceScenes: MarketplaceScene[] = [
     policySlugs: ["mixed-sku-logistics", "dexterous-pick-place"],
     objectTags: ["pallets", "totes"],
     price: 180,
+    variationCount: 550,
+    episodeCount: 5500,
+    episodesPerVariation: 10,
+    sceneOnlyPrice: 80,
+    episodesOnlyPrice: 120,
+    bundlePrice: 180,
     releaseDate: "2024-11-23",
     tags: ["Industrial", "Logistics"],
     deliverables: ["USD", "Isaac Mission playback"],
@@ -591,7 +684,12 @@ export const marketplaceScenes: MarketplaceScene[] = [
     policySlugs: ["precision-insertion-assembly"],
     objectTags: ["sample racks", "drawers"],
     price: 210,
-    frameCount: 750,
+    variationCount: 750,
+    episodeCount: 7500,
+    episodesPerVariation: 10,
+    sceneOnlyPrice: 95,
+    episodesOnlyPrice: 140,
+    bundlePrice: 210,
     releaseDate: "2024-11-19",
     tags: ["Precision", "Assembly"],
     deliverables: ["USD", "STEP"],
@@ -607,6 +705,12 @@ export const marketplaceScenes: MarketplaceScene[] = [
     policySlugs: ["panel-interaction-suite"],
     objectTags: ["valves", "knobs"],
     price: 155,
+    variationCount: 450,
+    episodeCount: 4500,
+    episodesPerVariation: 10,
+    sceneOnlyPrice: 70,
+    episodesOnlyPrice: 105,
+    bundlePrice: 155,
     releaseDate: "2024-11-17",
     tags: ["Inspection", "Industrial"],
     deliverables: ["USD", "GLTF"],
@@ -622,6 +726,12 @@ export const marketplaceScenes: MarketplaceScene[] = [
     policySlugs: ["laundry-folding-assist"],
     objectTags: ["folding tables", "hampers"],
     price: 160,
+    variationCount: 400,
+    episodeCount: 4000,
+    episodesPerVariation: 10,
+    sceneOnlyPrice: 75,
+    episodesOnlyPrice: 105,
+    bundlePrice: 160,
     releaseDate: "2024-11-14",
     tags: ["Assistive", "Soft goods"],
     deliverables: ["USD", "Teleop demos"],
@@ -637,7 +747,12 @@ export const marketplaceScenes: MarketplaceScene[] = [
     policySlugs: ["dexterous-pick-place"],
     objectTags: ["shelves", "appliances"],
     price: 175,
-    frameCount: 500,
+    variationCount: 500,
+    episodeCount: 5000,
+    episodesPerVariation: 10,
+    sceneOnlyPrice: 80,
+    episodesOnlyPrice: 115,
+    bundlePrice: 175,
     releaseDate: "2024-12-02",
     tags: ["Food service", "Articulated"],
     deliverables: ["USD / Isaac 4.x"],
@@ -653,7 +768,12 @@ export const marketplaceScenes: MarketplaceScene[] = [
     policySlugs: ["dexterous-pick-place", "precision-insertion-assembly"],
     objectTags: ["drawers", "shelves"],
     price: 225,
-    frameCount: 500,
+    variationCount: 500,
+    episodeCount: 5000,
+    episodesPerVariation: 10,
+    sceneOnlyPrice: 105,
+    episodesOnlyPrice: 150,
+    bundlePrice: 225,
     releaseDate: "2024-11-30",
     tags: ["Healthcare", "Precision", "Secure"],
     deliverables: ["USD", "Semantic layers"],
@@ -670,6 +790,12 @@ export const marketplaceScenes: MarketplaceScene[] = [
     policySlugs: ["mixed-sku-logistics", "dexterous-pick-place"],
     objectTags: ["totes", "racking"],
     price: 185,
+    variationCount: 550,
+    episodeCount: 5500,
+    episodesPerVariation: 10,
+    sceneOnlyPrice: 85,
+    episodesOnlyPrice: 125,
+    bundlePrice: 185,
     releaseDate: "2024-11-24",
     tags: ["Industrial", "AMR-ready"],
     deliverables: ["USD", "URDF"],
@@ -685,7 +811,12 @@ export const marketplaceScenes: MarketplaceScene[] = [
     policySlugs: ["articulated-access-validation", "panel-interaction-suite"],
     objectTags: ["doors", "switches"],
     price: 200,
-    frameCount: 500,
+    variationCount: 500,
+    episodeCount: 5000,
+    episodesPerVariation: 10,
+    sceneOnlyPrice: 90,
+    episodesOnlyPrice: 135,
+    bundlePrice: 200,
     releaseDate: "2024-11-21",
     tags: ["Cleanroom", "Safety"],
     deliverables: ["USD", "Event scripts"],
@@ -701,6 +832,12 @@ export const marketplaceScenes: MarketplaceScene[] = [
     policySlugs: ["panel-interaction-suite"],
     objectTags: ["switches", "knobs"],
     price: 165,
+    variationCount: 400,
+    episodeCount: 4000,
+    episodesPerVariation: 10,
+    sceneOnlyPrice: 75,
+    episodesOnlyPrice: 110,
+    bundlePrice: 165,
     releaseDate: "2024-11-16",
     tags: ["HVAC", "Controls"],
     deliverables: ["USD", "GLTF"],
@@ -716,7 +853,12 @@ export const marketplaceScenes: MarketplaceScene[] = [
     policySlugs: ["laundry-folding-assist", "articulated-access-validation"],
     objectTags: ["drawers", "hampers"],
     price: 180,
-    frameCount: 750,
+    variationCount: 750,
+    episodeCount: 7500,
+    episodesPerVariation: 10,
+    sceneOnlyPrice: 80,
+    episodesOnlyPrice: 120,
+    bundlePrice: 180,
     releaseDate: "2024-11-13",
     tags: ["Assistive", "Organization"],
     deliverables: ["USD"],
@@ -746,7 +888,7 @@ export const sceneRecipes: SceneRecipe[] = [
     domainRandomization: [
       "SKU swaps + facing randomization",
       "Clutter permutations on support surfaces",
-      "HDRI + time-of-day lighting (500–2,000 frames/scene)",
+      "HDRI + time-of-day lighting (500–2,000 variations/scene)",
     ],
     deliverables: [
       "Lightweight .usda layout",
@@ -778,7 +920,7 @@ export const sceneRecipes: SceneRecipe[] = [
     domainRandomization: [
       "Tote + carton swaps with scale normalization",
       "Spawn density + aisle clutter controls",
-      "HDRI + area light profiles (500–2,000 frames/scene)",
+      "HDRI + area light profiles (500–2,000 variations/scene)",
     ],
     deliverables: [
       ".usda lane scaffold",
@@ -810,7 +952,7 @@ export const sceneRecipes: SceneRecipe[] = [
     domainRandomization: [
       "Utensil + smallware swaps",
       "Lighting temperature + intensity",
-      "Pose noise + articulation states (500–2,000 frames/scene)",
+      "Pose noise + articulation states (500–2,000 variations/scene)",
     ],
     deliverables: [
       ".usda layout layer",
@@ -842,7 +984,7 @@ export const sceneRecipes: SceneRecipe[] = [
     domainRandomization: [
       "Rack + instrument swaps",
       "Material randomization for benches + flooring",
-      "Light temperature + intensity sweeps (500–2,000 frames/scene)",
+      "Light temperature + intensity sweeps (500–2,000 variations/scene)",
     ],
     deliverables: [
       ".usda interface layer",
@@ -873,7 +1015,7 @@ export const sceneRecipes: SceneRecipe[] = [
     domainRandomization: [
       "Switchgear + breaker swaps",
       "Dust/wear material randomization",
-      "Spotlight + area light rigs (500–2,000 frames/scene)",
+      "Spotlight + area light rigs (500–2,000 variations/scene)",
     ],
     deliverables: [
       ".usda layout",
@@ -905,7 +1047,7 @@ export const sceneRecipes: SceneRecipe[] = [
     domainRandomization: [
       "Garment + hamper swaps",
       "Fold-surface clutter controls",
-      "HDRI + temperature shifts (500–2,000 frames/scene)",
+      "HDRI + temperature shifts (500–2,000 variations/scene)",
     ],
     deliverables: [
       "Lightweight .usda layer",
@@ -1193,7 +1335,7 @@ export const scenes: Scene[] = [
     ctaText: "Add to quote",
     seo: "Bulk dry goods aisle with articulated dispensers and scale for manipulation tasks.",
     highlights: [
-      "Seeded frames for dataset diversity",
+      "Seeded variations for dataset diversity",
       "Embedded signage metadata",
       "Material IDs for granular fill levels",
     ],
@@ -1284,7 +1426,7 @@ export const scenes: Scene[] = [
     ctaText: "Reserve",
     seo: "Cross-dock staging area with articulated dock lever and pallet handling assets.",
     highlights: [
-      "Rainy + sunny lighting frames",
+      "Rainy + sunny lighting variations",
       "Restraint sensors flagged as USD tokens",
       "Line markings exported as semantic layers",
     ],
@@ -1330,7 +1472,7 @@ export const scenes: Scene[] = [
     seo: "Pallet buffer zone tuned for palletizing and AMR handoff policies.",
     highlights: [
       "Fork pocket physics volumes",
-      "Dynamic signage frames",
+      "Dynamic signage variations",
       "Safety envelope markup",
     ],
   },
@@ -1374,7 +1516,7 @@ export const scenes: Scene[] = [
     ctaText: "Join waitlist",
     seo: "Dock-high bay environment with articulated leveler and vehicle restraint for automation pilots.",
     highlights: [
-      "Weather frames bundled",
+      "Weather variations bundled",
       "Truck approach spline annotated",
       "Collision proxies tuned for compliance",
     ],
@@ -1510,7 +1652,7 @@ export const scenes: Scene[] = [
     ctaText: "Book",
     seo: "Sample preparation lab with articulated fume hood and carousel.",
     highlights: [
-      "UV-safe texture frames",
+      "UV-safe texture variations",
       "Calibrated lighting for machine vision",
       "Semantic tags for reagents",
     ],
@@ -1647,7 +1789,7 @@ export const scenes: Scene[] = [
     highlights: [
       "Utility labels with text metadata",
       "Floor drain SDF",
-      "Hook height frames",
+      "Hook height variations",
     ],
   },
   {
@@ -1735,7 +1877,7 @@ export const scenes: Scene[] = [
     ctaText: "Request scene",
     seo: "Residential laundry alcove with articulated washer and dryer controls.",
     highlights: [
-      "Stacked + side-by-side frames",
+      "Stacked + side-by-side variations",
       "Laundry basket spawn points",
       "High-contrast textures for assistive research",
     ],
@@ -1769,7 +1911,7 @@ export const caseStudies: CaseStudy[] = [
     outcomes: [
       "Cut policy tuning time by 60%",
       "Validated AMR clearances before site visit",
-      "Delivered 4 scenario frames in under 10 days",
+      "Delivered 4 scenario variations in under 10 days",
     ],
     cta: "Book a warehouse walkthrough",
   },
@@ -1782,7 +1924,7 @@ export const caseStudies: CaseStudy[] = [
     body:
       "We rebuilt a flagship retail aisle with signage, price tags, and semantic IDs. Teams trained grasp-place behaviors, tuned suction compliance, and exported annotation-ready datasets.",
     outcomes: [
-      "8x shelf frames",
+      "8x shelf variations",
       "Product-level semantic metadata",
       "SLAM validation with synthetic-lidar",
     ],
@@ -2346,7 +2488,7 @@ export const jobs: Job[] = [
 //     ctaText: "Add to quote",
 //     seo: "Bulk dry goods aisle with articulated dispensers and scale for manipulation tasks.",
 //     highlights: [
-//       "Seeded frames for dataset diversity",
+//       "Seeded variations for dataset diversity",
 //       "Embedded signage metadata",
 //       "Material IDs for granular fill levels",
 //     ],
@@ -2439,7 +2581,7 @@ export const jobs: Job[] = [
 //     ctaText: "Reserve",
 //     seo: "Cross-dock staging area with articulated dock lever and pallet handling assets.",
 //     highlights: [
-//       "Rainy + sunny lighting frames",
+//       "Rainy + sunny lighting variations",
 //       "Restraint sensors flagged as USD tokens",
 //       "Line markings exported as semantic layers",
 //     ],
@@ -2486,7 +2628,7 @@ export const jobs: Job[] = [
 //     seo: "Pallet buffer zone tuned for palletizing and AMR handoff policies.",
 //     highlights: [
 //       "Fork pocket physics volumes",
-//       "Dynamic signage frames",
+//       "Dynamic signage variations",
 //       "Safety envelope markup",
 //     ],
 //   },
@@ -2531,7 +2673,7 @@ export const jobs: Job[] = [
 //     ctaText: "Join waitlist",
 //     seo: "Dock-high bay environment with articulated leveler and vehicle restraint for automation pilots.",
 //     highlights: [
-//       "Weather frames bundled",
+//       "Weather variations bundled",
 //       "Truck approach spline annotated",
 //       "Collision proxies tuned for compliance",
 //     ],
@@ -2670,7 +2812,7 @@ export const jobs: Job[] = [
 //     ctaText: "Book",
 //     seo: "Sample preparation lab with articulated fume hood and carousel.",
 //     highlights: [
-//       "UV-safe texture frames",
+//       "UV-safe texture variations",
 //       "Calibrated lighting for machine vision",
 //       "Semantic tags for reagents",
 //     ],
@@ -2810,7 +2952,7 @@ export const jobs: Job[] = [
 //     highlights: [
 //       "Utility labels with text metadata",
 //       "Floor drain SDF",
-//       "Hook height frames",
+//       "Hook height variations",
 //     ],
 //   },
 //   {
@@ -2900,7 +3042,7 @@ export const jobs: Job[] = [
 //     ctaText: "Request scene",
 //     seo: "Residential laundry alcove with articulated washer and dryer controls.",
 //     highlights: [
-//       "Stacked + side-by-side frames",
+//       "Stacked + side-by-side variations",
 //       "Laundry basket spawn points",
 //       "High-contrast textures for assistive research",
 //     ],
@@ -2932,7 +3074,7 @@ export const jobs: Job[] = [
 //     outcomes: [
 //       "Cut policy tuning time by 60%",
 //       "Validated AMR clearances before site visit",
-//       "Delivered 4 scenario frames in under 10 days",
+//       "Delivered 4 scenario variations in under 10 days",
 //     ],
 //     cta: "Book a warehouse walkthrough",
 //   },
@@ -2944,7 +3086,7 @@ export const jobs: Job[] = [
 //     hero: "https://images.unsplash.com/photo-1563013544-824ae1b704d3?auto=format&fit=crop&w=1200&q=80",
 //     body: "We rebuilt a flagship retail aisle with signage, price tags, and semantic IDs. Teams trained grasp-place behaviors, tuned suction compliance, and exported annotation-ready datasets.",
 //     outcomes: [
-//       "8x shelf frames",
+//       "8x shelf variations",
 //       "Product-level semantic metadata",
 //       "SLAM validation with synthetic-lidar",
 //     ],

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -482,7 +482,7 @@ const offeringCards = [
       "Precision geometry with mass, inertia & friction properties",
       "Manifest for SimReady packs + asset fallbacks you install locally",
       "Task logic scaffolds tuned for vectorized RL and sim2real transfer",
-      "Frame generator for swaps, clutter, lighting, and articulation states (500–2,000 frames/scene)",
+      "Variation generator for swaps, clutter, lighting, and articulation states (500–2,000 variations/scene)",
     ],
     ctaLabel: "Request a recipe",
     ctaHref: "/recipes",
@@ -815,26 +815,26 @@ export default function Home() {
                 <div className="grid grid-cols-3 gap-2 rounded-lg border border-zinc-100 bg-zinc-50 p-3">
                   <div className="text-center">
                     <dt className="text-[10px] uppercase tracking-wider text-zinc-400">
-                      Cost
+                      Bundle
                     </dt>
                     <dd className="font-mono text-sm font-semibold text-zinc-900">
-                      ${dataset.pricePerScene}
+                      ${dataset.bundlePrice?.toLocaleString()}
                     </dd>
                   </div>
                   <div className="text-center border-l border-zinc-200">
                     <dt className="text-[10px] uppercase tracking-wider text-zinc-400">
-                      Scenes
+                      Variations
                     </dt>
                     <dd className="font-mono text-sm font-semibold text-zinc-900">
-                      {dataset.sceneCount}
+                      {dataset.variationCount?.toLocaleString()}
                     </dd>
                   </div>
                   <div className="text-center border-l border-zinc-200">
                     <dt className="text-[10px] uppercase tracking-wider text-zinc-400">
-                      Frames
+                      Episodes
                     </dt>
                     <dd className="font-mono text-sm font-semibold text-zinc-900">
-                      {dataset.frameCount}
+                      {dataset.episodeCount?.toLocaleString()}
                     </dd>
                   </div>
                 </div>
@@ -863,7 +863,7 @@ export default function Home() {
               Environment families
             </h2>
             <p className="mt-2 max-w-xl text-zinc-600">
-              Archetypes to anchor your wishlist. We keep releasing frames
+              Archetypes to anchor your wishlist. We keep releasing variations
               that span aisle widths, heights, and policy complexity.
             </p>
           </div>

--- a/client/src/pages/Solutions.tsx
+++ b/client/src/pages/Solutions.tsx
@@ -264,8 +264,8 @@ const recipeDeliverables = [
   },
   {
     icon: <Terminal className="h-5 w-5 text-indigo-600" />,
-    title: "Frame generator",
-    desc: "Omniverse Replicator scripts for swaps, clutter, lighting, material randomization, and articulation state noise. Typically 500–2,000 frames per scene.",
+    title: "Variation generator",
+    desc: "Omniverse Replicator scripts for swaps, clutter, lighting, material randomization, and articulation state noise. Typically 500–2,000 variations per scene, plus AI-generated episodes.",
   },
 ];
 
@@ -884,13 +884,13 @@ export default function Solutions() {
                   <Terminal className="h-3 w-3" /> Scene Recipes
                 </div>
                 <h2 className="text-3xl font-bold text-zinc-900 sm:text-4xl">
-                  Layouts, manifests, and frame generators. BYO SimReady assets.
+                  Layouts, manifests, and variation generators. BYO SimReady assets.
                 </h2>
                 <p className="text-zinc-600 leading-relaxed">
                   We deliver a lightweight USD layer plus a manifest that references NVIDIA SimReady packs you install locally. Omniverse Replicator scripts handle swaps, clutter, lighting, and articulation state randomization without us shipping the source assets.
                 </p>
                 <ul className="grid gap-3 text-sm text-zinc-700 sm:grid-cols-2">
-                  {["No asset redistribution: packs stay on your Nucleus/local disk", "Semantics + USDPhysics defaults aligned to SimReady best practices", "Frame generator tuned for RL-friendly randomization (500–2,000 frames/scene)", "Reusable integration snippets for Isaac Lab / Isaac Sim"].map(
+                  {["No asset redistribution: packs stay on your Nucleus/local disk", "Semantics + USDPhysics defaults aligned to SimReady best practices", "Variation generator tuned for RL-friendly randomization (500–2,000 variations/scene)", "Reusable integration snippets for Isaac Lab / Isaac Sim"].map(
                     (item) => (
                       <li
                         key={item}
@@ -935,9 +935,9 @@ export default function Solutions() {
                   </div>
                 ))}
                 <div className="col-span-full rounded-xl border border-emerald-100 bg-white p-5">
-                  <p className="text-xs font-bold uppercase tracking-[0.25em] text-emerald-700">Frame randomization</p>
+                  <p className="text-xs font-bold uppercase tracking-[0.25em] text-emerald-700">Variation randomization + Episodes</p>
                   <p className="mt-2 text-sm text-zinc-700">
-                    Replicator randomizes object swaps, clutter placement, HDRI/time-of-day, materials, and pose noise across hundreds of frames. We keep USD writes optional for RL loops.
+                    Replicator randomizes object swaps, clutter placement, HDRI/time-of-day, materials, and pose noise across hundreds of variations. AI-generated episodes (via Gemini) provide ready-to-train trajectories. We keep USD writes optional for RL loops.
                   </p>
                 </div>
               </div>


### PR DESCRIPTION
- Rename frameCount to variationCount throughout codebase
- Add episode-related fields to data types (episodeCount, episodesPerVariation)
- Add tiered pricing: sceneOnlyPrice, episodesOnlyPrice, bundlePrice
- Update MarketplaceCard to display variations + episodes with pricing
- Add purchase option selector in EnvironmentDetail (scene, episodes, bundle)
- Bundle includes discount with savings percentage displayed
- Note that episodes are AI-generated via Gemini
- Update all marketing copy to use "variations" instead of "frames"

This allows labs to purchase:
1. Scene only - just the 3D environment with domain randomization
2. Episodes only - AI-generated trajectories (requires scene ownership)
3. Bundle - both together at a discounted rate