### PR TITLE
Add static prerendering for public marketing routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "dev": "tsx watch --clear-screen=false --exclude vite.config.ts.* server/index.ts",
-    "build": "vite build && npx esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
+    "build": "vite build && tsx scripts/prerender.tsx && npx esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
     "db:push": "drizzle-kit push",

--- a/scripts/prerender.tsx
+++ b/scripts/prerender.tsx
@@ -1,0 +1,134 @@
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { Helmet } from "react-helmet";
+import { SiteLayout } from "../client/src/components/site/SiteLayout";
+import Home from "../client/src/pages/Home";
+import WhySimulation from "../client/src/pages/WhySimulation";
+import Environments from "../client/src/pages/Environments";
+import Solutions from "../client/src/pages/Solutions";
+import Pricing from "../client/src/pages/Pricing";
+import Learn from "../client/src/pages/Learn";
+import Docs from "../client/src/pages/Docs";
+import Evals from "../client/src/pages/Evals";
+import RLTraining from "../client/src/pages/RLTraining";
+import CaseStudies from "../client/src/pages/CaseStudies";
+import Careers from "../client/src/pages/Careers";
+import Contact from "../client/src/pages/Contact";
+import PartnerProgram from "../client/src/pages/PartnerProgram";
+import Portal from "../client/src/pages/Portal";
+import Login from "../client/src/pages/Login";
+import ForgotPassword from "../client/src/pages/ForgotPassword";
+import Privacy from "../client/src/pages/Privacy";
+import Terms from "../client/src/pages/Terms";
+import NotFound from "../client/src/pages/NotFound";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const componentMap: Record<string, React.ComponentType> = {
+  Home,
+  WhySimulation,
+  Environments,
+  Solutions,
+  Pricing,
+  Learn,
+  Docs,
+  Evals,
+  RLTraining,
+  CaseStudies,
+  Careers,
+  Contact,
+  PartnerProgram,
+  Portal,
+  Login,
+  ForgotPassword,
+  Privacy,
+  Terms,
+  NotFound,
+};
+
+const routePattern =
+  /<Route\s+path="([^"]+)"[\s\S]*?component=\{withLayout\(([^)]+)\)\}[\s\S]*?\/>/g;
+
+const rootPattern = /<div id="root"><\/div>/;
+
+function routePathToFile(distPath: string, routePath: string) {
+  if (routePath === "/") {
+    return path.join(distPath, "index.html");
+  }
+
+  return path.join(distPath, routePath.replace(/^\//, ""), "index.html");
+}
+
+function renderRoute(component: React.ComponentType) {
+  const markup = renderToStaticMarkup(
+    <SiteLayout>
+      {React.createElement(component)}
+    </SiteLayout>
+  );
+  const helmet = Helmet.renderStatic();
+
+  return {
+    markup,
+    helmet,
+  };
+}
+
+async function main() {
+  const mainPath = path.resolve(__dirname, "..", "client", "src", "main.tsx");
+  const distPath = path.resolve(__dirname, "..", "dist", "public");
+  const templatePath = path.join(distPath, "index.html");
+
+  const [mainSource, template] = await Promise.all([
+    fs.promises.readFile(mainPath, "utf8"),
+    fs.promises.readFile(templatePath, "utf8"),
+  ]);
+
+  if (!rootPattern.test(template)) {
+    throw new Error("Could not locate the root element in the template HTML.");
+  }
+
+  const routes = Array.from(mainSource.matchAll(routePattern)).map((match) => ({
+    path: match[1],
+    componentName: match[2],
+  }));
+
+  const staticRoutes = routes.filter(
+    (route) => !route.path.includes(":") && route.path.length > 0
+  );
+
+  if (staticRoutes.length === 0) {
+    throw new Error("No static routes found for prerendering.");
+  }
+
+  for (const route of staticRoutes) {
+    const component = componentMap[route.componentName];
+    if (!component) {
+      throw new Error(
+        `Missing component mapping for ${route.componentName} (${route.path}).`
+      );
+    }
+
+    const { markup, helmet } = renderRoute(component);
+    const html = template
+      .replace(rootPattern, `<div id="root">${markup}</div>`)
+      .replace(
+        "</head>",
+        [
+          helmet.title.toString(),
+          helmet.meta.toString(),
+          helmet.link.toString(),
+          helmet.script.toString(),
+        ].join("\n") + "\n</head>"
+      );
+
+    const outputFile = routePathToFile(distPath, route.path);
+    await fs.promises.mkdir(path.dirname(outputFile), { recursive: true });
+    await fs.promises.writeFile(outputFile, html, "utf8");
+  }
+}
+
+await main();

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -44,6 +44,7 @@ export async function setupVite(app: Express, server: Server) {
 
 export function serveStatic(app: Express) {
   const distPath = path.resolve(__dirname, "public");
+  const indexPath = path.resolve(distPath, "index.html");
 
   if (!fs.existsSync(distPath)) {
     throw new Error(
@@ -54,7 +55,26 @@ export function serveStatic(app: Express) {
   app.use(express.static(distPath));
 
   // fall through to index.html if the file doesn't exist
-  app.use("*", (_req, res) => {
-    res.sendFile(path.resolve(distPath, "index.html"));
+  app.use("*", (req, res) => {
+    if (req.method !== "GET") {
+      res.sendStatus(404);
+      return;
+    }
+
+    const hasExtension = path.extname(req.path) !== "";
+    if (!hasExtension) {
+      const cleanedPath = req.path.replace(/\/+$/, "") || "/";
+      const htmlPath =
+        cleanedPath === "/"
+          ? indexPath
+          : path.resolve(distPath, cleanedPath.slice(1), "index.html");
+
+      if (fs.existsSync(htmlPath)) {
+        res.sendFile(htmlPath);
+        return;
+      }
+    }
+
+    res.sendFile(indexPath);
   });
 }


### PR DESCRIPTION
### Motivation
- Serve readable HTML for public marketing routes without requiring client JavaScript so direct GET requests return usable content for crawlers and users.
- Keep the existing SPA code and layout while generating pre-rendered snapshots at build time to improve SEO and first‑load readability.

### Description
- Add a new build-time prerender script `scripts/prerender.tsx` that parses `client/src/main.tsx` for route definitions, renders each static route with the shared `SiteLayout` using `react-dom/server`, injects `react-helmet` head tags, and writes `dist/public/<route>/index.html` snapshots for non-parameterized routes.
- Run the prerender step as part of the `build` script in `package.json` immediately after `vite build` via `tsx scripts/prerender.tsx`.
- Update server static serving in `server/vite.ts` to prefer route-specific HTML files (when they exist) for `GET` requests and to fall back to `index.html` only when no snapshot is found, while ignoring requests that include a file extension.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69683b62ba248329ab47f38dd086e17e)