### PR TITLE
Update website offerings and focus messaging

### DIFF
--- a/client/src/components/CheckoutModal.tsx
+++ b/client/src/components/CheckoutModal.tsx
@@ -75,7 +75,7 @@ export function CheckoutModal({ isOpen, onClose, item }: CheckoutModalProps) {
             <div>
               <h3 className="font-semibold text-zinc-900">{item.title}</h3>
               <p className="text-xs text-zinc-500 capitalize">
-                {item.type === "dataset" ? `Dataset Bundle • ${item.sceneCount || 1} scenes` : "Single Scene"}
+                {item.type === "dataset" ? `Benchmark Pack • ${item.sceneCount || 1} scenes` : "Scene Library"}
               </p>
             </div>
             <span className="text-lg font-bold text-zinc-900">

--- a/client/src/components/site/Footer.tsx
+++ b/client/src/components/site/Footer.tsx
@@ -1,7 +1,6 @@
 const footerLinks = [
   { label: "Solutions", href: "/solutions" },
-  { label: "Evals", href: "/evals" },
-  { label: "RL Training", href: "/rl-training" },
+  { label: "Benchmarks", href: "/evals" },
   { label: "Pricing", href: "/pricing" },
   { label: "New to Simulation?", href: "/learn" },
   { label: "Docs", href: "/docs" },

--- a/client/src/components/site/Header.tsx
+++ b/client/src/components/site/Header.tsx
@@ -4,8 +4,7 @@ import { Menu, X } from "lucide-react";
 
 const navLinks = [
   { href: "/environments", label: "Marketplace" },
-  { href: "/evals", label: "Evals" },
-  { href: "/rl-training", label: "RL Training" },
+  { href: "/evals", label: "Benchmarks" },
   { href: "/careers", label: "Careers" },
   { href: "/contact", label: "Contact" },
 ];

--- a/client/src/components/site/MarketplaceCard.tsx
+++ b/client/src/components/site/MarketplaceCard.tsx
@@ -181,7 +181,7 @@ export function MarketplaceCard({ item, type }: MarketplaceCardProps) {
         <div className="absolute bottom-3 left-3 flex gap-2">
           <span className="inline-flex items-center gap-1.5 rounded-full border border-white/30 bg-black/60 px-2.5 py-1 text-xs font-semibold text-white backdrop-blur-sm">
             <Package className="h-3 w-3" />
-            {isDataset ? "Dataset Bundle" : "Single Scene"}
+            {isDataset ? "Benchmark Pack" : "Scene Library"}
           </span>
           <span className="inline-flex items-center gap-1 rounded-full border border-emerald-400/30 bg-emerald-500/80 px-2 py-1 text-[10px] font-bold text-white backdrop-blur-sm">
             <Play className="h-2.5 w-2.5" />

--- a/client/src/pages/EnvironmentDetail.tsx
+++ b/client/src/pages/EnvironmentDetail.tsx
@@ -353,7 +353,7 @@ export default function EnvironmentDetail({ params }: EnvironmentDetailProps) {
             <div className="flex flex-wrap items-center gap-2">
               <span className="inline-flex items-center gap-1 rounded-full bg-zinc-900 px-3 py-1 text-xs font-semibold text-white">
                 <Package className="h-3 w-3" />
-                {isDataset ? "Dataset Bundle" : "Single Scene"}
+                {isDataset ? "Benchmark Pack" : "Scene Library"}
               </span>
               {marketplaceItem.isNew && (
                 <span className="inline-flex items-center gap-1 rounded-full bg-indigo-100 px-3 py-1 text-xs font-semibold text-indigo-700">

--- a/client/src/pages/Environments.tsx
+++ b/client/src/pages/Environments.tsx
@@ -45,8 +45,8 @@ const sortOptions = [
 
 const itemTypeOptions: Array<{ label: string; value: MarketplaceItemType }> = [
   { label: "All Items", value: "all" },
-  { label: "Dataset Bundles", value: "datasets" },
-  { label: "Single Scenes", value: "scenes" },
+  { label: "Benchmark Packs", value: "datasets" },
+  { label: "Scene Library", value: "scenes" },
 ];
 
 // Combine location types from both datasets and scenes
@@ -542,10 +542,10 @@ export default function Environments() {
       )}
 
       <Helmet>
-        <title>Marketplace | Blueprint - SimReady Datasets for Robotics</title>
+        <title>Marketplace | Blueprint - Benchmark Packs & Scene Library</title>
         <meta
           name="description"
-          content="Browse SimReady synthetic datasets and individual scenes for robotics training. Isaac-ready USD packages with randomizers, task logic, and validation notes."
+          content="Browse benchmark packs with evaluation harnesses and SimReady scenes for robotics policy evaluation. Isaac-ready USD packages with tasks, metrics, and standardized protocols."
         />
         <meta name="robots" content="index, follow" />
         <meta property="og:type" content="website" />
@@ -553,14 +553,14 @@ export default function Environments() {
         <meta property="og:title" content="Marketplace | Blueprint" />
         <meta
           property="og:description"
-          content="Browse SimReady synthetic datasets and individual scenes for robotics training. Daily drops with Isaac-ready USD packages."
+          content="Browse benchmark packs and SimReady scenes for robotics policy evaluation. Standardized benchmarks with evaluation harnesses."
         />
         <meta property="og:image" content="https://tryblueprint.io/images/Gemini_EnvironentsBanner.png" />
         <meta name="twitter:card" content="summary_large_image" />
         <meta name="twitter:title" content="Marketplace | Blueprint" />
         <meta
           name="twitter:description"
-          content="SimReady synthetic datasets for robotics. Isaac-ready USD packages with randomizers and task logic."
+          content="Benchmark packs and SimReady scenes for robotics. Isaac-ready USD packages with evaluation harnesses."
         />
         <meta name="twitter:image" content="https://tryblueprint.io/images/Gemini_EnvironentsBanner.png" />
         <link rel="canonical" href="https://tryblueprint.io/environments" />
@@ -577,19 +577,18 @@ export default function Environments() {
           <div className="space-y-6">
             <div className="inline-flex items-center gap-2 rounded-full border border-indigo-100 bg-indigo-50/50 px-3 py-1 text-xs font-medium uppercase tracking-wider text-indigo-600 backdrop-blur-sm">
               <Database className="h-3 w-3" />
-              Synthetic Marketplace
+              Marketplace
             </div>
 
             <div className="max-w-4xl">
               <h1 className="text-4xl font-bold tracking-tight text-zinc-950 sm:text-5xl lg:text-6xl">
-                Plug-and-play SimReady datasets.
+                Benchmark Packs & Scene Library
               </h1>
               <p className="mt-6 max-w-2xl text-lg text-zinc-600">
-                Daily drops of synthetic scenes authored for Isaac-ready
-                training. Each dataset includes randomizer scripts, USD
-                packages, task logic (actions, observations, rewards, resets,
-                parallel env defaults), and validation notes so you can train
-                without touching the pipeline.
+                Runnable benchmark suites with SimReady scenes, tasks, and evaluation harnesses.
+                Each pack includes USD scenes, task definitions, fixed seeds, and standardized
+                metrics so you can measure policy performance immediately. Browse individual
+                scenes for custom benchmark assembly.
               </p>
             </div>
           </div>
@@ -604,7 +603,7 @@ export default function Environments() {
               <span className="font-medium text-zinc-900">
                 {syntheticDatasets.length}
               </span>
-              active families
+              benchmark packs
             </div>
             <div className="h-4 w-px bg-zinc-300" />
             <div className="flex items-center gap-2">
@@ -620,7 +619,7 @@ export default function Environments() {
               <span className="font-medium text-zinc-900">
                 {marketplaceScenes.length}
               </span>
-              individual scenes
+              in scene library
             </div>
             {newestRelease && (
               <>
@@ -824,8 +823,8 @@ export default function Environments() {
               {itemTypeFilter === "all"
                 ? "items"
                 : itemTypeFilter === "datasets"
-                ? "dataset bundles"
-                : "individual scenes"}
+                ? "benchmark packs"
+                : "scenes"}
             </p>
             {totalPages > 1 && (
               <p className="text-zinc-400">
@@ -860,7 +859,7 @@ export default function Environments() {
                 <section className="space-y-6">
                   <div className="flex items-center gap-3">
                     <h2 className="text-2xl font-bold text-zinc-900">
-                      ⭐ Featured Dataset Bundles
+                      Featured Benchmark Packs
                     </h2>
                     <span className="rounded-full bg-indigo-100 px-3 py-1 text-xs font-bold text-indigo-700">
                       Best Value

--- a/client/src/pages/Evals.tsx
+++ b/client/src/pages/Evals.tsx
@@ -138,8 +138,8 @@ export default function Evals() {
   return (
     <>
       <SEO
-        title="Evals | Policy Evaluation at Scale"
-        description="Genie Sim 3.0 powered evaluation with VLM scoring, Isaac Lab-Arena integration, and GPU-parallel benchmarking. 100,000+ scenarios with automated task generation."
+        title="Benchmarks | Policy Evaluation at Scale"
+        description="Standardized benchmark suites for robotics policy evaluation. Genie Sim 3.0 powered with VLM scoring, Isaac Lab-Arena integration, and GPU-parallel benchmarking."
         canonical="/evals"
       />
       <div className="relative min-h-screen bg-white font-sans text-zinc-900 selection:bg-indigo-100 selection:text-indigo-900">
@@ -152,31 +152,32 @@ export default function Evals() {
               <div className="space-y-6">
                 <div className="inline-flex items-center gap-2 rounded-full border border-emerald-200 bg-emerald-50/50 px-3 py-1 text-xs font-medium uppercase tracking-wider text-emerald-700 backdrop-blur-sm">
                   <Sparkles className="h-3 w-3" />
-                  Isaac Lab-Arena Integration
+                  Standardized Benchmarks
                 </div>
                 <h1 className="text-5xl font-bold tracking-tight text-zinc-950 sm:text-6xl">
-                  Policy evaluation at scale.
+                  Benchmark your policies at scale.
                 </h1>
                 <p className="max-w-2xl text-lg leading-relaxed text-zinc-600">
-                  Blueprint scenes export to NVIDIA Isaac Lab-Arena format with Genie Sim 3.0
-                  powering automated data generation. LLM-generated tasks, cuRobo trajectory
-                  planning, and VLM-based evaluation at 100,000+ scenarios scale.
+                  Runnable benchmark suites with scenes, tasks, and evaluation harnesses.
+                  Fixed seeds, deterministic resets, and standardized metrics. Plug in your
+                  policy, get a comparable score immediately. Powered by Genie Sim 3.0 with
+                  VLM-based evaluation at 100,000+ scenarios scale.
                 </p>
               </div>
 
               <div className="flex flex-col gap-4 sm:flex-row">
                 <a
-                  href="/environments"
+                  href="/environments?type=datasets"
                   className="inline-flex items-center justify-center gap-2 rounded-full bg-zinc-900 px-6 py-3 text-sm font-semibold text-white shadow-lg transition hover:bg-zinc-700"
                 >
-                  Browse Arena-Ready Scenes
+                  Browse Benchmark Packs
                   <ArrowRight className="h-4 w-4" />
                 </a>
                 <a
-                  href="/contact?request=evaluation"
+                  href="/contact?request=benchmark"
                   className="inline-flex items-center justify-center gap-2 rounded-full border border-zinc-200 bg-white px-6 py-3 text-sm font-semibold text-zinc-700 shadow-sm transition hover:bg-zinc-50"
                 >
-                  Request Evaluation Setup
+                  Request Custom Benchmark
                 </a>
               </div>
 
@@ -641,16 +642,16 @@ export default function Evals() {
                   Ready to benchmark your policies?
                 </h2>
                 <p className="mt-4 max-w-2xl mx-auto text-indigo-100">
-                  Every Blueprint scene now ships Arena-ready with affordance tags, task definitions,
-                  and evaluation infrastructure. Start benchmarking today.
+                  Every Blueprint benchmark pack ships with scenes, tasks, evaluation harnesses,
+                  and standardized metrics. Start measuring policy performance today.
                 </p>
 
                 <div className="mt-8 flex flex-col gap-4 sm:flex-row sm:justify-center">
                   <a
-                    href="/environments"
+                    href="/environments?type=datasets"
                     className="inline-flex items-center justify-center rounded-xl bg-white px-8 py-4 text-sm font-semibold text-indigo-600 shadow-lg transition hover:bg-indigo-50"
                   >
-                    Browse Arena-Ready Scenes
+                    Browse Benchmark Packs
                     <LayoutGrid className="ml-2 h-4 w-4" />
                   </a>
                   <a

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -412,6 +412,7 @@ import {
   Box,
   CheckCircle2,
   Cpu,
+  Database,
   Fingerprint,
   Layers,
   LayoutGrid,
@@ -463,38 +464,53 @@ const SHOW_REAL_WORLD_CAPTURE = false;
 
 const offeringCards = [
   {
-    title: "Synthetic SimReady Scenes",
-    badge: "Marketplace",
+    title: "Benchmark Packs",
+    badge: "Evaluation",
     description:
-      "Physics-accurate dataset drops with deterministic domain randomization, plug-and-play USD, and sim2real validation notes.",
+      "Runnable benchmark suites with SimReady scenes, tasks, and an eval harness. Plug in your policy and get a standardized report.",
     bullets: [
-      "Filter by policy, object coverage, and facility archetype",
-      "Domain randomization scripts for visual & physics variation",
-      "Task logic included: actions, observations, rewards, resets, and parallel env configs",
-      "Built for field robotics, industrial automation & humanoid training",
+      "Scenes + tasks + evaluation harness in one package",
+      "Fixed seeds, deterministic resets, and reproducible protocols",
+      "JSON reports: success rate, time-to-success, collisions, path efficiency",
+      "Isaac Lab-Arena format with GPU-parallel evaluation",
     ],
-    ctaLabel: "Browse drops",
-    ctaHref: "/environments",
+    ctaLabel: "Browse benchmarks",
+    ctaHref: "/environments?type=datasets",
+    icon: <BarChart3 className="h-8 w-8 text-zinc-900" />,
+  },
+  {
+    title: "Scene Library",
+    badge: "Assets",
+    description:
+      "Individual SimReady USD scenes for training, evaluation, or custom benchmark assembly. Physics-accurate with full metadata.",
+    bullets: [
+      "Physics-stable geometry with sub-mm tolerances",
+      "Full articulation: joints, friction, mass, inertia properties",
+      "Domain randomization scripts included",
+      "Compatible with Isaac Sim, MuJoCo, and leading simulators",
+    ],
+    ctaLabel: "Browse scenes",
+    ctaHref: "/environments?type=scenes",
     icon: <LayoutGrid className="h-8 w-8 text-zinc-900" />,
   },
   {
-    title: "Scene Recipes",
-    badge: "Layouts + Frames",
+    title: "Dataset Packs",
+    badge: "Training Data",
     description:
-      "Lightweight USD layers with physics metadata, PBR materials, and Replicator scripts for domain randomization.",
+      "Pre-generated episode trajectories for offline training. Observations, actions, states, and labels in LeRobot format.",
     bullets: [
-      "Precision geometry with mass, inertia & friction properties",
-      "Manifest for SimReady packs + asset fallbacks you install locally",
-      "Task logic scaffolds tuned for vectorized RL and sim2real transfer",
-      "Variation generator for swaps, clutter, lighting, and articulation states (500–2,000 variations/scene)",
+      "Thousands of expert trajectories per scene/task",
+      "Multi-sensor: RGB-D, proprioception, end-effector poses",
+      "Train/val/test splits with example data loaders",
+      "Ideal for imitation learning and offline RL",
     ],
-    ctaLabel: "Request a recipe",
-    ctaHref: "/recipes",
-    icon: <Terminal className="h-8 w-8 text-zinc-900" />,
+    ctaLabel: "Browse datasets",
+    ctaHref: "/environments?type=datasets",
+    icon: <Database className="h-8 w-8 text-zinc-900" />,
   },
   {
     title: "Reference Photo Reconstruction",
-    badge: "Exclusive",
+    badge: "Custom",
     description:
       "Upload a single wide photo and we'll rebuild that exact layout with physics-accurate geometry and visual fidelity.",
     bullets: [
@@ -521,14 +537,31 @@ const offeringCards = [
     ctaHref: "/contact",
     icon: <Scan className="h-8 w-8 text-zinc-900" />,
   },
+  {
+    title: "Scene Recipes",
+    badge: "Layouts + Frames",
+    description:
+      "Lightweight USD layers with physics metadata, PBR materials, and Replicator scripts for domain randomization.",
+    bullets: [
+      "Precision geometry with mass, inertia & friction properties",
+      "Manifest for SimReady packs + asset fallbacks you install locally",
+      "Task logic scaffolds tuned for vectorized RL and sim2real transfer",
+      "Variation generator for swaps, clutter, lighting, and articulation states (500–2,000 variations/scene)",
+    ],
+    ctaLabel: "Request a recipe",
+    ctaHref: "/recipes",
+    icon: <Terminal className="h-8 w-8 text-zinc-900" />,
+  },
 ];
 
-// Hidden: Scene Recipes temporarily removed from offerings (will be added back later)
+// Hidden offerings (will be added back later when ready)
 const SHOW_SCENE_RECIPES = false;
+const SHOW_DATASET_PACKS = true; // Dataset Packs shown - part of main offering
 
 const visibleOfferingCards = offeringCards.filter((card) => {
   if (!SHOW_REAL_WORLD_CAPTURE && card.title === "Real-world Capture") return false;
   if (!SHOW_SCENE_RECIPES && card.title === "Scene Recipes") return false;
+  if (!SHOW_DATASET_PACKS && card.title === "Dataset Packs") return false;
   return true;
 });
 
@@ -1012,10 +1045,10 @@ export default function Home() {
             Premium Capabilities
           </div>
           <h2 className="mt-6 text-3xl font-bold tracking-tight text-zinc-900 sm:text-4xl">
-            From scenes to trained policies
+            From scenes to benchmarked policies
           </h2>
           <p className="mt-4 max-w-2xl mx-auto text-zinc-600">
-            Powered by Genie Sim 3.0 for automated data generation. Every bundle includes
+            Powered by Genie Sim 3.0 for automated data generation and evaluation. Every bundle includes
             LLM-generated tasks, GPU-accelerated trajectories, and VLM-evaluated episodes
             in LeRobot format. Upgrade for VLA fine-tuning and sim2real validation.
           </p>
@@ -1080,12 +1113,12 @@ export default function Home() {
           <div className="relative z-10 grid gap-8 lg:grid-cols-2 lg:items-center">
             <div>
               <h3 className="text-2xl font-bold text-white sm:text-3xl">
-                Choose your training data bundle
+                Choose your benchmark bundle
               </h3>
               <p className="mt-4 text-indigo-100">
-                From single-scene experiments to foundation model scale. Every bundle includes
-                physics-accurate USD, domain randomization, and Genie Sim 3.0-generated episodes
-                with automated task generation and cuRobo trajectory planning.
+                From single-scene benchmarks to foundation model evaluation at scale. Every bundle includes
+                physics-accurate USD, evaluation harness, and Genie Sim 3.0-generated episodes
+                with automated task generation and standardized metrics.
               </p>
               <div className="mt-6 flex flex-wrap gap-4">
                 <a
@@ -1176,14 +1209,14 @@ export default function Home() {
                   href="/evals"
                   className="inline-flex items-center justify-center gap-2 rounded-xl bg-white px-6 py-3 text-sm font-semibold text-emerald-700 shadow-lg transition hover:bg-emerald-50"
                 >
-                  Learn About Evals
+                  Learn About Benchmarks
                   <ArrowRight className="h-4 w-4" />
                 </a>
                 <a
                   href="/environments"
                   className="inline-flex items-center justify-center gap-2 rounded-xl border border-white/30 bg-white/10 px-6 py-3 text-sm font-semibold text-white backdrop-blur-sm transition hover:bg-white/20"
                 >
-                  Browse Arena-Ready Scenes
+                  Browse Benchmark Packs
                 </a>
               </div>
             </div>
@@ -1249,134 +1282,6 @@ export default function Home() {
 
       {/* --- Coming Soon / Future Offerings --- */}
       <ComingSoon />
-
-      {/* --- Coming Q2 2026 Services Section --- */}
-      <section className="mx-auto max-w-7xl px-4 pb-12 sm:px-6 lg:px-8">
-        <div className="relative overflow-hidden rounded-3xl bg-zinc-950 px-6 py-16 shadow-2xl sm:px-12 sm:py-20">
-          {/* Background decoration */}
-          <div className="absolute top-0 right-0 -mt-12 -mr-12 h-64 w-64 rounded-full bg-violet-900/30 blur-3xl" />
-          <div className="absolute bottom-0 left-0 -mb-12 -ml-12 h-64 w-64 rounded-full bg-emerald-900/20 blur-3xl" />
-
-          <div className="relative z-10 space-y-12">
-            {/* Header */}
-            <div className="text-center">
-              <div className="inline-flex items-center gap-2 text-amber-400">
-                <span className="relative flex h-2 w-2">
-                  <span className="relative inline-flex h-2 w-2 rounded-full bg-amber-500"></span>
-                </span>
-                <p className="text-xs font-bold uppercase tracking-widest">
-                  Coming Q2 2026
-                </p>
-              </div>
-              <h3 className="mt-4 text-3xl font-bold text-white sm:text-4xl">
-                New Services on the Horizon
-              </h3>
-              <p className="mt-4 max-w-2xl mx-auto text-zinc-400">
-                We're expanding the Blueprint platform with two powerful new capabilities.
-              </p>
-            </div>
-
-            {/* Service Cards */}
-            <div className="grid gap-6 md:grid-cols-2">
-              {/* RL Training Card */}
-              <div className="rounded-2xl bg-white/5 p-6 ring-1 ring-white/10">
-                <div className="flex items-start justify-between mb-4">
-                  <div className="rounded-lg bg-violet-500/20 p-2">
-                    <Cpu className="h-6 w-6 text-violet-400" />
-                  </div>
-                  <span className="rounded-full bg-violet-500/20 px-2 py-0.5 text-xs font-bold text-violet-400">
-                    New
-                  </span>
-                </div>
-                <h4 className="text-xl font-bold text-white">RL Training-as-a-Service</h4>
-                <p className="mt-2 text-sm text-zinc-400">
-                  Train robot policies at scale with GPU-parallel reinforcement learning. You bring the scene,
-                  we run thousands of simulations in parallel, and deliver trained policy checkpoints with
-                  benchmark reports.
-                </p>
-                <ul className="mt-4 space-y-2 text-xs text-zinc-500">
-                  <li className="flex items-center gap-2">
-                    <CheckCircle2 className="h-3 w-3 text-emerald-500" />
-                    4096+ parallel environments
-                  </li>
-                  <li className="flex items-center gap-2">
-                    <CheckCircle2 className="h-3 w-3 text-emerald-500" />
-                    Production-ready policy delivery
-                  </li>
-                  <li className="flex items-center gap-2">
-                    <CheckCircle2 className="h-3 w-3 text-emerald-500" />
-                    Standardized benchmark evaluation
-                  </li>
-                </ul>
-                <a
-                  href="/rl-training"
-                  className="mt-4 inline-flex items-center gap-1 text-sm font-semibold text-violet-400 hover:text-violet-300"
-                >
-                  Learn more <ArrowRight className="h-3 w-3" />
-                </a>
-              </div>
-
-              {/* Capture Card */}
-              <div className="rounded-2xl bg-white/5 p-6 ring-1 ring-white/10">
-                <div className="flex items-start justify-between mb-4">
-                  <div className="rounded-lg bg-emerald-500/20 p-2">
-                    <Scan className="h-6 w-6 text-emerald-400" />
-                  </div>
-                  <span className="rounded-full bg-emerald-500/20 px-2 py-0.5 text-xs font-bold text-emerald-400">
-                    New
-                  </span>
-                </div>
-                <h4 className="text-xl font-bold text-white">Real-World Capture Service</h4>
-                <p className="mt-2 text-sm text-zinc-400">
-                  We scan your exact facility and return a physics-accurate digital twin with sim2real-validated
-                  geometry, delivered with USD, URDF, and comprehensive QA reports.
-                </p>
-                <ul className="mt-4 space-y-2 text-xs text-zinc-500">
-                  <li className="flex items-center gap-2">
-                    <CheckCircle2 className="h-3 w-3 text-emerald-500" />
-                    On-site professional capture
-                  </li>
-                  <li className="flex items-center gap-2">
-                    <CheckCircle2 className="h-3 w-3 text-emerald-500" />
-                    Physics-accurate reconstruction
-                  </li>
-                  <li className="flex items-center gap-2">
-                    <CheckCircle2 className="h-3 w-3 text-emerald-500" />
-                    Isaac Sim & URDF compatible
-                  </li>
-                </ul>
-                <a
-                  href="/contact?service=capture"
-                  className="mt-4 inline-flex items-center gap-1 text-sm font-semibold text-emerald-400 hover:text-emerald-300"
-                >
-                  Join waitlist <ArrowRight className="h-3 w-3" />
-                </a>
-              </div>
-            </div>
-
-            {/* CTA */}
-            <div className="text-center">
-              <p className="text-sm text-zinc-500 mb-4">
-                In the meantime, explore our synthetic marketplace or submit a photo for reconstruction.
-              </p>
-              <div className="flex flex-col sm:flex-row gap-4 justify-center">
-                <a
-                  href="/environments"
-                  className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 text-sm font-semibold text-zinc-900 transition-colors hover:bg-zinc-200"
-                >
-                  Browse Marketplace
-                </a>
-                <a
-                  href="/contact?request=snapshot"
-                  className="inline-flex items-center justify-center gap-2 rounded-lg border border-zinc-700 px-6 py-3 text-sm font-semibold text-white transition-colors hover:bg-zinc-800"
-                >
-                  Upload a Photo
-                </a>
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
     </div>
     </>
   );

--- a/client/src/pages/Solutions.tsx
+++ b/client/src/pages/Solutions.tsx
@@ -624,14 +624,14 @@ function ArenaIntegrationSection() {
               href="/evals"
               className="inline-flex items-center justify-center gap-2 rounded-xl bg-white px-6 py-3 text-sm font-semibold text-emerald-700 shadow-lg transition hover:bg-emerald-50"
             >
-              Learn About Evals
+              Learn About Benchmarks
               <ArrowRight className="h-4 w-4" />
             </a>
             <a
-              href="/environments"
+              href="/environments?type=datasets"
               className="inline-flex items-center justify-center gap-2 rounded-xl border border-white/30 bg-white/10 px-6 py-3 text-sm font-semibold text-white backdrop-blur-sm transition hover:bg-white/20"
             >
-              Browse Arena-Ready Scenes
+              Browse Benchmark Packs
             </a>
           </div>
         </div>


### PR DESCRIPTION
- Remove RL Training from navigation (Header and Footer)
- Remove "Coming Q2 2026" section promoting RL Training from Home page
- Update offering cards to prioritize Benchmark Packs, Scene Library, and Dataset Packs
- Rename "Evals" to "Benchmarks" in navigation links
- Update Marketplace page terminology:
  - "Dataset Bundles" → "Benchmark Packs"
  - "Single Scenes" → "Scene Library"
- Update Environment Detail page badges with new terminology
- Update Evals page messaging to focus on benchmarking and standardized evaluation
- Update Solutions page CTAs to link to Benchmark Packs
- Update MarketplaceCard and CheckoutModal with new terminology

This aligns the website with the new product focus:
1. Benchmark Packs (scenes + tasks + eval harness) as lead product
2. Scene Library (individual SimReady scenes) as add-on SKU
3. Dataset Packs (pre-generated episodes) as upsell