### PR TITLE
Remove Stripe secret key fallbacks and require STRIPE_SECRET_KEY at startup

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -20,6 +20,12 @@ Set the Firebase web config and Admin credentials in your deployment secrets bef
 
 These variables must be available in the build/runtime environment (Replit secrets, hosting console, or CI) so both the Vite build and Express routes can initialize Firebase.
 
+## Stripe configuration
+
+Stripe checkout and onboarding routes require the secret key at runtime:
+
+- `STRIPE_SECRET_KEY` (required; server startup fails fast if unset)
+
 ## Method 1: Pre-Deployment Script (Recommended)
 
 This method fixes the package.json file before deployment:

--- a/client/src/pages/api/create-checkout-session/route.ts
+++ b/client/src/pages/api/create-checkout-session/route.ts
@@ -46,10 +46,15 @@ type CheckoutRequestBody = {
   };
 };
 
-const stripeSecretKey = process.env.STRIPE_SECRET_KEY || "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";
-const stripe = stripeSecretKey
-  ? new Stripe(stripeSecretKey)
-  : null;
+const stripeSecretKey = process.env.STRIPE_SECRET_KEY?.trim();
+
+function getStripeClient() {
+  if (!stripeSecretKey) {
+    throw new Error("STRIPE_SECRET_KEY environment variable is required");
+  }
+
+  return new Stripe(stripeSecretKey);
+}
 
 const configuredOrigins = (process.env.CHECKOUT_ALLOWED_ORIGINS || "")
   .split(",")
@@ -97,9 +102,7 @@ export default async function handler(req: Request, res: Response) {
   }
 
   try {
-    if (!stripe) {
-      throw new Error("STRIPE_SECRET_KEY environment variable is required");
-    }
+    const stripe = getStripeClient();
 
     const body = (req.body || {}) as CheckoutRequestBody;
     const sessionType: PaymentSessionType =

--- a/server/constants/stripe.ts
+++ b/server/constants/stripe.ts
@@ -1,13 +1,12 @@
 import Stripe from "stripe";
 
-const STRIPE_SECRET_KEY =
-  process.env.STRIPE_SECRET_KEY?.trim() ||
-  process.env.STRIPE_LIVE_SECRET_KEY?.trim() ||
-  "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";
+const STRIPE_SECRET_KEY = process.env.STRIPE_SECRET_KEY?.trim();
 
-export const stripeClient = STRIPE_SECRET_KEY
-  ? new Stripe(STRIPE_SECRET_KEY, { apiVersion: "2024-06-20" })
-  : null;
+if (!STRIPE_SECRET_KEY) {
+  throw new Error("STRIPE_SECRET_KEY environment variable is required at startup.");
+}
+
+export const stripeClient = new Stripe(STRIPE_SECRET_KEY, { apiVersion: "2024-06-20" });
 
 export const STRIPE_CONNECT_ACCOUNT_ID =
   process.env.STRIPE_CONNECT_ACCOUNT_ID?.trim() || "acct_1OE1ptPrtLGHqzOG";


### PR DESCRIPTION
### Motivation
- Prevent accidental use of a hardcoded/checked-in Stripe secret and force explicit configuration for production secrets.
- Fail fast at server startup so deployments clearly surface a missing `STRIPE_SECRET_KEY` rather than silently using a fallback.
- Ensure server-side and checkout routes validate the presence of the secret before creating a Stripe client.
- Document the runtime requirement so deployers know to set `STRIPE_SECRET_KEY` in their environment.

### Description
- Updated `server/constants/stripe.ts` to read `STRIPE_SECRET_KEY` from `process.env`, throw an error if it is unset, and always export a real `stripeClient` via `new Stripe(...)` instead of a nullable client.
- Updated `client/src/pages/api/create-checkout-session/route.ts` to remove the hardcoded fallback, trim the env var, and add `getStripeClient()` which throws when `STRIPE_SECRET_KEY` is missing and returns a `Stripe` instance when present.
- Added a short note to `DEPLOYMENT.md` documenting that `STRIPE_SECRET_KEY` is required and that the server will fail startup if it is not set.

### Testing
- No automated tests were executed for this change.
- Local static checks and a quick code search were used to locate and update references to the deprecated fallback, with no runtime tests performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969069a7e5883298ced719e53583dad)