### PR TITLE
Fix React import in PremiumAnalyticsSection to resolve build error

### DIFF
--- a/client/src/components/site/PremiumAnalyticsSection.tsx
+++ b/client/src/components/site/PremiumAnalyticsSection.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import {
   BarChart3,
   CheckCircle2,


### PR DESCRIPTION
### Motivation
- The build/prerender failed with `ReferenceError: React is not defined` originating from `client/src/components/site/PremiumAnalyticsSection.tsx`, so an explicit React import was required to avoid runtime errors during bundling/prerendering.

### Description
- Add an explicit `import React from "react";` at the top of `client/src/components/site/PremiumAnalyticsSection.tsx` to ensure JSX is compiled and `React` is available at runtime.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696868ccfce483299d093abc4c5656ad)