### PR TITLE
Enforce robots.txt deployment consistency

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -132,3 +132,24 @@ If you encounter deployment errors:
 3. Ensure all environment variables are properly set in Replit Secrets
 
 4. If you're still facing issues, check the deployment logs for specific error messages
+
+## Robots.txt and indexing headers (production)
+
+Production deploys must serve `client/public/robots.txt` verbatim. The Vite build copies `client/public/*` into `dist/public/`, and the server explicitly serves `/robots.txt` from `dist/public/robots.txt`. In production, the server now fails startup if that file is missing so we never ship a hosting default like `Disallow: /`.【F:server/index.ts†L234-L257】
+
+### Deployment checklist
+
+1. Ensure `client/public/robots.txt` contains the intended directives (no generated defaults).
+2. Confirm the build output includes the file:
+   ```
+   ls -l dist/public/robots.txt
+   ```
+3. Verify the deployed site serves the same content (no CDN/hosting override):
+   ```
+   curl -sS https://<your-domain>/robots.txt
+   ```
+4. Confirm no header-based overrides are set by the host/CDN (Cloud Run + Express do not set these by default). For any proxy/CDN you add, verify the response headers for `/` and `/robots.txt` do **not** include `X-Robots-Tag: noindex`:
+   ```
+   curl -sSI https://<your-domain>/ | rg -i 'x-robots-tag'
+   curl -sSI https://<your-domain>/robots.txt | rg -i 'x-robots-tag'
+   ```

--- a/server/index.ts
+++ b/server/index.ts
@@ -234,12 +234,15 @@ app.use((req, res, next) => {
   const publicDir = path.resolve(process.cwd(), "dist", "public");
   const robotsPath = path.join(publicDir, "robots.txt");
   const sitemapPath = path.join(publicDir, "sitemap.xml");
+  const isProduction = process.env.NODE_ENV === "production";
 
   if (!fs.existsSync(robotsPath)) {
-    logger.warn(
-      { path: robotsPath },
-      "robots.txt is missing from dist/public. Falling back to allow-all response."
-    );
+    const message =
+      "robots.txt is missing from dist/public. Ensure client/public/robots.txt is deployed verbatim.";
+    if (isProduction) {
+      throw new Error(message);
+    }
+    logger.warn({ path: robotsPath }, message);
   }
 
   app.get("/robots.txt", (_req, res) => {
@@ -247,7 +250,7 @@ app.use((req, res, next) => {
       return res.sendFile(robotsPath);
     }
 
-    return res.type("text/plain").send("User-agent: *\nAllow: /\n");
+    return res.status(500).type("text/plain").send("robots.txt is missing.");
   });
 
   app.get("/sitemap.xml", (_req, res) => {


### PR DESCRIPTION
### Motivation

- Prevent accidental shipping of hosting/CDN-generated robots rules by ensuring the app serves the exact `client/public/robots.txt` file.  
- The server previously fell back to an "allow-all" text when `dist/public/robots.txt` was missing, which could hide an unintended default `Disallow: /` from a host; production should fail fast instead.  
- Repository inspection did not find any code that sets `X-Robots-Tag` header overrides, so protecting the served file is the remaining control point.

### Description

- Updated `server/index.ts` to treat a missing `dist/public/robots.txt` as a startup error when `NODE_ENV` is `production` and to return a `500` response in non-production instead of silently returning an allow-all fallback.  
- Added an explicit message recommending that deploys include `client/public/robots.txt` verbatim and adjusted the runtime log/error to direct attention to the missing file.  
- Documented robots/indexing guidance in `DEPLOYMENT.md` with a checklist and verification commands (`ls`, `curl`, `curl -sSI | rg -i 'x-robots-tag'`) so future deploys confirm the file is published and no `X-Robots-Tag: noindex` header is applied.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969241b50208329bf0127a5308dea0b)