### PR TITLE
Add public /api/site-content endpoint returning site summary

### DIFF
--- a/client/public/llms.txt
+++ b/client/public/llms.txt
@@ -14,3 +14,6 @@ High-priority public URLs:
 - /terms
 
 Full content: /llms-full.txt
+
+API endpoints:
+- /api/site-content (public JSON summary of key pages and non-sensitive content)

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -18,6 +18,7 @@ import waitlistHandler from "./routes/waitlist";
 import applyHandler from "./routes/apply";
 import healthRouter from "./routes/health";
 import errorsRouter from "./routes/errors";
+import siteContentRouter from "./routes/site-content";
 import verifyFirebaseToken from "./middleware/verifyFirebaseToken";
 import { csrfCookieHandler, csrfProtection } from "./middleware/csrf";
 
@@ -26,6 +27,9 @@ export function registerRoutes(app: Express) {
 
   // Health check routes (no /api prefix for standard probe paths)
   app.use(healthRouter);
+
+  // Public content summary for external tooling.
+  app.use("/api/site-content", siteContentRouter);
 
   // API routes for Express
   app.get("/api/csrf", csrfCookieHandler);

--- a/server/routes/site-content.ts
+++ b/server/routes/site-content.ts
@@ -1,0 +1,45 @@
+import { Router, Request, Response } from "express";
+
+const router = Router();
+
+router.get("/", (_req: Request, res: Response) => {
+  res.status(200).json({
+    summary:
+      "Blueprint provides SimReady 3D environments, datasets, evaluation tooling, and marketplace content for robotics and AI teams.",
+    pages: [
+      {
+        path: "/",
+        title: "Home",
+        description: "Overview of Blueprint's robotics data platform and core value proposition.",
+      },
+      {
+        path: "/marketplace",
+        title: "Marketplace",
+        description: "Discover curated 3D assets, datasets, and simulation-ready content.",
+      },
+      {
+        path: "/docs",
+        title: "Docs",
+        description: "Product documentation, onboarding, and platform guides.",
+      },
+      {
+        path: "/pricing",
+        title: "Pricing",
+        description: "Plan options and pricing details for teams and enterprises.",
+      },
+      {
+        path: "/solutions",
+        title: "Solutions",
+        description: "Use cases for robotics, autonomy, and AI evaluation workflows.",
+      },
+      {
+        path: "/contact",
+        title: "Contact",
+        description: "Ways to reach the Blueprint team for sales and support.",
+      },
+    ],
+    safety: "This endpoint only returns public, non-sensitive summaries.",
+  });
+});
+
+export default router;


### PR DESCRIPTION
### Motivation
- Provide a small, machine-friendly summary of key public pages for external tooling and LLMs.
- Make the site structure discoverable without exposing sensitive information.
- Offer a single public endpoint that can be consumed by integrations and monitoring systems.

### Description
- Added a new router at `server/routes/site-content.ts` that serves a static JSON summary (`summary`, `pages`, and `safety`) at its root GET handler.
- Registered the router in `server/routes.ts` via `app.use("/api/site-content", siteContentRouter)` to expose the endpoint at `/api/site-content`.
- Documented the new endpoint in `client/public/llms.txt` so it is discoverable to LLMs and external tooling.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696914b9e2cc8329b4e6e069061fd10b)