### PR TITLE
Add profile fields to UserData and populate displayName/photoURL on creation

### DIFF
--- a/client/src/lib/firebase.ts
+++ b/client/src/lib/firebase.ts
@@ -97,6 +97,14 @@ export interface UserData {
   uid: string;
   email: string;
   name: string;
+  displayName?: string;
+  photoURL?: string;
+  bio?: string;
+  jobTitle?: string;
+  company?: string;
+  timeZone?: string;
+  language?: string;
+  phoneNumber?: string;
   username: string;
   deviceToken: string;
   referralCode: string;
@@ -149,12 +157,70 @@ export interface UserData {
   skillLevels: { [key: string]: number };
   mostFrequentLocation: string;
   deviceTypes: string[];
+  planUsage?: number;
+  planExpiryDate?: Date | null;
+  activeBlueprintsPercentage?: number;
+  planCost?: number | string;
+  planHours?: number | string;
+  currentMonthHours?: number;
+  accountSettings?: {
+    email2FA?: boolean;
+    sms2FA?: boolean;
+    securityAlerts?: boolean;
+    loginAttempts?: boolean;
+  };
+  notificationSettings?: {
+    emailNotifications?: boolean;
+    pushNotifications?: boolean;
+    blueprintChanges?: boolean;
+    teamUpdates?: boolean;
+    usageAlerts?: boolean;
+    marketingEmails?: boolean;
+    weeklyDigest?: boolean;
+    securityNotifications?: boolean;
+  };
+  apiKeys?: Array<{
+    id?: string;
+    label?: string;
+    key?: string;
+    createdAt?: Date;
+    lastUsed?: Date;
+  }>;
+  integrations?: Array<{
+    id?: string;
+    name?: string;
+    status?: string;
+    connectedAt?: Date;
+  }>;
+  teamMembers?: {
+    count?: number;
+    pending?: number;
+  };
+  blueprintsShared?: {
+    count?: number;
+    sharedWith?: number;
+  };
+  billingHistory?: Array<{
+    id?: string;
+    date?: Date;
+    amount?: number;
+    status?: string;
+  }>;
+  paymentMethods?: Array<{
+    brand?: string;
+    last4?: string;
+    expiryDate?: string;
+  }>;
+  teamRoles?: {
+    count?: number;
+    roles?: string[];
+  };
 }
 
 // Firestore functions
 export const createUserDocument = async (
   user: FirebaseUser,
-  additionalData?: { name?: string },
+  additionalData?: { name?: string; displayName?: string; photoURL?: string },
 ): Promise<void> => {
   if (!user) {
     console.error("[Firebase] No user provided to createUserDocument");
@@ -174,7 +240,9 @@ export const createUserDocument = async (
 
     if (!snapshot.exists()) {
       const { email } = user;
-      const name = additionalData?.name || email?.split("@")[0] || "";
+      const name = additionalData?.name || user.displayName || email?.split("@")[0] || "";
+      const displayName = additionalData?.displayName || user.displayName || name;
+      const photoURL = additionalData?.photoURL || user.photoURL || "";
       const username = name.toLowerCase().replace(/\s+/g, "_");
       const timestamp = serverTimestamp();
 
@@ -182,6 +250,8 @@ export const createUserDocument = async (
         uid: user.uid,
         email,
         name,
+        displayName,
+        photoURL,
         username,
         deviceToken: "",
         referralCode: Math.random().toString(36).substring(2, 8).toUpperCase(),


### PR DESCRIPTION
### Motivation
- Add optional profile and settings fields to the `UserData` typing so `Settings.jsx` and `Header` can read properties like `displayName`/`photoURL` without TypeScript errors.
- Ensure newly created Firestore user documents store profile fields (from the Firebase `user` or `additionalData`) so UI components have consistent data to read.

### Description
- Expanded the `UserData` interface in `client/src/lib/firebase.ts` with optional profile fields (`displayName`, `photoURL`, `bio`, `jobTitle`, `company`, `timeZone`, `language`, `phoneNumber`) and several settings/metadata fields (`planUsage`, `planExpiryDate`, `accountSettings`, `notificationSettings`, `apiKeys`, `integrations`, `teamMembers`, `blueprintsShared`, `billingHistory`, `paymentMethods`, `teamRoles`, etc.).
- Updated `createUserDocument` signature to accept `additionalData?: { name?: string; displayName?: string; photoURL?: string }` and set `displayName`/`photoURL` (preferring `additionalData`, then `user.displayName`/`user.photoURL`, then sensible fallbacks) when creating a new user document.
- Wrote `displayName` and `photoURL` into the `newUserData` object that is passed to `setDoc` so new users have these fields populated.
- Confirmed that `client/src/components/site/Header.tsx` and `client/src/pages/Settings.jsx` read `userData.displayName`/`userData.photoURL` (and other profile fields) consistent with the new optional typings.

### Testing
- No automated tests were executed for this change.
- Changes were committed and the modified file is `client/src/lib/firebase.ts`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696846d79ff883298b2f6f9d6109f223)