### PR TITLE
Prefer currentUser avatar/displayName in Nav

### DIFF
--- a/client/src/components/Nav.jsx
+++ b/client/src/components/Nav.jsx
@@ -66,7 +66,12 @@ export default function Nav({
     }
   }, [logout, toast, setLocation]);
 
-  const userInitials = getInitials(userData?.name || userData?.displayName);
+  const resolvedDisplayName =
+    currentUser?.displayName || userData?.displayName;
+  const resolvedPhotoURL = currentUser?.photoURL || userData?.photoURL || "";
+  const userInitials = getInitials(
+    resolvedDisplayName || userData?.name || userData?.displayName,
+  );
 
   const navLinks = [
     { href: "/why-simulation", label: "Why Simulation?", badge: "New" },
@@ -182,9 +187,8 @@ export default function Nav({
                     aria-label="User menu"
                   >
                     <UserAvatarDisplay
-                      photoURL={userData?.photoURL}
-                      name={userData?.name}
-                      displayName={userData?.displayName}
+                      photoURL={resolvedPhotoURL}
+                      displayName={resolvedDisplayName}
                       initials={userInitials}
                     />
                   </Button>
@@ -333,12 +337,12 @@ export default function Nav({
 }
 
 // ===== memoized bits =====
-const UserAvatarDisplay = memo(({ photoURL, name, displayName, initials }) => {
+const UserAvatarDisplay = memo(({ photoURL, displayName, initials }) => {
   return (
     <Avatar className="h-10 w-10">
       <AvatarImage
-        src={photoURL || ""}
-        alt={name || displayName || "User Profile"}
+        src={photoURL}
+        alt={displayName || "User Profile"}
         onError={(e) => {
           e.target.style.display = "none";
         }}


### PR DESCRIPTION
### Motivation
- Ensure the nav avatar and alt text use the most authoritative profile data so the avatar shown in the header matches the Settings/profile photo.

### Description
- Resolve `resolvedDisplayName` and `resolvedPhotoURL` by preferring `currentUser` fields over `userData` and compute initials from the resolved name or fallbacks.
- Pass the resolved `photoURL` and `displayName` into `UserAvatarDisplay` instead of `userData` fields directly.
- Update `UserAvatarDisplay` to accept `photoURL` and `displayName`, set `AvatarImage`'s `src` to `photoURL` and `alt` to `displayName || "User Profile"`, and remove the unused `name` prop.
- Changes made in `client/src/components/Nav.jsx` to ensure the header avatar matches the authenticated user's profile.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968507f66ec83299cb656f533d8a3d7)