### PR TITLE
Gate marketplace and benchmark navigation

### DIFF
--- a/client/src/components/site/MarketplaceCard.tsx
+++ b/client/src/components/site/MarketplaceCard.tsx
@@ -4,6 +4,7 @@ import { loadStripe } from "@stripe/stripe-js";
 import { Shield, Package, Sparkles, TrendingUp, ShoppingCart, Loader2, Play, Layers, Database } from "lucide-react";
 import type { SyntheticDataset, MarketplaceScene, TrainingDataset } from "@/data/content";
 import { useLocation } from "wouter";
+import { useAuth } from "@/contexts/AuthContext";
 
 interface MarketplaceCardProps {
   item: SyntheticDataset | MarketplaceScene | TrainingDataset;
@@ -14,6 +15,7 @@ export function MarketplaceCard({ item, type }: MarketplaceCardProps) {
   const [isRedirecting, setIsRedirecting] = useState(false);
   const [imageLoaded, setImageLoaded] = useState(false);
   const [, navigate] = useLocation();
+  const { currentUser } = useAuth();
   const isDataset = type === "dataset";
   const isTraining = type === "training";
   const isScene = type === "scene";
@@ -136,9 +138,15 @@ export function MarketplaceCard({ item, type }: MarketplaceCardProps) {
     [dataset, isDataset, isTraining, isRedirecting, scene, training, slug],
   );
 
-  const handleCardClick = () => {
-    navigate(`/marketplace/${slug}`);
-  };
+  const handleCardClick = useCallback(() => {
+    const targetPath = `/marketplace/${slug}`;
+    if (!currentUser) {
+      sessionStorage.setItem("redirectAfterAuth", targetPath);
+      navigate("/login");
+      return;
+    }
+    navigate(targetPath);
+  }, [currentUser, navigate, slug]);
 
   return (
     <article

--- a/client/src/components/site/SceneCard.tsx
+++ b/client/src/components/site/SceneCard.tsx
@@ -1,15 +1,31 @@
 import { InteractionBadges } from "./InteractionBadges";
 import type { Scene } from "@/data/content";
+import { useAuth } from "@/contexts/AuthContext";
+import { useLocation } from "wouter";
 
 interface SceneCardProps {
   scene: Scene;
 }
 
 export function SceneCard({ scene }: SceneCardProps) {
+  const { currentUser } = useAuth();
+  const [, navigate] = useLocation();
+
+  const handleCardClick = () => {
+    const targetPath = `/marketplace/${scene.slug}`;
+    if (!currentUser) {
+      sessionStorage.setItem("redirectAfterAuth", targetPath);
+      navigate("/login");
+      return;
+    }
+    navigate(targetPath);
+  };
+
   return (
-    <a
-      href={`/marketplace/${scene.slug}`}
-      className="group flex flex-col overflow-hidden rounded-3xl border border-slate-200 bg-white transition hover:-translate-y-1 hover:shadow-lg"
+    <button
+      type="button"
+      onClick={handleCardClick}
+      className="group flex flex-col overflow-hidden rounded-3xl border border-slate-200 bg-white text-left transition hover:-translate-y-1 hover:shadow-lg"
     >
       <div className="aspect-[4/3] overflow-hidden bg-slate-100">
         <img
@@ -37,6 +53,6 @@ export function SceneCard({ scene }: SceneCardProps) {
           </span>
         </div>
       </div>
-    </a>
+    </button>
   );
 }

--- a/client/src/pages/Evals.tsx
+++ b/client/src/pages/Evals.tsx
@@ -1,4 +1,5 @@
 import { SEO } from "@/components/SEO";
+import { useAuth } from "@/contexts/AuthContext";
 import { syntheticDatasets } from "@/data/content";
 import {
   ArrowRight,
@@ -22,6 +23,7 @@ import {
   Workflow,
   Zap,
 } from "lucide-react";
+import { useLocation } from "wouter";
 
 // --- Data ---
 
@@ -137,6 +139,18 @@ function DotPattern() {
 // --- Main Component ---
 
 export default function Evals() {
+  const { currentUser } = useAuth();
+  const [, navigate] = useLocation();
+
+  const handleBenchmarkClick = (targetPath: string) => {
+    if (!currentUser) {
+      sessionStorage.setItem("redirectAfterAuth", targetPath);
+      navigate("/login");
+      return;
+    }
+    navigate(targetPath);
+  };
+
   return (
     <>
       <SEO
@@ -722,10 +736,11 @@ export default function Evals() {
 
               <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
                 {syntheticDatasets.map((benchmark) => (
-                  <a
+                  <button
                     key={benchmark.slug}
-                    href={`/benchmarks/${benchmark.slug}`}
-                    className="group rounded-2xl border border-zinc-200 bg-white p-6 shadow-sm transition-all hover:shadow-md hover:border-emerald-200"
+                    type="button"
+                    onClick={() => handleBenchmarkClick(`/benchmarks/${benchmark.slug}`)}
+                    className="group rounded-2xl border border-zinc-200 bg-white p-6 text-left shadow-sm transition-all hover:shadow-md hover:border-emerald-200"
                   >
                     <div className="aspect-video overflow-hidden rounded-xl mb-4">
                       <img
@@ -756,7 +771,7 @@ export default function Evals() {
                         <span>{benchmark.variationCount?.toLocaleString()} variations</span>
                       </div>
                     </div>
-                  </a>
+                  </button>
                 ))}
               </div>
 


### PR DESCRIPTION
### Motivation

- Prevent unauthenticated users from navigating directly to marketplace/benchmark detail pages and preserve intended destination for post-login redirect. 
- Align on existing redirect handling used by `ProtectedRoute` by setting `redirectAfterAuth` and navigating to `/login`. 

### Description

- Use `useAuth()` and `useLocation()` in `client/src/components/site/MarketplaceCard.tsx` to check `currentUser` and, when missing, call `sessionStorage.setItem("redirectAfterAuth", targetPath)` then `navigate("/login")` before aborting navigation. 
- Replace the anchor-based scene card with a clickable element in `client/src/components/site/SceneCard.tsx` and add the same auth check + `redirectAfterAuth` behavior to the card click handler. 
- Replace benchmark `<a href>` cards on `client/src/pages/Evals.tsx` with `button` elements and a shared `handleBenchmarkClick` that stores `redirectAfterAuth` and routes to `/login` for unauthenticated users, otherwise navigates to the benchmark page. 

### Testing

- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968554e57cc8329ba871f91086df648)