### PR TITLE
Remove Perplexity endpoint from feature config UI

### DIFF
--- a/client/src/components/FeatureConfigScreens.jsx
+++ b/client/src/components/FeatureConfigScreens.jsx
@@ -2251,9 +2251,9 @@ export const InteractiveExperiencesConfigScreen = ({
         prompt = `${locationInfo} - I'm creating a fact or fiction interactive experience for customers that come in to have fun and increase industry knowledge - give me ${configData.questionCount} different fact or fiction questions on the industry along with the answer`;
       }
 
-      // Call Perplexity API
+      // Call content generation API
       const response = await fetch(
-        "https://api.perplexity.ai/chat/completions",
+        import.meta.env.VITE_CONTENT_GENERATION_API_URL,
         {
           method: "POST",
           headers: {
@@ -2279,11 +2279,11 @@ export const InteractiveExperiencesConfigScreen = ({
         },
       );
 
-      // In generateContent function, after Perplexity API call
+      // In generateContent function, after API call
       const data = await response.json();
-      console.log("Perplexity API response:", data);
+      console.log("Content API response:", data);
       const rawContent = data.choices[0].message.content;
-      console.log("Raw content from Perplexity:", rawContent);
+      console.log("Raw content from content API:", rawContent);
 
       // In formatContentWithGemini function, after Gemini API call
       const result = await model.generateContent(prompt);


### PR DESCRIPTION
### Motivation
- Remove the hard-coded Perplexity endpoint from the feature configuration UI and make the content-generation endpoint configurable so the UI no longer references Perplexity directly.

### Description
- Replace the hard-coded URL with `import.meta.env.VITE_CONTENT_GENERATION_API_URL` in `client/src/components/FeatureConfigScreens.jsx`.
- Update comments and `console.log` messages to provider-neutral text (`Perplexity` -> `content API`).
- Leave request headers unchanged (no functional change to request payload or downstream formatting logic).

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696916468f948329bfe82022d8fae517)