### PR TITLE
Initialize Firebase client services only in browser

### DIFF
--- a/client/src/contexts/AuthContext.tsx
+++ b/client/src/contexts/AuthContext.tsx
@@ -41,14 +41,15 @@ export function useAuth() {
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   // Set persistence to LOCAL
   React.useEffect(() => {
-    if (!auth) {
+    const firebaseAuth = auth;
+    if (!firebaseAuth) {
       console.warn("Firebase auth not initialized. Skipping persistence setup.");
       return;
     }
     
     const initPersistence = async () => {
       try {
-        await firebasePersistence(auth!, browserLocalPersistence);
+        await firebasePersistence(firebaseAuth, browserLocalPersistence);
       } catch (error) {
         console.error("Error setting persistence:", error);
       }
@@ -155,7 +156,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   };
 
   React.useEffect(() => {
-    if (!auth) {
+    const firebaseAuth = auth;
+    if (!firebaseAuth) {
       setLoading(false);
       return;
     }
@@ -175,7 +177,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
     try {
       unsubscribe = onAuthStateChanged(
-        auth,
+        firebaseAuth,
         async (user) => {
           setCurrentUser(user);
           if (user) {


### PR DESCRIPTION
### Motivation
- Avoid initializing Firebase services during server-side execution by ensuring the client SDK runs only in a browser context.
- Make the exported Firebase service objects nullable when not running in the browser so call sites can guard and fail fast.

### Description
- Added `const isBrowser = typeof window !== "undefined"` and only run `initializeApp` when `isBrowser` is true, making `app` a `FirebaseApp | null` in `client/src/lib/firebase.ts`.
- Export `auth`, `db`, and `storage` as nullable (`Auth | null`, `Firestore` cast from `dbInstance`, and `FirebaseStorage`) and introduced `requireAuth`/`requireDb` helpers to throw early if services are not initialized.
- Updated all Firebase helper functions to use the instance-backed variables (`authInstance`, `dbInstance`, `storageInstance`) and replaced direct `auth`/`db` usage with `requireAuth()`/`requireDb()` where appropriate.
- Updated `AuthProvider` in `client/src/contexts/AuthContext.tsx` to safely use the nullable `auth` instance for persistence setup and `onAuthStateChanged` listener.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696862f396408329bb7862e4cd280ab9)