### PR TITLE
Add prerender pipeline for public routes

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -34,9 +34,10 @@
       content="SimReady scenes for robotics. OpenUSD, clean pivots and physics, Isaac-ready joints and colliders. Prove policies faster with realistic environments."
     />
     <meta name="robots" content="index, follow" />
+    <!--app-head-->
   </head>
   <body class="font-sans">
-    <div id="root"></div>
+    <div id="root"><!--app-html--></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/client/src/AppRoutes.tsx
+++ b/client/src/AppRoutes.tsx
@@ -1,0 +1,93 @@
+import { Suspense, lazy } from "react";
+import type { ComponentType } from "react";
+import { Route, Switch } from "wouter";
+import { SiteLayout } from "./components/site/SiteLayout";
+import { LoadingScreen } from "./components/site/LoadingScreen";
+import ProtectedRoute from "./components/ProtectedRoute";
+
+const Home = lazy(() => import("./pages/Home"));
+const WhySimulation = lazy(() => import("./pages/WhySimulation"));
+const Environments = lazy(() => import("./pages/Environments"));
+// const Recipes = lazy(() => import("./pages/Recipes")); // Hidden: recipes temporarily removed from offerings
+const EnvironmentDetail = lazy(() => import("./pages/EnvironmentDetail"));
+const Solutions = lazy(() => import("./pages/Solutions"));
+const Pricing = lazy(() => import("./pages/Pricing"));
+const Learn = lazy(() => import("./pages/Learn"));
+// const Capture = lazy(() => import("./pages/Capture")); // Capture service coming Q2 2026
+const Docs = lazy(() => import("./pages/Docs"));
+const Evals = lazy(() => import("./pages/Evals"));
+const BenchmarkDetail = lazy(() => import("./pages/BenchmarkDetail"));
+const RLTraining = lazy(() => import("./pages/RLTraining"));
+const CaseStudies = lazy(() => import("./pages/CaseStudies"));
+const Careers = lazy(() => import("./pages/Careers"));
+const Contact = lazy(() => import("./pages/Contact"));
+const PartnerProgram = lazy(() => import("./pages/PartnerProgram"));
+const Portal = lazy(() => import("./pages/Portal"));
+const Login = lazy(() => import("./pages/Login"));
+const ForgotPassword = lazy(() => import("./pages/ForgotPassword"));
+const Privacy = lazy(() => import("./pages/Privacy"));
+const Terms = lazy(() => import("./pages/Terms"));
+const Settings = lazy(() => import("./pages/Settings"));
+const NotFound = lazy(() => import("./pages/NotFound"));
+
+const withLayout = <P extends object>(Component: ComponentType<P>) =>
+  (props: P) => (
+    <SiteLayout>
+      <Component {...props} />
+    </SiteLayout>
+  );
+
+const withProtectedLayout = <P extends object>(
+  Component: ComponentType<P>,
+) =>
+  (props: P) => (
+    <ProtectedRoute>
+      <SiteLayout>
+        <Component {...props} />
+      </SiteLayout>
+    </ProtectedRoute>
+  );
+
+export function AppRoutes() {
+  return (
+    <Suspense fallback={<LoadingScreen />}>
+      <Switch>
+        <Route path="/" component={withLayout(Home)} />
+        <Route path="/why-simulation" component={withLayout(WhySimulation)} />
+        {/* Primary route: /marketplace (canonical), /environments kept for backwards compatibility */}
+        <Route path="/marketplace" component={withLayout(Environments)} />
+        <Route path="/environments" component={withLayout(Environments)} />
+        <Route
+          path="/marketplace/:slug"
+          component={withProtectedLayout(EnvironmentDetail)}
+        />
+        <Route
+          path="/environments/:slug"
+          component={withProtectedLayout(EnvironmentDetail)}
+        />
+        <Route path="/solutions" component={withLayout(Solutions)} />
+        <Route path="/pricing" component={withLayout(Pricing)} />
+        <Route path="/learn" component={withLayout(Learn)} />
+        <Route path="/docs" component={withLayout(Docs)} />
+        <Route path="/evals" component={withLayout(Evals)} />
+        <Route path="/benchmarks" component={withLayout(Evals)} />
+        <Route
+          path="/benchmarks/:slug"
+          component={withProtectedLayout(BenchmarkDetail)}
+        />
+        <Route path="/rl-training" component={withLayout(RLTraining)} />
+        <Route path="/case-studies" component={withLayout(CaseStudies)} />
+        <Route path="/careers" component={withLayout(Careers)} />
+        <Route path="/contact" component={withLayout(Contact)} />
+        <Route path="/partners" component={withLayout(PartnerProgram)} />
+        <Route path="/portal" component={withLayout(Portal)} />
+        <Route path="/login" component={withLayout(Login)} />
+        <Route path="/forgot-password" component={withLayout(ForgotPassword)} />
+        <Route path="/privacy" component={withLayout(Privacy)} />
+        <Route path="/terms" component={withLayout(Terms)} />
+        <Route path="/settings" component={withLayout(Settings)} />
+        <Route component={withLayout(NotFound)} />
+      </Switch>
+    </Suspense>
+  );
+}

