### PR TITLE
Remove test-mode auth bypass and add ProtectedRoute redirect test

### DIFF
--- a/client/src/components/ProtectedRoute.tsx
+++ b/client/src/components/ProtectedRoute.tsx
@@ -13,16 +13,6 @@ export default function ProtectedRoute({ children }: ProtectedRouteProps) {
   const [, setLocation] = useLocation();
   const [isReady, setIsReady] = useState(false);
 
-  const urlParams = new URLSearchParams(window.location.search);
-  const isTestMode =
-    urlParams.get("resetOnboarding") === "true" ||
-    urlParams.get("test") === "true";
-
-  // If in test mode, bypass auth check
-  if (isTestMode) {
-    return children; // or whatever your component normally returns when authenticated
-  }
-
   useEffect(() => {
     // Only proceed when loading is complete
     if (!loading) {

--- a/client/tests/components/ProtectedRoute.test.tsx
+++ b/client/tests/components/ProtectedRoute.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import ProtectedRoute from "@/components/ProtectedRoute";
+
+const setLocation = vi.fn();
+
+vi.mock("wouter", () => ({
+  useLocation: () => ["/marketplace", setLocation],
+}));
+
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => ({
+    currentUser: null,
+    userData: null,
+    loading: false,
+  }),
+}));
+
+describe("ProtectedRoute", () => {
+  beforeEach(() => {
+    setLocation.mockClear();
+    sessionStorage.clear();
+    window.history.pushState({}, "", "/marketplace?test=true");
+  });
+
+  it("redirects unauthenticated users to /login even with test query params", async () => {
+    render(
+      <ProtectedRoute>
+        <div>Protected Content</div>
+      </ProtectedRoute>,
+    );
+
+    await waitFor(() => {
+      expect(setLocation).toHaveBeenCalledWith("/login");
+    });
+  });
+});


### PR DESCRIPTION
### Motivation
- Close a test-mode security hole that bypassed authentication when `?test=true` or similar query params were present so protected pages could be accessed without real auth.
- Ensure production builds do not include any unauthenticated bypass and that protected routes always enforce login.

### Description
- Remove the `URLSearchParams`-based `isTestMode` check and the early `return` from `client/src/components/ProtectedRoute.tsx` so the component always enforces auth.
- Add a unit/test file `client/tests/components/ProtectedRoute.test.tsx` that mocks `wouter` and the auth context and asserts unauthenticated access redirects to `/login` even when the URL contains `?test=true`.
- No other runtime behavior changes were introduced beyond enforcing the existing redirect flow and storing `redirectAfterAuth` in `sessionStorage`.

### Testing
- Added a Vitest test `client/tests/components/ProtectedRoute.test.tsx` to verify redirect behavior, but test execution was not run as part of this rollout.
- No automated test failures were observed because test execution was not performed in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69690750d3a08329befea1577c8619a6)