### PR TITLE
Connect login page to AuthContext flows

### DIFF
--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -9,6 +9,7 @@ import { SiteLayout } from "./components/site/SiteLayout";
 import { LoadingScreen } from "./components/site/LoadingScreen";
 import { CookieConsent } from "./components/CookieConsent";
 import { Analytics } from "./components/Analytics";
+import { AuthProvider } from "./contexts/AuthContext";
 
 const Home = lazy(() => import("./pages/Home"));
 const WhySimulation = lazy(() => import("./pages/WhySimulation"));
@@ -87,10 +88,12 @@ function Router() {
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
-      <Analytics />
-      <Router />
-      <Toaster />
-      <CookieConsent />
+      <AuthProvider>
+        <Analytics />
+        <Router />
+        <Toaster />
+        <CookieConsent />
+      </AuthProvider>
     </QueryClientProvider>
   </StrictMode>,
 );


### PR DESCRIPTION
### Motivation
- Replace the simulated auth flow in the login page with the real authentication functions and surface real error messages so users see meaningful feedback when sign in/up or Google sign-in fails.
- Keep existing client-side validation and loading states while integrating with the centralized auth provider.

### Description
- Import `useAuth` and obtain `signIn`, `signUp`, and `signInWithGoogle` from the auth context via `const { signIn, signUp, signInWithGoogle } = useAuth()`.
- Replace the simulated timeout in `handleSubmit` with real calls to `signIn(email, password)` when `mode === 'signin'` and `signUp(email, password, name)` for signups, and preserve the existing `isLoading` behavior.
- Add local `authError` state and render an inline error alert inside the form to surface messages from thrown auth errors.
- Wire the Google button to call `signInWithGoogle()` via a new `handleGoogleSignIn` handler and display any failures in the same `authError` UI.

### Testing
- Ran `npm run dev`, which failed to start the dev server due to an unrelated runtime error: `unable to determine transport target for "pino-pretty"` (dev server did not start).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69683c1b54d4832998679dc2c4d656c1)