### PR TITLE
Wrap AuthProvider with Wouter router for SSR-safe useLocation

### DIFF
--- a/client/src/AppShell.tsx
+++ b/client/src/AppShell.tsx
@@ -15,12 +15,14 @@ type AppShellProps = {
 export function AppShell({ children, locationHook }: AppShellProps) {
   return (
     <QueryClientProvider client={queryClient}>
-      <AuthProvider>
-        <Analytics />
-        <WouterRouter hook={locationHook}>{children}</WouterRouter>
-        <Toaster />
-        <CookieConsent />
-      </AuthProvider>
+      <WouterRouter hook={locationHook}>
+        <AuthProvider>
+          <Analytics />
+          {children}
+          <Toaster />
+          <CookieConsent />
+        </AuthProvider>
+      </WouterRouter>
     </QueryClientProvider>
   );
 }


### PR DESCRIPTION
### Motivation
- Ensure any consumers of `useLocation` (including `AuthProvider`) resolve against the provided router hook (e.g. `memoryLocation` during SSR) and avoid accessing `window.location` on the server.

### Description
- Move the `<WouterRouter hook={locationHook}>` to wrap `AuthProvider` and its children in `client/src/AppShell.tsx`, changing the render tree to `QueryClientProvider -> WouterRouter -> AuthProvider -> Analytics -> {children} -> Toaster -> CookieConsent`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69686ba1be788329a508d80d512dc5e2)