### PR TITLE
Guard Firestore debug env access in SSR

### DIFF
--- a/client/src/lib/firebase.ts
+++ b/client/src/lib/firebase.ts
@@ -74,8 +74,12 @@ export const testFirestoreConnection = async (): Promise<boolean> => {
   }
 };
 
+const env =
+  typeof import.meta !== "undefined"
+    ? (import.meta as { env?: { DEV?: boolean; VITE_FIREBASE_DEBUG?: string } }).env
+    : undefined;
 const isFirestoreDebugEnabled =
-  import.meta.env.DEV || import.meta.env.VITE_FIREBASE_DEBUG === "true";
+  (env?.DEV ?? false) || env?.VITE_FIREBASE_DEBUG === "true";
 
 export const runFirestoreConnectionTestIfDebug = async (): Promise<boolean> => {
   if (!isFirestoreDebugEnabled) {


### PR DESCRIPTION
### Motivation
- Prevent runtime errors when `import.meta` is unavailable (Node/SSR) while preserving the existing debug flag behavior.
- Ensure Firestore debug mode remains disabled by default when environment info is not present.

### Description
- Add a local `env` helper computed as `typeof import.meta !== "undefined" ? (import.meta as { env?: { DEV?: boolean; VITE_FIREBASE_DEBUG?: string } }).env : undefined` in `client/src/lib/firebase.ts`.
- Compute `isFirestoreDebugEnabled` using `(env?.DEV ?? false) || env?.VITE_FIREBASE_DEBUG === "true"` so the module-scope logic never reads properties from `undefined`.
- Keep the debug-check at module scope and retain the existing `runFirestoreConnectionTestIfDebug` behavior.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696862790d608329b3a29154981c9e35)