### PR TITLE
Add Sentry browser error tracking integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,12 @@ VITE_FIREBASE_MEASUREMENT_ID=G-7LHTQSRF9L
 # Enable analytics in development (optional)
 # VITE_ENABLE_ANALYTICS=true
 
+# Sentry browser SDK DSN for error tracking
+# VITE_SENTRY_DSN=https://examplePublicKey@o0.ingest.sentry.io/0
+
+# Enable the error tracking smoke test helper (optional)
+# VITE_ENABLE_ERROR_TRACKING_SMOKE_TEST=true
+
 # Stripe API keys for checkout integration
 # VITE_STRIPE_PUBLISHABLE_KEY=pk_test_your_stripe_publishable_key
 # STRIPE_SECRET_KEY=sk_test_your_stripe_secret_key

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -26,6 +26,28 @@ Stripe checkout and onboarding routes require the secret key at runtime:
 
 - `STRIPE_SECRET_KEY` (required; server startup fails fast if unset)
 
+## Error tracking (Sentry)
+
+Client-side error tracking uses the Sentry browser SDK. Provide the DSN in your
+deployment environment so Vite can inject it at build time:
+
+- `VITE_SENTRY_DSN` (required to send events to Sentry)
+
+Optional smoke test toggle:
+
+- `VITE_ENABLE_ERROR_TRACKING_SMOKE_TEST=true` (exposes `window.runErrorTrackingSmokeTest()` for a
+  one-time verification in staging/production).
+
+### Smoke test steps
+
+1. Deploy with `VITE_SENTRY_DSN` set (and the smoke test toggle if desired).
+2. Open the deployed site in a browser.
+3. In the devtools console, run:
+   ```
+   window.runErrorTrackingSmokeTest?.()
+   ```
+4. Confirm the "Sentry smoke test" event appears in the Sentry dashboard.
+
 ## Database migrations (Drizzle)
 
 This project uses Drizzle migrations generated from `db/schema.ts`. Migrations live in the `migrations/` directory and should always be committed to the repository.

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "@radix-ui/react-tooltip": "^1.1.3",
         "@react-oauth/google": "^0.12.1",
         "@replit/vite-plugin-shadcn-theme-json": "^0.0.3",
+        "@sentry/react": "^10.34.0",
         "@stripe/stripe-js": "^5.4.0",
         "@tanstack/react-query": "^5.60.5",
         "@tweenjs/tween.js": "^25.0.0",
@@ -5845,6 +5846,97 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@sentry-internal/browser-utils": {
+      "version": "10.34.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.34.0.tgz",
+      "integrity": "sha512-0YNr60rGHyedmwkO0lbDBjNx2KAmT3kWamjaqu7Aw+jsESoPLgt+fzaTVvUBvkftBDui2PeTSzXm/nqzssctYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.34.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback": {
+      "version": "10.34.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.34.0.tgz",
+      "integrity": "sha512-wgGnq+iNxsFSOe9WX/FOvtoItSTjgLJJ4dQkVYtcVM6WGBVIg4wgNYfECCnRNztUTPzpZHLjC9r+4Pym451DDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.34.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay": {
+      "version": "10.34.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.34.0.tgz",
+      "integrity": "sha512-Vmea0GcOg57z/S1bVSj3saFcRvDqdLzdy4wd9fQMpMgy5OCbTlo7lxVUndKzbcZnanma6zF6VxwnWER1WuN9RA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.34.0",
+        "@sentry/core": "10.34.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "10.34.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.34.0.tgz",
+      "integrity": "sha512-XWH/9njtgMD+LLWjc4KKgBpb+dTCkoUEIFDxcvzG/87d+jirmzf0+r8EfpLwKG+GrqNiiGRV39zIqu0SfPl+cw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/replay": "10.34.0",
+        "@sentry/core": "10.34.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/browser": {
+      "version": "10.34.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.34.0.tgz",
+      "integrity": "sha512-8WCsAXli5Z+eIN8dMY8KGQjrS3XgUp1np/pjdeWNrVPVR8q8XpS34qc+f+y/LFrYQC9bs2Of5aIBwRtDCIvRsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.34.0",
+        "@sentry-internal/feedback": "10.34.0",
+        "@sentry-internal/replay": "10.34.0",
+        "@sentry-internal/replay-canvas": "10.34.0",
+        "@sentry/core": "10.34.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.34.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.34.0.tgz",
+      "integrity": "sha512-4FFpYBMf0VFdPcsr4grDYDOR87mRu6oCfb51oQjU/Pndmty7UgYo0Bst3LEC/8v0SpytBtzXq+Wx/fkwulBesg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "10.34.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.34.0.tgz",
+      "integrity": "sha512-LDpg9WDrEwo6lr/YOAA54id/g5D1PGKEIiOGxqRZbBVyjzrsquwzhSG2CMqnp+YO6lz/r96LWuqm2cvfpht2zA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "10.34.0",
+        "@sentry/core": "10.34.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.33.20",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@radix-ui/react-tooltip": "^1.1.3",
     "@react-oauth/google": "^0.12.1",
     "@replit/vite-plugin-shadcn-theme-json": "^0.0.3",
+    "@sentry/react": "^10.34.0",
     "@stripe/stripe-js": "^5.4.0",
     "@tanstack/react-query": "^5.60.5",
     "@tweenjs/tween.js": "^25.0.0",


### PR DESCRIPTION
### Motivation

- Add a production-ready client-side error provider so runtime errors are forwarded to an external observability platform (Sentry) and can be inspected in a dashboard. 
- Allow the Sentry DSN to be injected by the build/deployment environment via Vite for safe configuration in staging/production. 
- Provide a small smoke-test mechanism to verify event delivery from deployed builds without changing application logic.

### Description

- Added `@sentry/react` to dependencies and updated `package-lock.json` accordingly. 
- Integrated Sentry in the client error tracking service (`client/src/lib/errorTracking.ts`) by importing Sentry, initializing it when `VITE_SENTRY_DSN` is present, forwarding captured exceptions via `Sentry.withScope`/`Sentry.captureException`, and mirroring breadcrumbs and `setUser` to Sentry. 
- Exposed a smoke-test helper `runSmokeTest()` and conditionally attached `window.runErrorTrackingSmokeTest` when `VITE_ENABLE_ERROR_TRACKING_SMOKE_TEST` is set; `runSmokeTest()` sends a test event titled "Sentry smoke test". 
- Documented the new environment variables in `.env.example` and `DEPLOYMENT.md` and added short smoke-test steps for deploy verification.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696910f5b5588329a6b09c203c05fda0)