### PR TITLE
Add Drizzle migrations and CI migration step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,20 @@ on:
 jobs:
   audit:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: blueprint_ci
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U postgres -d blueprint_ci"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -23,3 +37,8 @@ jobs:
 
       - name: npm audit (high/critical)
         run: npm audit --audit-level=high
+
+      - name: Apply database migrations
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/blueprint_ci
+        run: npm run db:migrate

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -26,6 +26,35 @@ Stripe checkout and onboarding routes require the secret key at runtime:
 
 - `STRIPE_SECRET_KEY` (required; server startup fails fast if unset)
 
+## Database migrations (Drizzle)
+
+This project uses Drizzle migrations generated from `db/schema.ts`. Migrations live in the `migrations/` directory and should always be committed to the repository.
+
+### Development workflow
+
+1. Update `db/schema.ts` as needed.
+2. Generate a migration:
+   ```
+   npm run db:generate
+   ```
+3. Apply it locally:
+   ```
+   npm run db:migrate
+   ```
+
+### Production workflow
+
+1. Generate and commit migrations in your development branch (see above).
+2. Ensure `DATABASE_URL` is set in the deployment environment.
+3. Apply migrations during deploy:
+   ```
+   npm run db:migrate
+   ```
+
+### CI / automated deploys
+
+CI runs `npm run db:migrate` against a disposable Postgres instance so migrations are applied and verified as part of the pipeline.
+
 ## Method 1: Pre-Deployment Script (Recommended)
 
 This method fixes the package.json file before deployment:

--- a/migrations/0000_yellow_umar.sql
+++ b/migrations/0000_yellow_umar.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS "users" (
+	"id" integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "users_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 2147483647 START WITH 1 CACHE 1),
+	"username" text NOT NULL,
+	"password" text NOT NULL,
+	CONSTRAINT "users_username_unique" UNIQUE("username")
+);

--- a/migrations/meta/0000_snapshot.json
+++ b/migrations/meta/0000_snapshot.json
@@ -1,0 +1,69 @@
+{
+  "id": "ba7b863a-973e-41dc-9364-c1d5848e40aa",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "users_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1768491603177,
+      "tag": "0000_yellow_umar",
+      "breakpoints": true
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "build": "tsx scripts/generate-sitemap.ts && vite build && npx esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
+    "db:generate": "drizzle-kit generate",
+    "db:migrate": "drizzle-kit migrate",
     "db:push": "drizzle-kit push",
     "generate-qr": "tsx scripts/generate-qr.ts"
   },


### PR DESCRIPTION
### Motivation

- Ensure database schema is captured as SQL migrations generated from `db/schema.ts` so schema changes are versioned and reproducible. 
- Run and verify migrations in CI/deploy so deployments apply schema changes against a disposable Postgres instance before releasing.

### Description

- Add generated migration files under `migrations/` including `migrations/0000_yellow_umar.sql` and metadata in `migrations/meta/` representing the `users` table. 
- Add npm scripts `db:generate` and `db:migrate` that invoke `drizzle-kit` for generating and applying migrations. 
- Document the development, production, and CI migration workflow in `DEPLOYMENT.md` and instruct to commit migrations. 
- Update the CI workflow `.github/workflows/ci.yml` to start a disposable Postgres service and run `npm run db:migrate` against it during the pipeline.

### Testing

- Ran `npx drizzle-kit generate` locally which succeeded and produced `migrations/0000_yellow_umar.sql` and metadata files in `migrations/meta/` as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69690a2851ac8329938383dba8679b5f)