### PR TITLE
Move navigation items to footer

### DIFF
--- a/client/src/components/site/Footer.tsx
+++ b/client/src/components/site/Footer.tsx
@@ -1,10 +1,9 @@
 const footerLinks = [
-  { label: "Environments", href: "/environments" },
   { label: "Solutions", href: "/solutions" },
+  { label: "Pricing", href: "/pricing" },
+  { label: "New to Simulation?", href: "/learn" },
   { label: "Docs", href: "/docs" },
-//  { label: "Case Studies", href: "/case-studies" },
-  { label: "Careers", href: "/careers" },
-  { label: "Contact", href: "/contact" },
+  { label: "Portal", href: "/portal" },
   { label: "Privacy", href: "/privacy" },
   { label: "Terms", href: "/terms" },
 ];

--- a/client/src/components/site/Header.tsx
+++ b/client/src/components/site/Header.tsx
@@ -4,13 +4,6 @@ import { Menu, X } from "lucide-react";
 
 const navLinks = [
   { href: "/environments", label: "Environments" },
-  // { href: "/recipes", label: "Scene Recipes" }, // Hidden: recipes temporarily removed from offerings
-  { href: "/solutions", label: "Solutions" },
-  { href: "/pricing", label: "Pricing" },
-  { href: "/learn", label: "New to Simulation?" },
-  { href: "/docs", label: "Docs" },
-  { href: "/portal", label: "Portal" },
- // { href: "/case-studies", label: "Case Studies" },
   { href: "/careers", label: "Careers" },
   { href: "/contact", label: "Contact" },
 ];


### PR DESCRIPTION
Move Solutions, Pricing, New to Simulation?, Docs, and Portal from the top navigation tabs to the footer. Keep Environments, Careers, and Contact in the header for main navigation.