### PR TITLE
Switch TypeScript JSX runtime to react-jsx and add missing React import

### DIFF
--- a/client/src/components/site/PremiumAnalyticsSection.tsx
+++ b/client/src/components/site/PremiumAnalyticsSection.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import {
   BarChart3,
   CheckCircle2,

--- a/tsconfig.client.json
+++ b/tsconfig.client.json
@@ -9,7 +9,7 @@
     "module": "ESNext",
     "strict": true,
     "lib": ["ES2015", "ES2017", "ES2018", "ES2019", "ES2020", "esnext", "dom", "dom.iterable"],
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "esModuleInterop": true,
     "noEmitOnError": false,
     "skipLibCheck": true,

--- a/tsconfig.full.json
+++ b/tsconfig.full.json
@@ -9,7 +9,7 @@
     "module": "ESNext",
     "strict": true,
     "lib": ["ES2015", "ES2017", "ES2018", "ES2019", "ES2020", "esnext", "dom", "dom.iterable"],
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "esModuleInterop": true,
     "noEmitOnError": false,
     "skipLibCheck": true,


### PR DESCRIPTION
### Motivation
- Prerender/build was failing with `ReferenceError: React is not defined` because many JSX/TSX files rely on JSX without explicit `React` imports and the TS configs used the `preserve` JSX mode which can require a global `React` at runtime.
- Switching the TS JSX runtime to `react-jsx` provides the automatic runtime and prevents these runtime errors across the client codebase.

### Description
- Update the `jsx` compiler option from `preserve` to `react-jsx` in `tsconfig.client.json` to enable the automatic JSX runtime for client builds.
- Apply the same `jsx` change in `tsconfig.full.json` for consistent compilation across the project.
- Add an explicit `import React from "react";` to `client/src/components/site/PremiumAnalyticsSection.tsx` to ensure the component that previously triggered the error has the `React` identifier available.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696868ccfce483299d093abc4c5656ad)