### PR TITLE
Remove hardcoded Parallel/Perplexity API keys and require env vars

### DIFF
--- a/server/routes/post-signup-workflows.ts
+++ b/server/routes/post-signup-workflows.ts
@@ -11,8 +11,7 @@ import {
   type PostSignupWorkflowPromptInput,
 } from "../utils/ai-prompts";
 
-const parallelApiKey =
-  process.env.PARALLEL_API_KEY || "V9xyphAxwfrJb1faYC5c_-x4T93eYzbZDWdenFEw";
+const parallelApiKey = process.env.PARALLEL_API_KEY;
 const rawParallelBaseUrl =
   process.env.PARALLEL_API_BASE_URL || "https://api.parallel.ai";
 const parallelBaseUrl = rawParallelBaseUrl.replace(/\/+$/, "");
@@ -58,9 +57,7 @@ const parallelWebhookEvents = process.env.PARALLEL_WEBHOOK_EVENTS
       .filter(Boolean)
   : ["task.updated", "task.completed", "task.failed"];
 
-const perplexityApiKey =
-  process.env.PERPLEXITY_API_KEY ||
-  "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";
+const perplexityApiKey = process.env.PERPLEXITY_API_KEY;
 const perplexityTimeoutMs = Number(process.env.PERPLEXITY_TIMEOUT_MS ?? 60_000);
 const deepResearchModel =
   process.env.PERPLEXITY_DEEP_RESEARCH_MODEL || "sonar-reasoning-pro";
@@ -73,6 +70,14 @@ const reasoningEffort = (process.env.PERPLEXITY_REASONING_EFFORT ?? "high") as
 const PERPLEXITY_ENDPOINT = "https://api.perplexity.ai/chat/completions";
 const PERPLEXITY_SYSTEM_MESSAGE =
   "You are Blueprint's automation copilot. Follow the user's instructions exactly and respond with valid JSON whenever a schema is provided.";
+
+if (!parallelApiKey) {
+  throw new Error("PARALLEL_API_KEY is not configured");
+}
+
+if (!perplexityApiKey) {
+  throw new Error("PERPLEXITY_API_KEY is not configured");
+}
 
 type AiProvider = "perplexity" | "parallel";
 


### PR DESCRIPTION
### Motivation

- Remove embedded default API keys for Parallel and Perplexity to eliminate leaked secrets and ensure deployments use managed secrets.
- Fail fast on startup when provider credentials are missing so configuration errors are obvious and addressed before runtime.

### Description

- Replaced hardcoded defaults by reading `PARALLEL_API_KEY` and `PERPLEXITY_API_KEY` from `process.env` in `server/routes/post-signup-workflows.ts`.
- Added explicit startup validation that throws `Error("PARALLEL_API_KEY is not configured")` and `Error("PERPLEXITY_API_KEY is not configured")` when the respective env vars are missing.
- No other configuration or runtime logic was changed; all other Parallel/Perplexity settings remain unchanged.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969074cdd80832990f7c061c627fb79)