### PR TITLE
Add Rollup manualChunks vendor splitting for Vite build

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,5 +24,59 @@ export default defineConfig({
   build: {
     outDir: path.resolve(__dirname, "dist/public"),
     emptyOutDir: true,
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (!id.includes("node_modules")) return;
+          if (
+            id.includes("three") ||
+            id.includes("three-stdlib") ||
+            id.includes("three-transform-controls")
+          ) {
+            return "vendor-3d";
+          }
+          if (id.includes("leaflet") || id.includes("react-leaflet")) {
+            return "vendor-maps";
+          }
+          if (id.includes("@googlemaps/js-api-loader")) {
+            return "vendor-google-maps";
+          }
+          if (
+            id.includes("openai") ||
+            id.includes("@anthropic-ai") ||
+            id.includes("@google/generative-ai") ||
+            id.includes("@google/genai") ||
+            id.includes("@google-cloud/aiplatform") ||
+            id.includes("lumaai")
+          ) {
+            return "vendor-ai";
+          }
+          if (id.includes("firebase") || id.includes("firebase-admin")) {
+            return "vendor-firebase";
+          }
+          if (id.includes("reactflow")) {
+            return "vendor-flow";
+          }
+          if (id.includes("@sentry")) {
+            return "vendor-sentry";
+          }
+          if (id.includes("framer-motion")) {
+            return "vendor-motion";
+          }
+          if (id.includes("@radix-ui")) {
+            return "vendor-radix";
+          }
+          if (
+            id.includes("@tanstack") ||
+            id.includes("react-router") ||
+            id.includes("react-dom") ||
+            id.includes("react/jsx-runtime")
+          ) {
+            return "vendor-react";
+          }
+          return "vendor";
+        },
+      },
+    },
   },
 });


### PR DESCRIPTION
### Motivation
- The production bundle produced a very large vendor chunk (~884 KB) which triggered Vite/Rollup size warnings and risks slower initial load.
- Split vendor-heavy libraries (3D, maps, AI, Firebase, Sentry, etc.) into separate chunks to improve caching and reduce the largest chunk size.

### Description
- Added `build.rollupOptions.output.manualChunks` to `vite.config.ts` to group node_modules imports into named vendor chunks like `vendor-3d`, `vendor-maps`, `vendor-google-maps`, `vendor-ai`, `vendor-firebase`, `vendor-flow`, `vendor-sentry`, `vendor-motion`, `vendor-radix`, `vendor-react`, and a fallback `vendor` chunk.
- The function detects common large libraries by checking `id.includes(...)` and returns the matching chunk name.
- No other build configuration or source files were modified.

### Testing
- Ran `npm run build -- --report` and the build completed successfully with module transforms and chunk rendering finishing without errors.
- Before the change the largest client chunk was about `884.67 kB`, and after the change the largest chunk is now `vendor-firebase ~466.15 kB`, bringing chunks under the 500 KB guidance and resolving the prior large-chunk warning.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696914ba614c832999ba4de7d912a475)