### PR TITLE
Rename Environments tab to Scenes or Marketplace

### DIFF
--- a/client/src/components/site/Header.tsx
+++ b/client/src/components/site/Header.tsx
@@ -3,7 +3,7 @@ import { useMemo, useState } from "react";
 import { Menu, X } from "lucide-react";
 
 const navLinks = [
-  { href: "/environments", label: "Environments" },
+  { href: "/environments", label: "Marketplace" },
   { href: "/careers", label: "Careers" },
   { href: "/contact", label: "Contact" },
 ];

--- a/client/src/pages/EnvironmentDetail.tsx
+++ b/client/src/pages/EnvironmentDetail.tsx
@@ -314,7 +314,7 @@ export default function EnvironmentDetail({ params }: EnvironmentDetailProps) {
     return (
       <>
         <Helmet>
-          <title>{marketplaceItem.title} | Blueprint Environments</title>
+          <title>{marketplaceItem.title} | Blueprint Marketplace</title>
           <meta
             name="description"
             content={marketplaceItem.description}
@@ -341,7 +341,7 @@ export default function EnvironmentDetail({ params }: EnvironmentDetailProps) {
             href="/environments"
             className="inline-flex items-center gap-2 text-sm font-semibold text-indigo-600 hover:text-indigo-700"
           >
-            <ArrowLeft className="h-4 w-4" /> Back to marketplace
+            <ArrowLeft className="h-4 w-4" /> Back to Marketplace
           </a>
 
         <div className="grid gap-10 lg:grid-cols-[1.1fr_0.9fr]">
@@ -793,13 +793,13 @@ export default function EnvironmentDetail({ params }: EnvironmentDetailProps) {
           Scene not found
         </h1>
         <p className="mt-4 text-sm text-slate-600">
-          The environment you are looking for isn’t in our network yet. Browse other scenes or contact us to request a custom build.
+          The environment you are looking for isn't in our network yet. Browse other scenes or contact us to request a custom build.
         </p>
         <a
           href="/environments"
           className="mt-6 inline-flex rounded-full border border-slate-300 px-6 py-3 text-sm font-semibold text-slate-900"
         >
-          Back to environments
+          Back to Marketplace
         </a>
       </div>
     );
@@ -823,7 +823,7 @@ export default function EnvironmentDetail({ params }: EnvironmentDetailProps) {
   return (
     <>
       <Helmet>
-        <title>{scene.title} | Blueprint Environments</title>
+        <title>{scene.title} | Blueprint Marketplace</title>
         <meta name="description" content={scene.seo} />
         <meta name="robots" content="index, follow" />
         <meta property="og:type" content="product" />

--- a/client/src/pages/Environments.tsx
+++ b/client/src/pages/Environments.tsx
@@ -519,7 +519,7 @@ export default function Environments() {
     return {
       "@context": "https://schema.org",
       "@type": "CollectionPage",
-      name: "Blueprint Environments Marketplace",
+      name: "Blueprint Marketplace",
       description: "SimReady synthetic datasets and scenes for robotics training. Isaac-ready USD packages with randomizers and task logic.",
       url: "https://tryblueprint.io/environments",
       mainEntity: {
@@ -542,7 +542,7 @@ export default function Environments() {
       )}
 
       <Helmet>
-        <title>Environments Marketplace | Blueprint - SimReady Datasets for Robotics</title>
+        <title>Marketplace | Blueprint - SimReady Datasets for Robotics</title>
         <meta
           name="description"
           content="Browse SimReady synthetic datasets and individual scenes for robotics training. Isaac-ready USD packages with randomizers, task logic, and validation notes."
@@ -550,14 +550,14 @@ export default function Environments() {
         <meta name="robots" content="index, follow" />
         <meta property="og:type" content="website" />
         <meta property="og:url" content="https://tryblueprint.io/environments" />
-        <meta property="og:title" content="Environments Marketplace | Blueprint" />
+        <meta property="og:title" content="Marketplace | Blueprint" />
         <meta
           property="og:description"
           content="Browse SimReady synthetic datasets and individual scenes for robotics training. Daily drops with Isaac-ready USD packages."
         />
         <meta property="og:image" content="https://tryblueprint.io/images/Gemini_EnvironentsBanner.png" />
         <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:title" content="Environments Marketplace | Blueprint" />
+        <meta name="twitter:title" content="Marketplace | Blueprint" />
         <meta
           name="twitter:description"
           content="SimReady synthetic datasets for robotics. Isaac-ready USD packages with randomizers and task logic."

--- a/client/src/pages/Pricing.tsx
+++ b/client/src/pages/Pricing.tsx
@@ -125,7 +125,7 @@ export default function Pricing() {
                 href="/environments"
                 className="inline-flex items-center gap-2 text-sm font-semibold text-zinc-900 hover:text-zinc-700"
               >
-                Browse Environments Marketplace
+                Browse Marketplace
                 <ChevronRight className="h-4 w-4" />
               </a>
             </div>


### PR DESCRIPTION
Updated navigation label and page titles to better reflect the commercial nature of the page. Changed user-facing text from "Environments" to "Marketplace" while keeping the /environments URL route unchanged to avoid breaking existing links.

Changes:
- Header navigation: "Environments" → "Marketplace"
- Page titles: Updated in Environments.tsx and EnvironmentDetail.tsx
- Breadcrumb links: "Back to marketplace" → "Back to Marketplace"
- Pricing page: "Browse Environments Marketplace" → "Browse Marketplace"