### PR TITLE
Remove users.password column and add password hashing utilities

### DIFF
--- a/db/schema.ts
+++ b/db/schema.ts
@@ -5,7 +5,6 @@ import { z } from "zod";
 export const users = pgTable("users", {
   id: integer().primaryKey().generatedAlwaysAsIdentity(),
   username: text("username").unique().notNull(),
-  password: text("password").notNull(),
 });
 
 export const insertUserSchema = createInsertSchema(users);

--- a/migrations/0000_drop_users_password.sql
+++ b/migrations/0000_drop_users_password.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "users" DROP COLUMN IF EXISTS "password";

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "@types/react-helmet": "^6.1.11",
         "axios": "^1.13.2",
         "backblaze-b2": "^1.7.0",
+        "bcryptjs": "^3.0.3",
         "canvas-confetti": "^1.9.3",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
@@ -7900,6 +7901,15 @@
       ],
       "license": "MIT"
     },
+    "node_modules/bcryptjs": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
+      "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
+      }
+    },
     "node_modules/bignumber.js": {
       "version": "9.1.2",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
@@ -13846,12 +13856,6 @@
       "engines": {
         "node": ">= 18"
       }
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "license": "MIT"
     },
     "node_modules/regexparam": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@types/react-helmet": "^6.1.11",
     "axios": "^1.13.2",
     "backblaze-b2": "^1.7.0",
+    "bcryptjs": "^3.0.3",
     "canvas-confetti": "^1.9.3",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",

--- a/server/tests/passwords.test.ts
+++ b/server/tests/passwords.test.ts
@@ -1,0 +1,22 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+
+import { hashPassword, verifyPassword } from "../utils/passwords";
+
+describe("password hashing", () => {
+  it("hashes passwords with a salt", async () => {
+    const password = "SuperSecure123!";
+    const hashed = await hashPassword(password);
+
+    expect(hashed).not.toBe(password);
+    expect(hashed.startsWith("$2")).toBe(true);
+  });
+
+  it("verifies matching passwords", async () => {
+    const password = "AnotherSecure123!";
+    const hashed = await hashPassword(password);
+
+    await expect(verifyPassword(password, hashed)).resolves.toBe(true);
+    await expect(verifyPassword("wrong-password", hashed)).resolves.toBe(false);
+  });
+});

--- a/server/utils/passwords.ts
+++ b/server/utils/passwords.ts
@@ -1,0 +1,14 @@
+import bcrypt from "bcryptjs";
+
+const SALT_ROUNDS = 12;
+
+export async function hashPassword(password: string): Promise<string> {
+  return bcrypt.hash(password, SALT_ROUNDS);
+}
+
+export async function verifyPassword(
+  password: string,
+  hashedPassword: string
+): Promise<boolean> {
+  return bcrypt.compare(password, hashedPassword);
+}


### PR DESCRIPTION
### Motivation

- The `users.password` column appeared to be unused in the server code and storing plaintext passwords is unsafe, so the schema column is removed and server-side helpers are prepared for proper hashed-password handling.

### Description

- Removed the `password` field from the users table definition in `db/schema.ts` and added a migration at `migrations/0000_drop_users_password.sql` to drop the column.
- Added bcrypt-based helpers `hashPassword` and `verifyPassword` in `server/utils/passwords.ts` using `bcryptjs` with `SALT_ROUNDS = 12`.
- Added tests in `server/tests/passwords.test.ts` that exercise `hashPassword` and `verifyPassword`.
- Added the `bcryptjs` dependency to `package.json` (and `package-lock.json`).

### Testing

- Ran the unit tests for the new password utilities with `npx vitest run server/tests/passwords.test.ts`, and both tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69690a2bfa2883299889d6ee6239f011)