### PR TITLE
Fix website indexing for search engines

### DIFF
--- a/server/vite.ts
+++ b/server/vite.ts
@@ -43,7 +43,7 @@ export async function setupVite(app: Express, server: Server) {
 }
 
 export function serveStatic(app: Express) {
-  const distPath = path.resolve(__dirname, "public");
+  const distPath = path.resolve(__dirname, "..", "dist", "public");
   const indexPath = path.resolve(distPath, "index.html");
 
   if (!fs.existsSync(distPath)) {


### PR DESCRIPTION
… output directory

The serveStatic function was looking for static files (including robots.txt and sitemap.xml) in the wrong location. It was trying to serve from server/public instead of dist/public, which meant Google couldn't find robots.txt to crawl the site.

This fix ensures the production server correctly serves the built static files including robots.txt, allowing Google to properly index the site.