### PR TITLE
Guard error tracking initialization during prerendering

### DIFF
--- a/client/src/lib/errorTracking.ts
+++ b/client/src/lib/errorTracking.ts
@@ -43,8 +43,13 @@ class ErrorTrackingService {
   init(options?: { dsn?: string; environment?: string }) {
     if (this.isInitialized) return;
 
-    this.dsn = options?.dsn || import.meta.env.VITE_SENTRY_DSN || null;
-    this.environment = options?.environment || import.meta.env.MODE || "development";
+    const env =
+      typeof import.meta !== "undefined"
+        ? (import.meta as ImportMeta).env
+        : undefined;
+
+    this.dsn = options?.dsn || env?.VITE_SENTRY_DSN || null;
+    this.environment = options?.environment || env?.MODE || "development";
 
     // Set up global error handlers
     this.setupGlobalHandlers();
@@ -196,7 +201,11 @@ class ErrorTrackingService {
   private async sendToOwnApi(errorData: Record<string, unknown>) {
     try {
       // Only send in production or if explicitly enabled
-      if (this.environment !== "production" && !import.meta.env.VITE_ENABLE_ERROR_TRACKING) {
+      const env =
+        typeof import.meta !== "undefined"
+          ? (import.meta as ImportMeta).env
+          : undefined;
+      if (this.environment !== "production" && !env?.VITE_ENABLE_ERROR_TRACKING) {
         return;
       }
 
@@ -253,7 +262,9 @@ class ErrorTrackingService {
 export const errorTracking = new ErrorTrackingService();
 
 // Auto-initialize
-errorTracking.init();
+if (typeof window !== "undefined") {
+  errorTracking.init();
+}
 
 // Export convenience functions
 export const captureException = errorTracking.captureException.bind(errorTracking);


### PR DESCRIPTION
### Motivation
- Prevent prerender/SSR crashes caused by accessing `import.meta.env` when it is undefined in non-browser contexts.
- Avoid registering browser global handlers and initializing the service during server-side rendering.

### Description
- Read Vite env via a guarded local `env` variable using `typeof import.meta !== "undefined" ? (import.meta as ImportMeta).env : undefined` and prefer `options` before env values for `dsn` and `environment`.
- Guard access to `VITE_ENABLE_ERROR_TRACKING` in `sendToOwnApi` using the same `env` pattern.
- Only auto-initialize the singleton with `errorTracking.init()` when `typeof window !== "undefined"` so initialization runs only in the browser.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696861da216c8329ab85c5a9a719fb9b)