### PR TITLE
Add Privacy link to cookie banner and expose personalization consent helper

### DIFF
--- a/client/src/components/Analytics.tsx
+++ b/client/src/components/Analytics.tsx
@@ -16,7 +16,7 @@ export function Analytics() {
       return;
     }
 
-    // Check consent status
+    // Check consent status (use isPersonalizationAllowed for marketing/personalization features)
     const consent = getCookieConsent();
     const analyticsAllowed = consent?.analytics ?? false;
 

--- a/client/src/components/CookieConsent.tsx
+++ b/client/src/components/CookieConsent.tsx
@@ -105,7 +105,11 @@ export function CookieConsent() {
         {/* Description */}
         <p className="mb-4 text-sm text-zinc-600">
           We use cookies to enhance your experience, analyze site traffic, and for marketing purposes.
-          You can customize your preferences or accept all cookies.
+          Review our{" "}
+          <a href="/privacy" className="font-medium text-indigo-600 hover:text-indigo-500">
+            Privacy &amp; Cookies
+          </a>{" "}
+          details, customize your preferences, or accept all cookies.
         </p>
 
         {/* Cookie Details (expandable) */}
@@ -210,6 +214,13 @@ export function getCookieConsent(): ConsentPreferences | null {
 export function isAnalyticsAllowed(): boolean {
   const consent = getCookieConsent();
   return consent?.analytics ?? false;
+}
+
+// Use this for personalization or marketing features that require explicit opt-in.
+// Example consumers: client/src/components/Analytics.tsx or any personalization logic.
+export function isPersonalizationAllowed(): boolean {
+  const consent = getCookieConsent();
+  return consent?.marketing ?? false;
 }
 
 // Extend Window interface for gtag


### PR DESCRIPTION
### Motivation
- Make the cookie consent banner clearly link to the privacy page so users can view the full “Privacy & Cookies” details from the banner text.
- Expose an explicit helper for personalization/marketing opt-in so analytics and personalization logic can respect the user’s marketing consent flag.

### Description
- Add a visible link to `/privacy` in the cookie banner copy in `client/src/components/CookieConsent.tsx` using an accessible anchor with styling classes.
- Export a new helper `isPersonalizationAllowed()` from `client/src/components/CookieConsent.tsx` that returns the `marketing` consent flag from stored preferences.
- Keep `getCookieConsent()` and `isAnalyticsAllowed()` intact and annotate the analytics initialization in `client/src/components/Analytics.tsx` to recommend using the personalization helper for marketing/personalization features.
- Minor inline documentation notes pointing at example consumers such as `client/src/components/Analytics.tsx` or any personalization logic.

### Testing
- Attempted to start the dev server with `npm run dev`, but the environment hit a runtime error related to `pino` transport configuration and did not provide a full running instance.
- Attempted a Playwright-based screenshot to visually verify the banner, but the headless Chromium launch failed with a crash (`TargetClosedError`/SIGSEGV) so no screenshot was produced.
- No automated unit or integration tests were run successfully in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696843dd141883299394c91aaee68397)