### PR TITLE
Add monitoring guidance and 5xx error tracking

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,0 +1,51 @@
+# Monitoring & Alerting (Render)
+
+This guide documents how to confirm service health in Render and set up uptime/5xx alerting using the existing health endpoints.
+
+## 1) Check Render logs for crash loops or missing env vars
+
+1. Open **Render → Service → Logs**.
+2. Filter for:
+   - **Crash loops**: repeated “process exited” or restart messages.
+   - **Missing env vars**: `process.env` warnings or explicit “undefined env var” errors.
+   - **Health check failures**: repeated 5xx around `/health` or `/health/ready`.
+3. If you see missing secrets, compare against the list in `DEPLOYMENT.md` and fix in Render’s **Environment** settings. 
+
+## 2) Confirm plan/cold-start behavior
+
+Render plan behavior can affect cold starts. Verify the current plan in **Render → Service → Settings** and confirm whether your plan includes cold-start sleep. If requests are failing after inactivity, consider upgrading the service plan to avoid idle spin-downs. 
+
+## 3) Verify `/health` and `/health/ready` in production
+
+These endpoints are already implemented:
+
+```bash
+curl -i https://<your-render-domain>/health
+curl -i https://<your-render-domain>/health/ready
+```
+
+Both should return `200` when the service is healthy and ready.
+
+## 4) Add uptime monitoring + 5xx alerting
+
+### Uptime monitoring
+Use any external uptime monitor (e.g., UptimeRobot, Better Stack, StatusCake) and point it at:
+
+```
+https://<your-render-domain>/health/ready
+```
+
+Configure a 1–5 minute check interval and enable notifications (email/Slack/PagerDuty).
+
+### 5xx alerting
+The server tracks error rates and counts in `/health/status`. Hook a log/metrics tool to:
+
+```
+https://<your-render-domain>/health/status
+```
+
+Set alert thresholds for:
+- `metrics.errorRate` above a baseline (for example, >2% over 5–10 minutes).
+- Or alert on any spikes in 5xx responses.
+
+If you already use a logging platform, configure a query/alert for `statusCode >= 500` and page on a spike.

--- a/server/index.ts
+++ b/server/index.ts
@@ -8,7 +8,7 @@ import { registerRoutes } from "./routes";
 import { setupVite, serveStatic } from "./vite";
 import geminiRouter from "./routes/gemini";
 import { attachRequestMeta, logger, generateTraceId, logSecurityEvent } from "./logger";
-import { incrementRequestCount } from "./routes/health";
+import { incrementRequestCount, incrementErrorCount } from "./routes/health";
 
 const app = express();
 
@@ -168,6 +168,10 @@ app.use((req, res, next) => {
     const durationMs = Number(endTime - startTime) / 1_000_000;
 
     const logLevel = res.statusCode >= 500 ? "error" : res.statusCode >= 400 ? "warn" : "info";
+
+    if (res.statusCode >= 500) {
+      incrementErrorCount();
+    }
 
     logger[logLevel](
       attachRequestMeta({


### PR DESCRIPTION
### Motivation
- Provide operational guidance for Render and make it easier to detect and respond to uptime and 5xx issues. 
- Ensure the internal health metrics exposed at `/health/status` reflect real 5xx spikes so alerting and dashboards are actionable. 

### Description
- Add `docs/monitoring.md` with steps to review Render logs, confirm plan/cold-start behavior, validate `curl` checks for `/health` and `/health/ready`, and configure uptime and 5xx alerting. 
- Import `incrementErrorCount` in `server/index.ts` and increment it when a response has `statusCode >= 500` in the request `finish` handler so `/health/status` metrics include 5xx counts. 
- No route behavior was changed; this only augments server-side metrics and adds documentation for monitoring. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696910f681fc8329b03522b8eb39f7c0)