### PR TITLE
Add Firebase token verification middleware and tests

### DIFF
--- a/server/middleware/verifyFirebaseToken.ts
+++ b/server/middleware/verifyFirebaseToken.ts
@@ -1,0 +1,24 @@
+import type { NextFunction, Request, Response } from "express";
+
+import admin from "../../client/src/lib/firebaseAdmin";
+
+export default async function verifyFirebaseToken(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  const authHeader = req.headers.authorization ?? "";
+  const [scheme, token] = authHeader.split(" ");
+
+  if (scheme !== "Bearer" || !token) {
+    return res.status(401).json({ error: "Missing or invalid authorization" });
+  }
+
+  try {
+    const decodedToken = await admin.auth().verifyIdToken(token);
+    res.locals.firebaseUser = decodedToken;
+    return next();
+  } catch (error) {
+    return res.status(401).json({ error: "Invalid or expired token" });
+  }
+}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -18,6 +18,7 @@ import waitlistHandler from "./routes/waitlist";
 import applyHandler from "./routes/apply";
 import healthRouter from "./routes/health";
 import errorsRouter from "./routes/errors";
+import verifyFirebaseToken from "./middleware/verifyFirebaseToken";
 
 export function registerRoutes(app: Express) {
   app.use(appleAssociationRouter);
@@ -28,19 +29,32 @@ export function registerRoutes(app: Express) {
   // API routes for Express
   app.use("/api/webhooks", webhooksRouter);
   app.use("/api/errors", errorsRouter);
-  app.post("/api/create-checkout-session", createCheckoutSessionHandler);
-  app.get("/api/googlePlaces", googlePlacesHandler);
-  app.all("/api/generate-image", generateImageHandler);
-  app.post("/api/submit-to-sheets", submitToSheetsHandler);
+  app.post(
+    "/api/create-checkout-session",
+    verifyFirebaseToken,
+    createCheckoutSessionHandler,
+  );
+  app.get("/api/googlePlaces", verifyFirebaseToken, googlePlacesHandler);
+  app.all("/api/generate-image", verifyFirebaseToken, generateImageHandler);
+  app.post(
+    "/api/submit-to-sheets",
+    verifyFirebaseToken,
+    submitToSheetsHandler,
+  );
   app.post("/api/process-waitlist", processWaitlistHandler);
+  // Public endpoints (no Firebase auth required).
   app.post("/api/contact", contactHandler);
   app.post("/api/waitlist", waitlistHandler);
   app.post("/api/apply", applyHandler);
   // app.post("/api/mapping-confirmation", processMappingConfirmationHandler); // Commented out - handler is not exported
   app.post("/api/demo-day-confirmation", demoDayConfirmationHandler);
-  app.post("/api/upload-to-b2", uploadToB2Handler);
-  app.post("/api/post-signup-workflows", postSignupWorkflowsHandler);
-  app.use("/api/ai-studio", aiStudioRouter);
-  app.use("/api/qr", qrLinkRouter);
+  app.post("/api/upload-to-b2", verifyFirebaseToken, uploadToB2Handler);
+  app.post(
+    "/api/post-signup-workflows",
+    verifyFirebaseToken,
+    postSignupWorkflowsHandler,
+  );
+  app.use("/api/ai-studio", verifyFirebaseToken, aiStudioRouter);
+  app.use("/api/qr", verifyFirebaseToken, qrLinkRouter);
   app.use("/v1/stripe", stripeAccountRouter);
 }

--- a/server/tests/auth-middleware.test.ts
+++ b/server/tests/auth-middleware.test.ts
@@ -1,0 +1,80 @@
+// @vitest-environment node
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import express from "express";
+import { createServer } from "http";
+import type { Server } from "http";
+
+const verifyIdToken = vi.fn().mockResolvedValue({ uid: "test-user" });
+
+vi.mock("../../client/src/lib/firebaseAdmin", () => ({
+  default: {
+    auth: () => ({
+      verifyIdToken,
+    }),
+  },
+  dbAdmin: null,
+  storageAdmin: null,
+  authAdmin: null,
+}));
+
+let server: Server;
+let baseUrl: string;
+let registerRoutes: typeof import("../routes").registerRoutes;
+
+beforeAll(async () => {
+  process.env.PARALLEL_API_KEY = "test-parallel-key";
+  process.env.PERPLEXITY_API_KEY = "test-perplexity-key";
+
+  ({ registerRoutes } = await import("../routes"));
+
+  const app = express();
+  app.use(express.json());
+  registerRoutes(app);
+
+  server = createServer(app);
+  await new Promise<void>((resolve) => {
+    server.listen(0, () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Failed to bind test server");
+      }
+      baseUrl = `http://127.0.0.1:${address.port}`;
+      resolve();
+    });
+  });
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+});
+
+const protectedEndpoints = [
+  { method: "POST", path: "/api/post-signup-workflows" },
+  { method: "POST", path: "/api/upload-to-b2" },
+  { method: "POST", path: "/api/ai-studio/chat" },
+  { method: "POST", path: "/api/qr/pending-session" },
+  { method: "GET", path: "/api/googlePlaces" },
+];
+
+describe("verifyFirebaseToken middleware", () => {
+  for (const endpoint of protectedEndpoints) {
+    it(`returns 401 when missing auth for ${endpoint.method} ${endpoint.path}`, async () => {
+      const response = await fetch(`${baseUrl}${endpoint.path}`, {
+        method: endpoint.method,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+
+      expect(response.status).toBe(401);
+    });
+  }
+});


### PR DESCRIPTION
### Motivation
- Protect server API endpoints that should only be accessible by authenticated users by verifying Firebase ID tokens.
- Keep truly public endpoints like `/api/contact` and `/api/waitlist` unauthenticated and explicitly document them.

### Description
- Add `server/middleware/verifyFirebaseToken.ts` which reads the `Authorization: Bearer <token>` header and calls `admin.auth().verifyIdToken`, attaching the decoded token to `res.locals.firebaseUser` on success and returning `401` on failure.
- Apply `verifyFirebaseToken` in `server/routes.ts` to protected endpoints including `POST /api/create-checkout-session`, `GET /api/googlePlaces`, `ALL /api/generate-image`, `POST /api/submit-to-sheets`, `POST /api/upload-to-b2`, `POST /api/post-signup-workflows`, and mount `ai-studio` and `qr` routers behind the middleware.
- Leave `POST /api/contact` and `POST /api/waitlist` as public routes and add an inline comment documenting them.
- Add integration tests in `server/tests/auth-middleware.test.ts` that mock `firebaseAdmin.auth().verifyIdToken` and assert that a set of protected endpoints return `401` when the `Authorization` header is missing.

### Testing
- Added a Vitest integration test file `server/tests/auth-middleware.test.ts` which boots an Express test server, mocks `verifyIdToken`, and checks protected routes return `401` without auth; the test file was added but not executed in this rollout.
- No automated test run was performed during this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969083264a883298a66c415e2693bff)