### PR TITLE
Remove unused auth middleware test env vars

### DIFF
--- a/server/tests/auth-middleware.test.ts
+++ b/server/tests/auth-middleware.test.ts
@@ -24,9 +24,6 @@ let csrfCookie: string;
 let csrfToken: string;
 
 beforeAll(async () => {
-  process.env.PARALLEL_API_KEY = "test-parallel-key";
-  process.env.PERPLEXITY_API_KEY = "test-perplexity-key";
-
   ({ registerRoutes } = await import("../routes"));
 
   const app = express();


### PR DESCRIPTION
### Motivation
- Remove leftover test-only environment assignments for `process.env.PARALLEL_API_KEY` and `process.env.PERPLEXITY_API_KEY` because the auth middleware tests no longer depend on those provider keys.

### Description
- Deleted the assignments to `process.env.PARALLEL_API_KEY` and `process.env.PERPLEXITY_API_KEY` from `server/tests/auth-middleware.test.ts`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969164bfca48329ba4eb78ecea4e93f)