### PR TITLE
Guard import.meta.env usage in analytics and auth flows

### DIFF
--- a/client/src/components/Analytics.tsx
+++ b/client/src/components/Analytics.tsx
@@ -1,13 +1,17 @@
 import { useEffect } from "react";
+import { getImportMetaEnv } from "@/lib/import-meta-env";
 import { getCookieConsent } from "./CookieConsent";
-
-const env: ImportMetaEnv | Record<string, never> = import.meta.env ?? {};
-
-// Replace with your actual GA4 Measurement ID
-const GA_MEASUREMENT_ID = env.VITE_GA_MEASUREMENT_ID ?? "G-XXXXXXXXXX";
 
 export function Analytics() {
   useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const env = getImportMetaEnv();
+    // Replace with your actual GA4 Measurement ID
+    const gaMeasurementId = env.VITE_GA_MEASUREMENT_ID ?? "G-XXXXXXXXXX";
+
     // Don't initialize in development unless explicitly enabled
     if (env.DEV && !env.VITE_ENABLE_ANALYTICS) {
       return;
@@ -26,7 +30,7 @@ export function Analytics() {
     const script = document.createElement("script");
     script.id = "ga-script";
     script.async = true;
-    script.src = `https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`;
+    script.src = `https://www.googletagmanager.com/gtag/js?id=${gaMeasurementId}`;
     document.head.appendChild(script);
 
     // Initialize gtag with consent mode
@@ -44,7 +48,7 @@ export function Analytics() {
     });
 
     // Configure GA
-    window.gtag("config", GA_MEASUREMENT_ID, {
+    window.gtag("config", gaMeasurementId, {
       anonymize_ip: true,
       cookie_flags: "SameSite=None;Secure",
     });

--- a/client/src/contexts/AuthContext.tsx
+++ b/client/src/contexts/AuthContext.tsx
@@ -17,6 +17,7 @@ import {
   UserData,
 } from "@/lib/firebase";
 import { User as FirebaseUser } from "firebase/auth";
+import { getImportMetaEnv } from "@/lib/import-meta-env";
 
 interface AuthContextType {
   currentUser: FirebaseUser | null;
@@ -75,9 +76,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const resolveRedirectPath = React.useCallback(
     (data: UserData | null): string => {
-      const marketingDestination =
-        (import.meta.env.VITE_MARKETING_DESTINATION as string | undefined)?.trim() ||
-        "/marketplace";
+      const marketingDestination = (() => {
+        if (typeof window === "undefined") {
+          return "/marketplace";
+        }
+        const env = getImportMetaEnv();
+        return (env.VITE_MARKETING_DESTINATION ?? "").trim() || "/marketplace";
+      })();
       let storedRedirect: string | null = null;
       try {
         storedRedirect = sessionStorage.getItem("redirectAfterAuth");

--- a/client/src/lib/import-meta-env.ts
+++ b/client/src/lib/import-meta-env.ts
@@ -1,0 +1,9 @@
+export type SafeImportMetaEnv = Partial<ImportMetaEnv>;
+
+export function getImportMetaEnv(): SafeImportMetaEnv {
+  if (typeof import.meta === "undefined") {
+    return {};
+  }
+
+  return (import.meta as { env?: SafeImportMetaEnv }).env ?? {};
+}


### PR DESCRIPTION
### Motivation
- Prevent runtime errors when `import.meta.env` is missing during server-side rendering or non-Vite environments by reading env only when safe.
- Ensure analytics initialization and auth redirect resolution happen only in browser contexts so SSR does not attempt to access browser-only globals.

### Description
- Add a small helper `getImportMetaEnv()` and type `SafeImportMetaEnv` in `client/src/lib/import-meta-env.ts` that returns a safe object when `import.meta` is undefined.
- Update `client/src/components/Analytics.tsx` to defer resolving `VITE_GA_MEASUREMENT_ID` into a browser-only `useEffect` guarded with `typeof window !== "undefined"` and use `getImportMetaEnv()` for env reads.
- Update `client/src/contexts/AuthContext.tsx` to read `VITE_MARKETING_DESTINATION` via `getImportMetaEnv()` inside a `window` check so server-rendered code does not read `import.meta.env`.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968650b17908329a31f32541952ab7a)