### PR TITLE
Guard analytics env access in Analytics component

### DIFF
--- a/client/src/components/Analytics.tsx
+++ b/client/src/components/Analytics.tsx
@@ -1,13 +1,15 @@
 import { useEffect } from "react";
 import { getCookieConsent } from "./CookieConsent";
 
+const env: ImportMetaEnv | Record<string, never> = import.meta.env ?? {};
+
 // Replace with your actual GA4 Measurement ID
-const GA_MEASUREMENT_ID = import.meta.env.VITE_GA_MEASUREMENT_ID || "G-XXXXXXXXXX";
+const GA_MEASUREMENT_ID = env.VITE_GA_MEASUREMENT_ID ?? "G-XXXXXXXXXX";
 
 export function Analytics() {
   useEffect(() => {
     // Don't initialize in development unless explicitly enabled
-    if (import.meta.env.DEV && !import.meta.env.VITE_ENABLE_ANALYTICS) {
+    if (env.DEV && !env.VITE_ENABLE_ANALYTICS) {
       return;
     }
 


### PR DESCRIPTION
### Motivation
- Prevent `TypeError` during prerendering by avoiding direct reads of `import.meta.env` when it may be undefined, while preserving the same behavior for Vite builds.

### Description
- Add a safe local `env` fallback (`const env: ImportMetaEnv | Record<string, never> = import.meta.env ?? {};`) and replace module-level and runtime reads of `import.meta.env` with `env`, including `env.VITE_GA_MEASUREMENT_ID ?? "G-XXXXXXXXXX"`, `env.DEV`, and `env.VITE_ENABLE_ANALYTICS`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696860d071d483299708f3c8a29133a8)