--- a/client/src/AppRoutesServer.tsx
+++ b/client/src/AppRoutesServer.tsx
@@ -1,0 +1,86 @@
+import type { ComponentType } from "react";
+import { Route, Switch } from "wouter";
+import { SiteLayout } from "./components/site/SiteLayout";
+import ProtectedRoute from "./components/ProtectedRoute";
+import Home from "./pages/Home";
+import WhySimulation from "./pages/WhySimulation";
+import Environments from "./pages/Environments";
+import EnvironmentDetail from "./pages/EnvironmentDetail";
+import Solutions from "./pages/Solutions";
+import Pricing from "./pages/Pricing";
+import Learn from "./pages/Learn";
+import Docs from "./pages/Docs";
+import Evals from "./pages/Evals";
+import BenchmarkDetail from "./pages/BenchmarkDetail";
+import RLTraining from "./pages/RLTraining";
+import CaseStudies from "./pages/CaseStudies";
+import Careers from "./pages/Careers";
+import Contact from "./pages/Contact";
+import PartnerProgram from "./pages/PartnerProgram";
+import Portal from "./pages/Portal";
+import Login from "./pages/Login";
+import ForgotPassword from "./pages/ForgotPassword";
+import Privacy from "./pages/Privacy";
+import Terms from "./pages/Terms";
+import Settings from "./pages/Settings";
+import NotFound from "./pages/NotFound";
+
+const withLayout = <P extends object>(Component: ComponentType<P>) =>
+  (props: P) => (
+    <SiteLayout>
+      <Component {...props} />
+    </SiteLayout>
+  );
+
+const withProtectedLayout = <P extends object>(
+  Component: ComponentType<P>,
+) =>
+  (props: P) => (
+    <ProtectedRoute>
+      <SiteLayout>
+        <Component {...props} />
+      </SiteLayout>
+    </ProtectedRoute>
+  );
+
+export function AppRoutesServer() {
+  return (
+    <Switch>
+      <Route path="/" component={withLayout(Home)} />
+      <Route path="/why-simulation" component={withLayout(WhySimulation)} />
+      {/* Primary route: /marketplace (canonical), /environments kept for backwards compatibility */}
+      <Route path="/marketplace" component={withLayout(Environments)} />
+      <Route path="/environments" component={withLayout(Environments)} />
+      <Route
+        path="/marketplace/:slug"
+        component={withProtectedLayout(EnvironmentDetail)}
+      />
+      <Route
+        path="/environments/:slug"
+        component={withProtectedLayout(EnvironmentDetail)}
+      />
+      <Route path="/solutions" component={withLayout(Solutions)} />
+      <Route path="/pricing" component={withLayout(Pricing)} />
+      <Route path="/learn" component={withLayout(Learn)} />
+      <Route path="/docs" component={withLayout(Docs)} />
+      <Route path="/evals" component={withLayout(Evals)} />
+      <Route path="/benchmarks" component={withLayout(Evals)} />
+      <Route
+        path="/benchmarks/:slug"
+        component={withProtectedLayout(BenchmarkDetail)}
+      />
+      <Route path="/rl-training" component={withLayout(RLTraining)} />
+      <Route path="/case-studies" component={withLayout(CaseStudies)} />
+      <Route path="/careers" component={withLayout(Careers)} />
+      <Route path="/contact" component={withLayout(Contact)} />
+      <Route path="/partners" component={withLayout(PartnerProgram)} />
+      <Route path="/portal" component={withLayout(Portal)} />
+      <Route path="/login" component={withLayout(Login)} />
+      <Route path="/forgot-password" component={withLayout(ForgotPassword)} />
+      <Route path="/privacy" component={withLayout(Privacy)} />
+      <Route path="/terms" component={withLayout(Terms)} />
+      <Route path="/settings" component={withLayout(Settings)} />
+      <Route component={withLayout(NotFound)} />
+    </Switch>
+  );
+}

