### PR TITLE
Fix memoryLocation import for server entry

### DIFF
--- a/client/src/entry-server.tsx
+++ b/client/src/entry-server.tsx
@@ -1,6 +1,6 @@
 import { renderToString } from "react-dom/server";
 import { Helmet } from "react-helmet";
-import { memoryLocation } from "wouter";
+import { memoryLocation } from "wouter/memory-location";
 import { AppShell } from "./AppShell";
 import { AppRoutesServer } from "./AppRoutesServer";
 


### PR DESCRIPTION
### Motivation
- Fix a TypeScript `TS2305` import error by importing the `memoryLocation` named export from the proper package path so server-side routing uses the correct export.

### Description
- Replace `import { memoryLocation } from "wouter";` with `import { memoryLocation } from "wouter/memory-location";` in `client/src/entry-server.tsx` and confirm no other files reference `memoryLocation`.

### Testing
- Ran `rg "memoryLocation" -n` to confirm only `client/src/entry-server.tsx` references it and ran `npm run build`, where the `vite build` completed (no TS2305 reported) but the overall `npm run build` failed due to `ERR_MODULE_NOT_FOUND` for `/scripts/public-routes` imported by `scripts/prerender.ts`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69685cf824bc832981672dac87ecba24)