### PR TITLE
Remove solutions page from navigation

### DIFF
--- a/client/src/components/site/Header.tsx
+++ b/client/src/components/site/Header.tsx
@@ -3,7 +3,6 @@ import { useMemo, useState } from "react";
 import { Menu, X } from "lucide-react";
 
 const navLinks = [
-  { href: "/solutions", label: "Solutions" },
   { href: "/marketplace", label: "Marketplace" },
   { href: "/evals", label: "Benchmarks" },
   { href: "/partners", label: "Partners" },


### PR DESCRIPTION
Solutions link is removed from the main navigation menu but remains accessible in the footer navigation.