### PR TITLE
Require auth for marketplace/environment/benchmark detail routes

### DIFF
--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -10,6 +10,7 @@ import { LoadingScreen } from "./components/site/LoadingScreen";
 import { CookieConsent } from "./components/CookieConsent";
 import { Analytics } from "./components/Analytics";
 import { AuthProvider } from "./contexts/AuthContext";
+import ProtectedRoute from "./components/ProtectedRoute";
 
 const Home = lazy(() => import("./pages/Home"));
 const WhySimulation = lazy(() => import("./pages/WhySimulation"));
@@ -43,6 +44,17 @@ const withLayout = <P extends object>(Component: React.ComponentType<P>) =>
     </SiteLayout>
   );
 
+const withProtectedLayout = <P extends object>(
+  Component: React.ComponentType<P>,
+) =>
+  (props: P) => (
+    <ProtectedRoute>
+      <SiteLayout>
+        <Component {...props} />
+      </SiteLayout>
+    </ProtectedRoute>
+  );
+
 function Router() {
   return (
     <Suspense fallback={<LoadingScreen />}>
@@ -54,11 +66,11 @@ function Router() {
         <Route path="/environments" component={withLayout(Environments)} />
         <Route
           path="/marketplace/:slug"
-          component={withLayout(EnvironmentDetail)}
+          component={withProtectedLayout(EnvironmentDetail)}
         />
         <Route
           path="/environments/:slug"
-          component={withLayout(EnvironmentDetail)}
+          component={withProtectedLayout(EnvironmentDetail)}
         />
         <Route path="/solutions" component={withLayout(Solutions)} />
         <Route path="/pricing" component={withLayout(Pricing)} />
@@ -68,7 +80,7 @@ function Router() {
         <Route path="/benchmarks" component={withLayout(Evals)} />
         <Route
           path="/benchmarks/:slug"
-          component={withLayout(BenchmarkDetail)}
+          component={withProtectedLayout(BenchmarkDetail)}
         />
         <Route path="/rl-training" component={withLayout(RLTraining)} />
         <Route path="/case-studies" component={withLayout(CaseStudies)} />


### PR DESCRIPTION
### Motivation
- Protect detail pages so unauthenticated users are redirected to login when accessing `/marketplace/:slug`, `/environments/:slug`, and `/benchmarks/:slug`.
- Preserve the intended destination across the login flow using the existing `ProtectedRoute` behavior that stores `redirectAfterAuth` in `sessionStorage`.
- Maintain existing test-mode behavior where `resetOnboarding=true` or `test=true` in the query string bypasses the auth guard.

### Description
- Import the existing `ProtectedRoute` component and add a `withProtectedLayout` HOC that wraps components in `ProtectedRoute` + `SiteLayout` in `client/src/main.tsx`.
- Replace the detail route components for `/marketplace/:slug` and `/environments/:slug` with `withProtectedLayout(EnvironmentDetail)`.
- Replace the detail route component for `/benchmarks/:slug` with `withProtectedLayout(BenchmarkDetail)`.
- All other public routes keep the original `withLayout` wrapper and behavior.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696854d52eac8329a4beaa4cb29894fa)