### PR TITLE
Update home page headline for services

### DIFF
--- a/client/src/components/site/ContactForm.tsx
+++ b/client/src/components/site/ContactForm.tsx
@@ -13,7 +13,7 @@ const offerings = [
   { value: "benchmark-packs", label: "Benchmark Packs - Evaluation suites with scenes, tasks & harnesses" },
   { value: "scene-library", label: "Scene Library - Individual SimReady USD scenes" },
   { value: "dataset-packs", label: "Dataset Packs - Pre-generated episodes for offline training" },
-  { value: "custom-capture", label: "Custom Capture - Real-world facility reconstruction" },
+  { value: "custom-capture", label: "Custom Scene - On-site facility scan to SimReady environment" },
 ] as const;
 
 export function ContactForm() {

--- a/client/src/pages/Evals.tsx
+++ b/client/src/pages/Evals.tsx
@@ -40,7 +40,7 @@ const pipelineSteps = [
   {
     step: "01",
     title: "Scene Generation",
-    desc: "Upload a photo or select from marketplace. Blueprint reconstructs physics-accurate 3D environments.",
+    desc: "Select from marketplace or request a custom scene. Blueprint delivers physics-accurate 3D environments ready for simulation.",
     icon: <Layers className="h-6 w-6" />,
   },
   {

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -581,14 +581,14 @@ function DotPattern() {
 }
 
 const heroDescriptionWithCapture =
-  "Physics-accurate environments with domain randomization, precision geometry, and sim2real-validated assets. Pick from our synthetic marketplace or send us to your actual site for a digital twin tuned to your deployment stack.";
+  "SimReady scenes, expert trajectories, and standardized benchmarks—plus $320k+ in premium analytics included. Everything you need to train, evaluate, and deploy robotic policies that transfer to the real world.";
 
 const heroDescriptionWithoutCapture =
-  "Physics-accurate environments with domain randomization, precision geometry, and sim2real-validated assets. Pick from our synthetic marketplace or upload a reference photo for an exclusive reconstruction.";
+  "SimReady scenes, expert trajectories, and standardized benchmarks—plus $320k+ in premium analytics included. Everything you need to train, evaluate, and deploy robotic policies that transfer to the real world.";
 
 const facilitySupportCopy = SHOW_REAL_WORLD_CAPTURE
-  ? "Need exact facility matching? Add on our capture service or upload one reference photo for an exclusive reconstruction. We rebuild your facility with plugs for Isaac and your QA stack."
-  : "Need exact facility matching? Upload one reference photo for an exclusive reconstruction. We’ll return a SimReady scene with plugs for Isaac and your QA stack.";
+  ? "Need exact facility matching? Request a custom SimReady scene built from your specifications. We'll deliver a physics-accurate environment with Isaac Lab configs and QA validation."
+  : "Need exact facility matching? Request a custom SimReady scene built from your specifications. We'll deliver a physics-accurate environment with Isaac Lab configs and QA validation.";
 
 export default function Home() {
   const datasetPreview = syntheticDatasets.slice(0, 3);
@@ -596,8 +596,8 @@ export default function Home() {
   return (
     <>
       <SEO
-        title="Blueprint | SimReady Scenes for Robotic Training"
-        description="Physics-accurate environments with domain randomization, precision geometry, and sim2real-validated assets. SimReady USD packages for Isaac Sim, MuJoCo, and leading robotics simulators."
+        title="Blueprint | The Complete Data Platform for Robotic AI"
+        description="SimReady scenes, expert trajectories, standardized benchmarks, and $320k+ in premium analytics. Everything robotics labs need to train, evaluate, and deploy policies that transfer to real robots."
         canonical="/"
         image="https://tryblueprint.io/images/og-home.png"
       />
@@ -616,7 +616,7 @@ export default function Home() {
                   SimReady Environment Network
                 </div>
                 <h1 className="text-5xl font-bold tracking-tight text-zinc-950 sm:text-6xl lg:text-7xl">
-                  SimReady worlds for robotic training.
+                  The complete data platform for robotic AI.
                 </h1>
                 <p className="max-w-xl text-lg leading-relaxed text-zinc-600">
                   {SHOW_REAL_WORLD_CAPTURE

--- a/client/src/pages/Portal.tsx
+++ b/client/src/pages/Portal.tsx
@@ -1389,17 +1389,17 @@ export default function Portal() {
                     <Sparkles className="h-6 w-6" />
                   </div>
                   <div>
-                    <h4 className="font-bold text-zinc-900">Photo-to-Evaluation Pipeline</h4>
+                    <h4 className="font-bold text-zinc-900">Site-to-Evaluation Pipeline</h4>
                     <p className="text-xs text-zinc-500">$15K – $50K (custom)</p>
                   </div>
                 </div>
                 <p className="mb-4 text-sm text-zinc-600 leading-relaxed">
-                  End-to-end service from photos of your real environment to trained, tested policies. We handle reconstruction, simulation, training, and evaluation.
+                  End-to-end service from your real environment to trained, tested policies. We handle 3D capture, simulation, training, and evaluation.
                 </p>
                 <ul className="mb-6 space-y-2 text-sm text-zinc-600">
                   <li className="flex items-center gap-2">
                     <CheckCircle2 className="h-4 w-4 text-emerald-500" />
-                    NeRF/Gaussian reconstruction
+                    On-site 3D capture + scene authoring
                   </li>
                   <li className="flex items-center gap-2">
                     <CheckCircle2 className="h-4 w-4 text-emerald-500" />

--- a/client/src/pages/RLTraining.tsx
+++ b/client/src/pages/RLTraining.tsx
@@ -56,7 +56,7 @@ const howItWorks = [
   {
     step: "01",
     title: "You Provide the Scene",
-    desc: "Use any Blueprint scene from our marketplace or your custom reconstruction. Every scene already includes Isaac Lab task configs.",
+    desc: "Use any Blueprint scene from our marketplace or request a custom scene. Every scene already includes Isaac Lab task configs.",
     icon: <Layers className="h-6 w-6" />,
   },
   {
@@ -322,7 +322,7 @@ export default function RLTraining() {
                   {/* Task Info */}
                   <div className="rounded-lg bg-zinc-900 p-4 font-mono text-xs text-zinc-300">
                     <p className="text-zinc-500"># Current training job</p>
-                    <p><span className="text-violet-400">scene:</span> kitchen_v3_reconstruction</p>
+                    <p><span className="text-violet-400">scene:</span> industrial_kitchen_v3</p>
                     <p><span className="text-violet-400">task:</span> dish_loading</p>
                     <p><span className="text-violet-400">robot:</span> franka_panda</p>
                     <p><span className="text-emerald-400">status:</span> training...</p>

--- a/client/src/pages/Solutions.tsx
+++ b/client/src/pages/Solutions.tsx
@@ -91,60 +91,10 @@ export default function Solutions() {
               </a>
             </div>
 
-            {/* Path 2: Photo Reconstruction */}
+            {/* Path 2: Custom Site Scan */}
             <div className="border-l-4 border-slate-900 pl-8 space-y-6">
               <div>
-                <h2 className="text-2xl font-bold text-slate-900">2. Convert photos to a scene (custom)</h2>
-                <p className="mt-2 text-slate-600">
-                  Send us a picture of your kitchen, warehouse, or lab. We automatically convert it into a training environment in 30-60 minutes.
-                </p>
-              </div>
-
-              <div className="space-y-3">
-                <div>
-                  <h3 className="font-semibold text-slate-900">What happens:</h3>
-                  <ol className="mt-3 space-y-2 text-slate-600">
-                    <li className="flex items-start gap-3">
-                      <span className="font-semibold text-slate-400 shrink-0">1.</span>
-                      <span>You upload a photo of your space</span>
-                    </li>
-                    <li className="flex items-start gap-3">
-                      <span className="font-semibold text-slate-400 shrink-0">2.</span>
-                      <span>Our AI reconstructs it into a 3D scene</span>
-                    </li>
-                    <li className="flex items-start gap-3">
-                      <span className="font-semibold text-slate-400 shrink-0">3.</span>
-                      <span>We add physics properties (weights, friction, etc.)</span>
-                    </li>
-                    <li className="flex items-start gap-3">
-                      <span className="font-semibold text-slate-400 shrink-0">4.</span>
-                      <span>You download the scene + 1000s of training examples</span>
-                    </li>
-                  </ol>
-                </div>
-
-                <div className="rounded-lg bg-slate-50 p-4 border border-slate-200">
-                  <p className="text-sm text-slate-600">
-                    <span className="font-semibold text-slate-900">Time to data:</span> 30-60 minutes
-                  </p>
-                  <p className="mt-2 text-sm text-slate-600">
-                    <span className="font-semibold text-slate-900">Cost:</span> $2,000 - $10,000 per conversion
-                  </p>
-                </div>
-              </div>
-
-              <a
-                href="/contact?service=photo-conversion"
-                className="inline-flex items-center justify-center gap-2 rounded-lg bg-slate-100 px-4 py-2 text-sm font-semibold text-slate-900 hover:bg-slate-200 transition"
-              >
-                Submit a photo
-              </a>
-            </div>
-
-            {/* Path 3: Custom Reconstruction */}
-            <div className="border-l-4 border-slate-900 pl-8 space-y-6">
-              <div>
-                <h2 className="text-2xl font-bold text-slate-900">3. Full site scan (most accurate)</h2>
+                <h2 className="text-2xl font-bold text-slate-900">2. Full site scan (most accurate)</h2>
                 <p className="mt-2 text-slate-600">
                   We send a team to physically scan your facility with laser precision. Best for when you need an exact digital copy for testing before real deployment.
                 </p>
@@ -175,7 +125,7 @@ export default function Solutions() {
 
                 <div className="rounded-lg bg-slate-50 p-4 border border-slate-200">
                   <p className="text-sm text-slate-600">
-                    <span className="font-semibold text-slate-900">Time to data:</span> 2-4 weeks (includes site visit + reconstruction)
+                    <span className="font-semibold text-slate-900">Time to data:</span> 2-4 weeks (includes site visit + scene authoring)
                   </p>
                   <p className="mt-2 text-sm text-slate-600">
                     <span className="font-semibold text-slate-900">Cost:</span> $10,000 - $50,000 depending on facility size
@@ -251,10 +201,6 @@ export default function Solutions() {
                 {
                   when: "You need data fast and don't need it customized",
                   path: "Use pre-made scenes"
-                },
-                {
-                  when: "You have a photo of your space and want it converted",
-                  path: "Photo reconstruction"
                 },
                 {
                   when: "You need laser-accurate 3D scan and real deployment testing",


### PR DESCRIPTION
HEADLINE CHANGE:
- Before: "SimReady worlds for robotic training."
- After: "The complete data platform for robotic AI."

This reflects Blueprint's expanded offerings beyond just SimReady scenes: scenes, datasets, benchmarks, evaluations, and $320k+ in premium analytics.

UPLOAD-TO-RECONSTRUCTION REMOVAL:
User confirmed this service is no longer offered. Removed references from:

Home.tsx:
- Updated headline to reflect complete platform
- Updated subheader to mention scenes, trajectories, benchmarks, analytics
- Removed "upload a reference photo for an exclusive reconstruction"
- Updated facilitySupportCopy to say "Request a custom SimReady scene"
- Updated SEO title/description

Solutions.tsx:
- Removed entire "Path 2: Photo Reconstruction" section
- Renumbered "Path 3: Full site scan" to "Path 2"
- Removed "Photo reconstruction" from path decision guide
- Changed "reconstruction" to "scene authoring" in time estimate

Evals.tsx:
- Changed "Upload a photo or select from marketplace" to "Select from marketplace or request a custom scene"

RLTraining.tsx:
- Changed "custom reconstruction" to "request a custom scene"
- Changed scene name "kitchen_v3_reconstruction" to "industrial_kitchen_v3"

Portal.tsx:
- Renamed "Photo-to-Evaluation Pipeline" to "Site-to-Evaluation Pipeline"
- Changed "from photos of your real environment" to "from your real environment"
- Changed "NeRF/Gaussian reconstruction" to "On-site 3D capture + scene authoring"

ContactForm.tsx:
- Changed "Custom Capture - Real-world facility reconstruction" to "Custom Scene - On-site facility scan to SimReady environment"

KEPT (still valid services):
- Full site scan / capture service (on-site 3D scanning)
- Custom scene requests
- Capture.tsx page (describes the capture service, not photo upload)

The goal is to position Blueprint as a complete robotics data platform (not just a SimReady scene provider) while removing the discontinued upload-to-reconstruction feature from all customer-facing copy.