### PR TITLE
Guard Firestore debug connection test behind env flag

### DIFF
--- a/client/src/lib/firebase.ts
+++ b/client/src/lib/firebase.ts
@@ -74,10 +74,18 @@ export const testFirestoreConnection = async (): Promise<boolean> => {
   }
 };
 
-// Run connection test on load (for debugging - remove in production)
-testFirestoreConnection().then(success => {
-  console.log("[Firebase] Initial connection test result:", success ? "SUCCESS" : "FAILED");
-});
+const isFirestoreDebugEnabled =
+  import.meta.env.DEV || import.meta.env.VITE_FIREBASE_DEBUG === "true";
+
+export const runFirestoreConnectionTestIfDebug = async (): Promise<boolean> => {
+  if (!isFirestoreDebugEnabled) {
+    return false;
+  }
+
+  const success = await testFirestoreConnection();
+  console.log("[Firebase] Debug connection test result:", success ? "SUCCESS" : "FAILED");
+  return success;
+};
 
 export const googleProvider = new GoogleAuthProvider();
 googleProvider.setCustomParameters({


### PR DESCRIPTION
### Motivation
- Prevent the Firestore connectivity test from running as a side effect of importing the Firebase module and make it opt-in for debugging only.

### Description
- Removed the unconditional call to `testFirestoreConnection()` on module load and added an `isFirestoreDebugEnabled` check based on `import.meta.env.DEV` or `VITE_FIREBASE_DEBUG`, plus an exported helper `runFirestoreConnectionTestIfDebug()` that invokes `testFirestoreConnection()` only when the debug flag is enabled.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69683f52e2748329bc95e762360d1608)