### PR TITLE
Fix prerender publicRoutes import path

### DIFF
--- a/scripts/prerender.ts
+++ b/scripts/prerender.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { publicRoutes } from "./public-routes";
+import { publicRoutes } from "../client/src/routes/publicRoutes";
 import { render } from "../client/src/entry-server";
 
 const distRoot = path.resolve("dist", "public");


### PR DESCRIPTION
### Motivation
- Update `scripts/prerender.ts` to import `publicRoutes` from `../client/src/routes/publicRoutes` (matching other scripts) so `tsx scripts/prerender.ts` resolves the module without import errors.

### Description
- Replace the local `./public-routes` import with `../client/src/routes/publicRoutes` in `scripts/prerender.ts` and keep the prerender logic unchanged.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69685f6205648329a1be4d8b55d8160f)