### PR TITLE
Add Log in / Sign up links to header and mobile nav

### DIFF
--- a/client/src/components/Nav.jsx
+++ b/client/src/components/Nav.jsx
@@ -269,15 +269,29 @@ export default function Nav({
               )} */}
 
               {!currentUser ? (
-                <Link
-                  href="/login"
-                  className="w-full"
-                  onClick={() => setIsMobileMenuOpen(false)}
-                >
-                  <Button className="w-full rounded-xl bg-gradient-to-r from-emerald-500 to-cyan-500 text-slate-900 font-semibold hover:opacity-90">
-                    Sign Up
-                  </Button>
-                </Link>
+                <>
+                  <Link
+                    href="/login"
+                    className="w-full"
+                    onClick={() => setIsMobileMenuOpen(false)}
+                  >
+                    <Button
+                      variant="outline"
+                      className="w-full rounded-xl border-2 border-slate-600 text-slate-100 hover:bg-slate-800"
+                    >
+                      Log in
+                    </Button>
+                  </Link>
+                  <Link
+                    href="/login"
+                    className="w-full"
+                    onClick={() => setIsMobileMenuOpen(false)}
+                  >
+                    <Button className="w-full rounded-xl bg-gradient-to-r from-emerald-500 to-cyan-500 text-slate-900 font-semibold hover:opacity-90">
+                      Sign Up
+                    </Button>
+                  </Link>
+                </>
               ) : (
                 <>
                   {/* {!hideAuthenticatedFeatures && (

--- a/client/src/components/site/Header.tsx
+++ b/client/src/components/site/Header.tsx
@@ -81,7 +81,22 @@ export function Header() {
           >
             Request a Scene
           </a>
-          {currentUser ? (
+          {!currentUser ? (
+            <>
+              <a
+                href="/login"
+                className="rounded-full border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:text-slate-900"
+              >
+                Log in
+              </a>
+              <a
+                href="/login"
+                className="rounded-full bg-slate-100 px-4 py-2 text-sm font-semibold text-slate-900 transition hover:bg-slate-200"
+              >
+                Sign up
+              </a>
+            </>
+          ) : (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <button
@@ -111,7 +126,7 @@ export function Header() {
                 <DropdownMenuItem onClick={handleSignOut}>Sign out</DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
-          ) : null}
+          )}
         </div>
         <button
           type="button"
@@ -143,7 +158,24 @@ export function Header() {
             >
               Request a Scene
             </a>
-            {currentUser ? (
+            {!currentUser ? (
+              <>
+                <a
+                  href="/login"
+                  className="rounded-full border border-slate-200 px-4 py-2 text-center text-slate-700"
+                  onClick={() => setOpen(false)}
+                >
+                  Log in
+                </a>
+                <a
+                  href="/login"
+                  className="rounded-full bg-slate-100 px-4 py-2 text-center font-semibold text-slate-900"
+                  onClick={() => setOpen(false)}
+                >
+                  Sign up
+                </a>
+              </>
+            ) : (
               <>
                 <a
                   href="/settings"
@@ -163,7 +195,7 @@ export function Header() {
                   Sign out
                 </button>
               </>
-            ) : null}
+            )}
           </nav>
         </div>
       ) : null}


### PR DESCRIPTION
### Motivation
- Ensure unauthenticated users can access the login flow from both the site header and the mobile navigation so they can sign in or sign up without needing other entry points.

### Description
- In `client/src/components/site/Header.tsx` show `Log in` and `Sign up` links next to the existing `Request a Scene` button for `!currentUser` on desktop and inside the mobile menu for `!currentUser` on mobile.
- In `client/src/components/Nav.jsx` update the mobile menu to render a `Log in` button (outline style) alongside the existing `Sign Up` button for `!currentUser` so mobile users have direct access to login.
- Preserved the existing authenticated menu and sign out flow for `currentUser`, and reused existing routes that point to `/login` for both actions.

### Testing
- Attempted to run the dev server with `npm run dev -- --host 0.0.0.0 --port 4173`, but the run failed due to a `pino-pretty` transport error; no successful automated run completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69684a514c888329ab84df448a9cf162)