--- a/client/src/AppShell.tsx
+++ b/client/src/AppShell.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from "react";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { Router as WouterRouter, type BaseLocationHook } from "wouter";
+import { Toaster } from "@/components/ui/toaster";
+import { CookieConsent } from "./components/CookieConsent";
+import { Analytics } from "./components/Analytics";
+import { AuthProvider } from "./contexts/AuthContext";
+import { queryClient } from "./lib/queryClient";
+
+type AppShellProps = {
+  children: ReactNode;
+  locationHook?: BaseLocationHook;
+};
+
+export function AppShell({ children, locationHook }: AppShellProps) {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <AuthProvider>
+        <Analytics />
+        <WouterRouter hook={locationHook}>{children}</WouterRouter>
+        <Toaster />
+        <CookieConsent />
+      </AuthProvider>
+    </QueryClientProvider>
+  );
+}

--- a/client/src/entry-server.tsx
+++ b/client/src/entry-server.tsx
@@ -1,0 +1,28 @@
+import { renderToString } from "react-dom/server";
+import { Helmet } from "react-helmet";
+import { memoryLocation } from "wouter";
+import { AppShell } from "./AppShell";
+import { AppRoutesServer } from "./AppRoutesServer";
+
+export function render(url: string) {
+  const location = memoryLocation({ path: url, static: true });
+
+  const html = renderToString(
+    <AppShell locationHook={location.hook}>
+      <AppRoutesServer />
+    </AppShell>,
+  );
+
+  const helmet = Helmet.renderStatic();
+  const head = [
+    helmet.title.toString(),
+    helmet.meta.toString(),
+    helmet.link.toString(),
+    helmet.script.toString(),
+    helmet.noscript.toString(),
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  return { html, head };
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,113 +1,13 @@
-import { StrictMode, Suspense, lazy } from "react";
+import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import { Route, Switch } from "wouter";
 import "./index.css";
-import { QueryClientProvider } from "@tanstack/react-query";
-import { queryClient } from "./lib/queryClient";
-import { Toaster } from "@/components/ui/toaster";
-import { SiteLayout } from "./components/site/SiteLayout";
-import { LoadingScreen } from "./components/site/LoadingScreen";
-import { CookieConsent } from "./components/CookieConsent";
-import { Analytics } from "./components/Analytics";
-import { AuthProvider } from "./contexts/AuthContext";
-import ProtectedRoute from "./components/ProtectedRoute";
-
-const Home = lazy(() => import("./pages/Home"));
-const WhySimulation = lazy(() => import("./pages/WhySimulation"));
-const Environments = lazy(() => import("./pages/Environments"));
-// const Recipes = lazy(() => import("./pages/Recipes")); // Hidden: recipes temporarily removed from offerings
-const EnvironmentDetail = lazy(() => import("./pages/EnvironmentDetail"));
-const Solutions = lazy(() => import("./pages/Solutions"));
-const Pricing = lazy(() => import("./pages/Pricing"));
-const Learn = lazy(() => import("./pages/Learn"));
-// const Capture = lazy(() => import("./pages/Capture")); // Capture service coming Q2 2026
-const Docs = lazy(() => import("./pages/Docs"));
-const Evals = lazy(() => import("./pages/Evals"));
-const BenchmarkDetail = lazy(() => import("./pages/BenchmarkDetail"));
-const RLTraining = lazy(() => import("./pages/RLTraining"));
-const CaseStudies = lazy(() => import("./pages/CaseStudies"));
-const Careers = lazy(() => import("./pages/Careers"));
-const Contact = lazy(() => import("./pages/Contact"));
-const PartnerProgram = lazy(() => import("./pages/PartnerProgram"));
-const Portal = lazy(() => import("./pages/Portal"));
-const Login = lazy(() => import("./pages/Login"));
-const ForgotPassword = lazy(() => import("./pages/ForgotPassword"));
-const Privacy = lazy(() => import("./pages/Privacy"));
-const Terms = lazy(() => import("./pages/Terms"));
-const Settings = lazy(() => import("./pages/Settings"));
-const NotFound = lazy(() => import("./pages/NotFound"));
-
-const withLayout = <P extends object>(Component: React.ComponentType<P>) =>
-  (props: P) => (
-    <SiteLayout>
-      <Component {...props} />
-    </SiteLayout>
-  );
-
-const withProtectedLayout = <P extends object>(
-  Component: React.ComponentType<P>,
-) =>
-  (props: P) => (
-    <ProtectedRoute>
-      <SiteLayout>
-        <Component {...props} />
-      </SiteLayout>
-    </ProtectedRoute>
-  );
-
-function Router() {
-  return (
-    <Suspense fallback={<LoadingScreen />}>
-      <Switch>
-        <Route path="/" component={withLayout(Home)} />
-        <Route path="/why-simulation" component={withLayout(WhySimulation)} />
-        {/* Primary route: /marketplace (canonical), /environments kept for backwards compatibility */}
-        <Route path="/marketplace" component={withLayout(Environments)} />
-        <Route path="/environments" component={withLayout(Environments)} />
-        <Route
-          path="/marketplace/:slug"
-          component={withProtectedLayout(EnvironmentDetail)}
-        />
-        <Route
-          path="/environments/:slug"
-          component={withProtectedLayout(EnvironmentDetail)}
-        />
-        <Route path="/solutions" component={withLayout(Solutions)} />
-        <Route path="/pricing" component={withLayout(Pricing)} />
-        <Route path="/learn" component={withLayout(Learn)} />
-        <Route path="/docs" component={withLayout(Docs)} />
-        <Route path="/evals" component={withLayout(Evals)} />
-        <Route path="/benchmarks" component={withLayout(Evals)} />
-        <Route
-          path="/benchmarks/:slug"
-          component={withProtectedLayout(BenchmarkDetail)}
-        />
-        <Route path="/rl-training" component={withLayout(RLTraining)} />
-        <Route path="/case-studies" component={withLayout(CaseStudies)} />
-        <Route path="/careers" component={withLayout(Careers)} />
-        <Route path="/contact" component={withLayout(Contact)} />
-        <Route path="/partners" component={withLayout(PartnerProgram)} />
-        <Route path="/portal" component={withLayout(Portal)} />
-        <Route path="/login" component={withLayout(Login)} />
-        <Route path="/forgot-password" component={withLayout(ForgotPassword)} />
-        <Route path="/privacy" component={withLayout(Privacy)} />
-        <Route path="/terms" component={withLayout(Terms)} />
-        <Route path="/settings" component={withLayout(Settings)} />
-        <Route component={withLayout(NotFound)} />
-      </Switch>
-    </Suspense>
-  );
-}
+import { AppShell } from "./AppShell";
+import { AppRoutes } from "./AppRoutes";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <AuthProvider>
-        <Analytics />
-        <Router />
-        <Toaster />
-        <CookieConsent />
-      </AuthProvider>
-    </QueryClientProvider>
+    <AppShell>
+      <AppRoutes />
+    </AppShell>
   </StrictMode>,
 );

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "dev": "tsx watch --clear-screen=false --exclude vite.config.ts.* server/index.ts",
-    "build": "tsx scripts/generate-sitemap.ts && vite build && npx esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
+    "build": "tsx scripts/generate-sitemap.ts && vite build && tsx scripts/prerender.ts && npx esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
     "db:push": "drizzle-kit push",

--- a/scripts/generate-sitemap.ts
+++ b/scripts/generate-sitemap.ts
@@ -1,31 +1,13 @@
 import fs from "node:fs";
 import path from "node:path";
+import { publicRoutes } from "./public-routes";
 
 const BASE_URL = "https://tryblueprint.io";
 const BUILD_DATE = new Date().toISOString().slice(0, 10);
 
-const routes = [
-  { path: "/", changefreq: "weekly", priority: 1.0 },
-  { path: "/why-simulation", changefreq: "monthly", priority: 0.8 },
-  { path: "/marketplace", changefreq: "daily", priority: 0.9 },
-  { path: "/solutions", changefreq: "monthly", priority: 0.8 },
-  { path: "/pricing", changefreq: "monthly", priority: 0.8 },
-  { path: "/learn", changefreq: "weekly", priority: 0.7 },
-  { path: "/docs", changefreq: "monthly", priority: 0.8 },
-  { path: "/evals", changefreq: "monthly", priority: 0.7 },
-  { path: "/benchmarks", changefreq: "monthly", priority: 0.7 },
-  { path: "/rl-training", changefreq: "monthly", priority: 0.7 },
-  { path: "/case-studies", changefreq: "monthly", priority: 0.7 },
-  { path: "/careers", changefreq: "weekly", priority: 0.6 },
-  { path: "/contact", changefreq: "monthly", priority: 0.6 },
-  { path: "/partners", changefreq: "monthly", priority: 0.6 },
-  { path: "/privacy", changefreq: "yearly", priority: 0.3 },
-  { path: "/terms", changefreq: "yearly", priority: 0.3 },
-];
-
 const xml = `<?xml version="1.0" encoding="UTF-8"?>\n` +
   `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n` +
-  routes
+  publicRoutes
     .map(({ path: routePath, changefreq, priority }) => {
       const loc = routePath === "/" ? `${BASE_URL}/` : `${BASE_URL}${routePath}`;
       return [

--- a/scripts/prerender.ts
+++ b/scripts/prerender.ts
@@ -1,0 +1,58 @@
+import fs from "node:fs";
+import path from "node:path";
+import { publicRoutes } from "./public-routes";
+import { render } from "../client/src/entry-server";
+
+const distRoot = path.resolve("dist", "public");
+const templatePath = path.join(distRoot, "index.html");
+
+if (!fs.existsSync(templatePath)) {
+  throw new Error(
+    `Missing ${templatePath}. Run the client build before prerendering.`,
+  );
+}
+
+const template = fs.readFileSync(templatePath, "utf-8");
+
+const normalizeRoute = (routePath: string) => {
+  if (routePath === "/") {
+    return "/";
+  }
+  return routePath.replace(/\/+$/, "");
+};
+
+const seen = new Set<string>();
+const routes = publicRoutes
+  .map((route) => normalizeRoute(route.path))
+  .filter((route) => {
+    if (seen.has(route)) {
+      return false;
+    }
+    seen.add(route);
+    return true;
+  });
+
+const hasHeadPlaceholder = template.includes("<!--app-head-->");
+const hasHtmlPlaceholder = template.includes("<!--app-html-->");
+
+if (!hasHeadPlaceholder || !hasHtmlPlaceholder) {
+  throw new Error(
+    "Prerender placeholders are missing from index.html. Add <!--app-head--> and <!--app-html-->.",
+  );
+}
+
+for (const route of routes) {
+  const { html, head } = render(route);
+  const page = template
+    .replace("<!--app-head-->", head)
+    .replace("<!--app-html-->", html);
+
+  const outputPath =
+    route === "/"
+      ? templatePath
+      : path.join(distRoot, route.slice(1), "index.html");
+
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.writeFileSync(outputPath, page, "utf-8");
+  console.log(`Prerendered ${route} -> ${outputPath}`);
+}

--- a/scripts/public-routes.ts
+++ b/scripts/public-routes.ts
@@ -1,0 +1,18 @@
+export const publicRoutes = [
+  { path: "/", changefreq: "weekly", priority: 1.0 },
+  { path: "/why-simulation", changefreq: "monthly", priority: 0.8 },
+  { path: "/marketplace", changefreq: "daily", priority: 0.9 },
+  { path: "/solutions", changefreq: "monthly", priority: 0.8 },
+  { path: "/pricing", changefreq: "monthly", priority: 0.8 },
+  { path: "/learn", changefreq: "weekly", priority: 0.7 },
+  { path: "/docs", changefreq: "monthly", priority: 0.8 },
+  { path: "/evals", changefreq: "monthly", priority: 0.7 },
+  { path: "/benchmarks", changefreq: "monthly", priority: 0.7 },
+  { path: "/rl-training", changefreq: "monthly", priority: 0.7 },
+  { path: "/case-studies", changefreq: "monthly", priority: 0.7 },
+  { path: "/careers", changefreq: "weekly", priority: 0.6 },
+  { path: "/contact", changefreq: "monthly", priority: 0.6 },
+  { path: "/partners", changefreq: "monthly", priority: 0.6 },
+  { path: "/privacy", changefreq: "yearly", priority: 0.3 },
+  { path: "/terms", changefreq: "yearly", priority: 0.3 },
+];


### PR DESCRIPTION
### Motivation
- Provide server-side rendering / prerendered HTML for public routes so crawlers and bots receive readable HTML and meta tags for improved SEO and social previews.
- Reuse the existing sitemap/route list to determine which pages should be prerendered.
- Keep runtime server behavior unchanged by leveraging the existing per-route `index.html` serving behavior in `server/vite.ts`.

### Description
- Add a server entry `client/src/entry-server.tsx` that renders the app with `renderToString` and collects head tags via `react-helmet` for injection into static HTML.
- Introduce a shared app shell and split routes into `client/src/AppRoutes.tsx` (client) and `client/src/AppRoutesServer.tsx` (server) and update `client/src/main.tsx` to use `AppShell` + `AppRoutes`.
- Add prerender placeholders to the HTML template (`client/index.html`): `<!--app-head-->` and `<!--app-html-->` to allow head/body injection by the prerender step.
- Add `scripts/public-routes.ts` and `scripts/prerender.ts` to iterate public routes, render HTML via `client/src/entry-server.tsx`, and write per-route files to `dist/public/<route>/index.html`, and update `scripts/generate-sitemap.ts` to reuse `publicRoutes`.
- Run the prerender step during the build by updating `package.json` to include `tsx scripts/prerender.ts` after `vite build` in the `build` script.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696858dd83508329b882552ee509276a)