### PR TITLE
Add Billing & Payment Methods section to Settings and Firestore wiring

### DIFF
--- a/client/src/lib/firebase.ts
+++ b/client/src/lib/firebase.ts
@@ -207,9 +207,13 @@ export interface UserData {
     status?: string;
   }>;
   paymentMethods?: Array<{
+    id?: string;
+    cardholder?: string;
     brand?: string;
     last4?: string;
     expiryDate?: string;
+    isDefault?: boolean;
+    stripePaymentMethodId?: string;
   }>;
   teamRoles?: {
     count?: number;
@@ -301,6 +305,8 @@ export const createUserDocument = async (
         skillLevels: {},
         mostFrequentLocation: "",
         deviceTypes: [],
+        billingHistory: [],
+        paymentMethods: [],
       };
 
       console.log("[Firebase] Attempting setDoc for new user...");
@@ -344,6 +350,19 @@ export const getUserData = async (uid: string): Promise<UserData | null> => {
       code: (error as any)?.code,
       message: (error as any)?.message,
     });
+    throw error;
+  }
+};
+
+export const updateUserBillingDetails = async (
+  uid: string,
+  updates: Pick<UserData, "paymentMethods" | "billingHistory">,
+): Promise<void> => {
+  try {
+    const userRef = doc(db, "users", uid);
+    await updateDoc(userRef, updates);
+  } catch (error) {
+    console.error("[Firebase] Error updating billing details:", error);
     throw error;
   }
 };

--- a/client/src/pages/Settings.jsx
+++ b/client/src/pages/Settings.jsx
@@ -1,16 +1,30 @@
 "use client";
 
