### PR TITLE
Redirect incomplete onboarding users to marketing destination

### DIFF
--- a/client/src/contexts/AuthContext.tsx
+++ b/client/src/contexts/AuthContext.tsx
@@ -74,6 +74,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const resolveRedirectPath = React.useCallback(
     (data: UserData | null): string => {
+      const marketingDestination =
+        (import.meta.env.VITE_MARKETING_DESTINATION as string | undefined)?.trim() ||
+        "/marketplace";
       let storedRedirect: string | null = null;
       try {
         storedRedirect = sessionStorage.getItem("redirectAfterAuth");
@@ -82,6 +85,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       }
 
       if (storedRedirect) {
+        const normalizedRedirect =
+          storedRedirect === "/onboarding" ? marketingDestination : storedRedirect;
         try {
           sessionStorage.removeItem("redirectAfterAuth");
         } catch (storageError) {
@@ -90,11 +95,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
             storageError,
           );
         }
-        return storedRedirect;
+        return normalizedRedirect;
       }
 
       if (data && data.finishedOnboarding !== true) {
-        return "/onboarding";
+        return marketingDestination;
       }
 
       return "/dashboard";


### PR DESCRIPTION
### Motivation
- Route users who have not finished onboarding to a public marketing destination (default `/marketplace`) and avoid sending them to the internal `/onboarding` route, while allowing a configurable marketing target via env.

### Description
- In `client/src/contexts/AuthContext.tsx` `resolveRedirectPath` now reads `VITE_MARKETING_DESTINATION` (falling back to `/marketplace`) and returns that when `userData.finishedOnboarding` is not `true`.
- Stored `sessionStorage` key `redirectAfterAuth` is normalized so any saved `"/onboarding"` value is replaced with the marketing destination before navigation.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696843ca35608329ab35938c6e33d63c)