### PR TITLE
Remove 'Sign up' CTAs from Header and Nav

### DIFF
--- a/client/src/components/Nav.jsx
+++ b/client/src/components/Nav.jsx
@@ -282,15 +282,6 @@ export default function Nav({
                       Log in
                     </Button>
                   </Link>
-                  <Link
-                    href="/login"
-                    className="w-full"
-                    onClick={() => setIsMobileMenuOpen(false)}
-                  >
-                    <Button className="w-full rounded-xl bg-gradient-to-r from-emerald-500 to-cyan-500 text-slate-900 font-semibold hover:opacity-90">
-                      Sign Up
-                    </Button>
-                  </Link>
                 </>
               ) : (
                 <>
@@ -412,16 +403,11 @@ InviteTeamButtonInternal.displayName = "InviteTeamButtonInternal";
 const SignInButtonInternal = memo(() => (
   <div className="flex items-center gap-3">
     <Link href="/login">
-      <Button 
+      <Button
         variant="outline"
         className="rounded-full border-2 border-slate-300 text-slate-900 bg-white hover:bg-slate-50 font-semibold px-8 py-2.5"
       >
         Log in
-      </Button>
-    </Link>
-    <Link href="/login">
-      <Button className="rounded-full bg-gradient-to-r from-emerald-500 to-cyan-500 text-slate-900 font-semibold hover:opacity-90 px-8 py-2.5">
-        Sign up
       </Button>
     </Link>
   </div>

--- a/client/src/components/site/Header.tsx
+++ b/client/src/components/site/Header.tsx
@@ -89,12 +89,6 @@ export function Header() {
               >
                 Log in
               </a>
-              <a
-                href="/login"
-                className="rounded-full bg-slate-100 px-4 py-2 text-sm font-semibold text-slate-900 transition hover:bg-slate-200"
-              >
-                Sign up
-              </a>
             </>
           ) : (
             <DropdownMenu>
@@ -166,13 +160,6 @@ export function Header() {
                   onClick={() => setOpen(false)}
                 >
                   Log in
-                </a>
-                <a
-                  href="/login"
-                  className="rounded-full bg-slate-100 px-4 py-2 text-center font-semibold text-slate-900"
-                  onClick={() => setOpen(false)}
-                >
-                  Sign up
                 </a>
               </>
             ) : (


### PR DESCRIPTION
### Motivation

- Remove redundant "Sign up" call-to-action links from the primary navigation so unauthenticated users see only the "Log in" action.

### Description

- Removed the `Sign up` anchor/button from the desktop and mobile action areas in `client/src/components/site/Header.tsx` so only the `Log in` link remains for unauthenticated users.
- Removed the `Sign Up` mobile menu link and removed the secondary `Sign up` button from `SignInButtonInternal` in `client/src/components/Nav.jsx`, leaving only the `Log in` button.
- Verified the modified files no longer contain `Sign up`/`Sign Up` CTAs.

### Testing

- Ran `npm run dev` to start the dev server and it failed with `unable to determine transport target for "pino-pretty"`, so the app could not be launched for manual verification.
- Executed a search through the updated components to confirm there are no remaining `Sign up`/`Sign Up` occurrences in the modified files; no matches were found.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69684da3d0b083299c6548e4f869b155)