### PR TITLE
Add settings route to main router

### DIFF
--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -33,6 +33,7 @@ const Login = lazy(() => import("./pages/Login"));
 const ForgotPassword = lazy(() => import("./pages/ForgotPassword"));
 const Privacy = lazy(() => import("./pages/Privacy"));
 const Terms = lazy(() => import("./pages/Terms"));
+const Settings = lazy(() => import("./pages/Settings"));
 const NotFound = lazy(() => import("./pages/NotFound"));
 
 const withLayout = <P extends object>(Component: React.ComponentType<P>) =>
@@ -79,6 +80,7 @@ function Router() {
         <Route path="/forgot-password" component={withLayout(ForgotPassword)} />
         <Route path="/privacy" component={withLayout(Privacy)} />
         <Route path="/terms" component={withLayout(Terms)} />
+        <Route path="/settings" component={withLayout(Settings)} />
         <Route component={withLayout(NotFound)} />
       </Switch>
     </Suspense>


### PR DESCRIPTION
### Motivation
- Expose the existing Settings page at the `/settings` URL and lazy-load it to keep bundle size small and route resolution consistent.

### Description
- Lazy-imported the Settings page by adding `const Settings = lazy(() => import("./pages/Settings"));` to `client/src/main.tsx` and added ` <Route path="/settings" component={withLayout(Settings)} />` before the NotFound fallback so `/settings` resolves.
- Confirmed existing header and navigation links already point to `/settings`, so they will now route to the newly added route without further changes.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69684db70bf88329b89eed28e5a7ea80)