-import { useMemo } from "react";
-import { Mail, ShieldCheck, ShoppingBag, User } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { CreditCard, Mail, ShieldCheck, ShoppingBag, User } from "lucide-react";
 import Nav from "@/components/Nav";
 import Footer from "@/components/Footer";
 import { useAuth } from "@/contexts/AuthContext";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { updateUserBillingDetails } from "@/lib/firebase";
 
 const sectionCardStyles =
   "rounded-2xl border border-zinc-200 bg-white p-6 shadow-sm";
 
 export default function SettingsPage() {
   const { currentUser, userData } = useAuth();
+  const [paymentMethods, setPaymentMethods] = useState([]);
+  const [billingHistory, setBillingHistory] = useState([]);
+  const [newPaymentMethod, setNewPaymentMethod] = useState({
+    cardholder: "",
+    cardNumber: "",
+    expiry: "",
+    cvc: "",
+  });
+  const [isSavingBilling, setIsSavingBilling] = useState(false);
+  const [billingMessage, setBillingMessage] = useState("");
 
   const createdDateLabel = useMemo(() => {
     const createdDate = userData?.createdDate;
@@ -45,6 +59,119 @@ export default function SettingsPage() {
 
   const purchases =
     userData?.purchases || userData?.library || userData?.purchasedItems || [];
+
+  useEffect(() => {
+    if (!userData) {
+      setPaymentMethods([]);
+      setBillingHistory([]);
+      return;
+    }
+    const normalizedMethods = Array.isArray(userData.paymentMethods)
+      ? userData.paymentMethods.map((method, index) => ({
+          id: method.id || `pm_${index}_${method.last4 || "card"}`,
+          ...method,
+        }))
+      : [];
+    if (normalizedMethods.length > 0 && !normalizedMethods.some((method) => method.isDefault)) {
+      normalizedMethods[0].isDefault = true;
+    }
+    setPaymentMethods(normalizedMethods);
+    setBillingHistory(Array.isArray(userData.billingHistory) ? userData.billingHistory : []);
+  }, [userData]);
+
+  const detectCardBrand = (cardNumber = "") => {
+    const normalized = cardNumber.replace(/\s+/g, "");
+    if (normalized.startsWith("4")) return "Visa";
+    if (normalized.startsWith("5")) return "Mastercard";
+    if (normalized.startsWith("34") || normalized.startsWith("37")) return "Amex";
+    if (normalized.startsWith("6")) return "Discover";
+    return "Card";
+  };
+
+  const formatBillingDate = (value) => {
+    if (!value) {
+      return "No date";
+    }
+    if (typeof value === "object" && typeof value.toDate === "function") {
+      return value.toDate().toLocaleDateString();
+    }
+    return new Date(value).toLocaleDateString();
+  };
+
+  const handleAddPaymentMethod = () => {
+    const normalizedNumber = newPaymentMethod.cardNumber.replace(/\s+/g, "");
+    if (
+      !newPaymentMethod.cardholder ||
+      normalizedNumber.length < 12 ||
+      !newPaymentMethod.expiry
+    ) {
+      setBillingMessage("Enter a valid cardholder, number, and expiry date.");
+      return;
+    }
+
+    const methodId =
+      typeof crypto !== "undefined" && crypto.randomUUID
+        ? crypto.randomUUID()
+        : `pm_${Date.now()}`;
+    const isDefault = paymentMethods.length === 0 || !paymentMethods.some((method) => method.isDefault);
+    const newMethod = {
+      id: methodId,
+      cardholder: newPaymentMethod.cardholder.trim(),
+      brand: detectCardBrand(normalizedNumber),
+      last4: normalizedNumber.slice(-4),
+      expiryDate: newPaymentMethod.expiry,
+      isDefault,
+    };
+
+    setPaymentMethods((prev) => [...prev, newMethod]);
+    setNewPaymentMethod({
+      cardholder: "",
+      cardNumber: "",
+      expiry: "",
+      cvc: "",
+    });
+    setBillingMessage("");
+  };
+
+  const handleSetDefault = (methodId) => {
+    setPaymentMethods((prev) =>
+      prev.map((method) => ({
+        ...method,
+        isDefault: method.id === methodId,
+      })),
+    );
+  };
+
+  const handleRemoveMethod = (methodId) => {
+    setPaymentMethods((prev) => {
+      const remaining = prev.filter((method) => method.id !== methodId);
+      if (remaining.length > 0 && !remaining.some((method) => method.isDefault)) {
+        remaining[0].isDefault = true;
+      }
+      return remaining;
+    });
+  };
+
+  const handleSaveBilling = async () => {
+    if (!currentUser) {
+      setBillingMessage("Sign in to update billing details.");
+      return;
+    }
+    setIsSavingBilling(true);
+    setBillingMessage("");
+    try {
+      await updateUserBillingDetails(currentUser.uid, {
+        paymentMethods,
+        billingHistory,
+      });
+      setBillingMessage("Billing details updated.");
+    } catch (error) {
+      console.error("Failed to update billing details:", error);
+      setBillingMessage("Unable to save billing details. Please try again.");
+    } finally {
+      setIsSavingBilling(false);
+    }
+  };
 
   return (
     <>
@@ -184,6 +311,220 @@ export default function SettingsPage() {
                         </div>
                       </div>
                     )}
+                  </div>
+                </div>
+              </section>
+
+              <section className={sectionCardStyles}>
+                <div className="flex items-start gap-4">
+                  <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-sky-50 text-sky-600">
+                    <CreditCard className="h-5 w-5" />
+                  </div>
+                  <div className="flex-1 space-y-6">
+                    <div>
+                      <h2 className="text-lg font-semibold text-zinc-900">
+                        Billing &amp; Payment Methods
+                      </h2>
+                      <p className="text-sm text-zinc-600">
+                        Manage saved payment options and review recent billing activity.
+                        For security, only card brand and last four digits are stored.
+                      </p>
+                    </div>
+
+                    <Card className="border border-zinc-200 shadow-none">
+                      <CardContent className="space-y-4 p-5">
+                        <div className="flex items-center justify-between">
+                          <div>
+                            <p className="text-sm font-semibold text-zinc-900">
+                              Saved payment methods
+                            </p>
+                            <p className="text-xs text-zinc-500">
+                              Set a default card for recurring charges.
+                            </p>
+                          </div>
+                        </div>
+
+                        {paymentMethods.length > 0 ? (
+                          <div className="space-y-3">
+                            {paymentMethods.map((method) => (
+                              <div
+                                key={method.id || `${method.brand}-${method.last4}`}
+                                className="flex flex-col gap-3 rounded-xl border border-zinc-200 bg-zinc-50 p-4 sm:flex-row sm:items-center sm:justify-between"
+                              >
+                                <div>
+                                  <p className="text-sm font-semibold text-zinc-900">
+                                    {method.brand || "Card"} •••• {method.last4 || "—"}
+                                  </p>
+                                  <p className="text-xs text-zinc-500">
+                                    Expires {method.expiryDate || "—"}
+                                  </p>
+                                  {method.isDefault && (
+                                    <span className="mt-2 inline-flex w-fit rounded-full bg-emerald-100 px-2 py-1 text-xs font-semibold text-emerald-700">
+                                      Default
+                                    </span>
+                                  )}
+                                </div>
+                                <div className="flex flex-wrap gap-2">
+                                  {!method.isDefault && (
+                                    <Button
+                                      variant="secondary"
+                                      onClick={() => handleSetDefault(method.id)}
+                                    >
+                                      Set default
+                                    </Button>
+                                  )}
+                                  <Button
+                                    variant="outline"
+                                    className="border-zinc-300 text-zinc-700"
+                                    onClick={() => handleRemoveMethod(method.id)}
+                                  >
+                                    Remove
+                                  </Button>
+                                </div>
+                              </div>
+                            ))}
+                          </div>
+                        ) : (
+                          <div className="rounded-xl border border-dashed border-zinc-300 bg-white p-4 text-sm text-zinc-500">
+                            No payment methods saved yet.
+                          </div>
+                        )}
+                      </CardContent>
+                    </Card>
+
+                    <Card className="border border-zinc-200 shadow-none">
+                      <CardContent className="space-y-4 p-5">
+                        <div>
+                          <p className="text-sm font-semibold text-zinc-900">
+                            Add payment method
+                          </p>
+                          <p className="text-xs text-zinc-500">
+                            Card details are tokenized in production; demo stores only the
+                            last four digits.
+                          </p>
+                        </div>
+                        <div className="grid gap-4 sm:grid-cols-2">
+                          <div className="space-y-2">
+                            <label className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-400">
+                              Cardholder
+                            </label>
+                            <Input
+                              placeholder="Jamie Appleseed"
+                              value={newPaymentMethod.cardholder}
+                              onChange={(event) =>
+                                setNewPaymentMethod((prev) => ({
+                                  ...prev,
+                                  cardholder: event.target.value,
+                                }))
+                              }
+                            />
+                          </div>
+                          <div className="space-y-2">
+                            <label className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-400">
+                              Card number
+                            </label>
+                            <Input
+                              placeholder="1234 5678 9012 3456"
+                              value={newPaymentMethod.cardNumber}
+                              onChange={(event) =>
+                                setNewPaymentMethod((prev) => ({
+                                  ...prev,
+                                  cardNumber: event.target.value,
+                                }))
+                              }
+                            />
+                          </div>
+                          <div className="space-y-2">
+                            <label className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-400">
+                              Expiry
+                            </label>
+                            <Input
+                              placeholder="MM/YY"
+                              value={newPaymentMethod.expiry}
+                              onChange={(event) =>
+                                setNewPaymentMethod((prev) => ({
+                                  ...prev,
+                                  expiry: event.target.value,
+                                }))
+                              }
+                            />
+                          </div>
+                          <div className="space-y-2">
+                            <label className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-400">
+                              CVC
+                            </label>
+                            <Input
+                              placeholder="123"
+                              value={newPaymentMethod.cvc}
+                              onChange={(event) =>
+                                setNewPaymentMethod((prev) => ({
+                                  ...prev,
+                                  cvc: event.target.value,
+                                }))
+                              }
+                            />
+                          </div>
+                        </div>
+                        <div className="flex flex-wrap items-center justify-between gap-3">
+                          <Button type="button" onClick={handleAddPaymentMethod}>
+                            Add payment method
+                          </Button>
+                          <span className="text-xs text-zinc-500">
+                            CVC is never stored.
+                          </span>
+                        </div>
+                      </CardContent>
+                    </Card>
+
+                    <Card className="border border-zinc-200 shadow-none">
+                      <CardContent className="space-y-4 p-5">
+                        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                          <div>
+                            <p className="text-sm font-semibold text-zinc-900">
+                              Recent billing history
+                            </p>
+                            <p className="text-xs text-zinc-500">
+                              Latest charges and invoice statuses.
+                            </p>
+                          </div>
+                        </div>
+                        {billingHistory.length > 0 ? (
+                          <div className="space-y-3">
+                            {billingHistory.map((entry, index) => (
+                              <div
+                                key={entry.id || `${entry.status}-${index}`}
+                                className="flex flex-col gap-2 rounded-xl border border-zinc-200 bg-zinc-50 p-4 text-sm sm:flex-row sm:items-center sm:justify-between"
+                              >
+                                <div>
+                                  <p className="font-semibold text-zinc-900">
+                                    {entry.amount ? `$${entry.amount}` : "—"}
+                                  </p>
+                                  <p className="text-xs text-zinc-500">
+                                    {formatBillingDate(entry.date)}
+                                  </p>
+                                </div>
+                                <span className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                                  {entry.status || "Pending"}
+                                </span>
+                              </div>
+                            ))}
+                          </div>
+                        ) : (
+                          <div className="rounded-xl border border-dashed border-zinc-300 bg-white p-4 text-sm text-zinc-500">
+                            No billing history yet.
+                          </div>
+                        )}
+                      </CardContent>
+                    </Card>
+
+                    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                      <Button onClick={handleSaveBilling} disabled={isSavingBilling}>
+                        {isSavingBilling ? "Saving..." : "Save billing updates"}
+                      </Button>
+                      {billingMessage && (
+                        <p className="text-sm text-zinc-500">{billingMessage}</p>
+                      )}
+                    </div>
                   </div>
                 </div>
               </section>


### PR DESCRIPTION
### Motivation
- Provide a customer-facing UI to view and manage payment methods and billing history inside the existing Settings page.
- Persist billing-related data on the user profile in Firestore so saved methods and history can be reused across sessions.

### Description
- Added a new "Billing & Payment Methods" section to `client/src/pages/Settings.jsx` that lists saved methods, shows billing history, and includes an "Add payment method" form with fields for cardholder, number, expiry, and CVC (CVC is not stored).
- Implemented client-side flows to add a card (extract brand/last4), set a default card, remove cards, and a `Save billing updates` action that calls `updateUserBillingDetails` to write `paymentMethods` and `billingHistory` to Firestore.
- Extended `UserData` in `client/src/lib/firebase.ts` to include richer payment method fields (`id`, `cardholder`, `isDefault`, `stripePaymentMethodId`) and `billingHistory`, initialized new users with empty billing arrays, and added `updateUserBillingDetails(uid, updates)` helper for updates.
- UI reuses existing components (`Card`, `Input`, `Button`) and includes lightweight card-brand detection; note that no Stripe Elements integration was added here and raw card numbers are only used client-side for demo storage of `last4`.

### Testing
- Attempted to run the dev server with `PORT=4173 npm run dev`, which started but failed during runtime due to a `pino-pretty` transport error so the app could not be fully exercised.
- Attempted an automated Playwright page load/screenshot of `http://127.0.0.1:4173/settings`, which failed with `net::ERR_EMPTY_RESPONSE` because the dev server did not complete startup.
- No unit tests or CI test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69685092f8808329900494a75b35bcca)