### PR TITLE
Update business signup primary needs & marketplace personalization for simulation offerings

### DIFF
--- a/client/src/hooks/useMarketplacePersonalization.ts
+++ b/client/src/hooks/useMarketplacePersonalization.ts
@@ -25,22 +25,20 @@ interface UseMarketplacePersonalizationReturn {
 
 // Map primary needs to marketplace categories/filters
 const PRIMARY_NEED_TO_CATEGORY: Record<string, string[]> = {
-  "training-data": ["training", "datasets"],
-  labeling: ["scenes", "datasets"],
-  rlhf: ["training", "datasets"],
-  collection: ["scenes"],
-  marketplace: ["all"],
+  "benchmark-packs": ["scenes", "datasets"],
+  "scene-library": ["scenes"],
+  "dataset-packs": ["training", "datasets"],
+  "custom-capture": ["scenes"],
   other: ["all"],
 };
 
 // Map primary needs to welcome messages
 const PRIMARY_NEED_MESSAGES: Record<string, string> = {
-  "training-data": "Here are training datasets perfect for your AI models",
-  labeling: "Discover high-quality labeled data for your project",
-  rlhf: "Explore preference and RLHF datasets",
-  collection: "Browse our custom data collection scenes",
-  marketplace: "Welcome! Explore our curated dataset marketplace",
-  other: "Welcome! Start exploring our data offerings",
+  "benchmark-packs": "Explore benchmark and eval packs with scenes, tasks, and harnesses",
+  "scene-library": "Browse SimReady scenes ready for simulation",
+  "dataset-packs": "Discover robotic policy trajectories and episodes for training",
+  "custom-capture": "Request custom scene captures tailored to your facility",
+  other: "Welcome! Start exploring our simulation data offerings",
 };
 
 // Extract keywords from project description for suggestions

--- a/client/src/lib/firebase.ts
+++ b/client/src/lib/firebase.ts
@@ -124,7 +124,7 @@ export interface UserData {
   finishedOnboarding: boolean;
 
   // Business signup fields
-  primaryNeeds?: ("training-data" | "labeling" | "rlhf" | "collection" | "marketplace" | "other")[];
+  primaryNeeds?: ("benchmark-packs" | "scene-library" | "dataset-packs" | "custom-capture" | "other")[];
   companySize?: "1-10" | "11-50" | "51-200" | "201-1000" | "1000+";
   projectDescription?: string;
   expectedVolume?: "exploring" | "small" | "medium" | "large" | "enterprise";

--- a/client/src/pages/BusinessSignUpFlow.tsx
+++ b/client/src/pages/BusinessSignUpFlow.tsx
@@ -56,11 +56,10 @@ import type { UserData } from "@/lib/firebase";
 
 // Primary need options
 const PRIMARY_NEED_OPTIONS = [
-  { value: "training-data", label: "Training data for AI models" },
-  { value: "labeling", label: "Data labeling & annotation" },
-  { value: "rlhf", label: "RLHF & preference data" },
-  { value: "collection", label: "Custom data collection" },
-  { value: "marketplace", label: "Dataset marketplace access" },
+  { value: "benchmark-packs", label: "Benchmark & eval packs (scenes, tasks & harnesses)" },
+  { value: "scene-library", label: "SimReady scenes (USD environments)" },
+  { value: "dataset-packs", label: "Robotic policy trajectories & episodes" },
+  { value: "custom-capture", label: "Custom scene capture (on-site facility scan)" },
   { value: "other", label: "Other" },
 ] as const;
 
@@ -705,7 +704,8 @@ export default function BusinessSignUpFlow() {
                     {/* Primary Need - Multi-choice */}
                     <div>
                       <Label className="text-sm font-medium text-zinc-700 mb-2 block">
-                        What are your primary needs? <span className="text-red-500">*</span>
+                        What are your primary needs? Select all that apply.{" "}
+                        <span className="text-red-500">*</span>
                       </Label>
                       <div className="space-y-2">
                         {PRIMARY_NEED_OPTIONS.map((option) => (

--- a/client/src/pages/OnboardingChecklist.tsx
+++ b/client/src/pages/OnboardingChecklist.tsx
@@ -231,11 +231,10 @@ export default function OnboardingChecklist() {
     if (!userData?.primaryNeeds || userData.primaryNeeds.length === 0) return null;
 
     const messages: Record<string, string> = {
-      "training-data": "Let's find the perfect training datasets for your AI model",
-      labeling: "Discover high-quality labeled datasets for your needs",
-      rlhf: "Explore RLHF and preference datasets to improve your models",
-      collection: "Browse our custom data collection options",
-      marketplace: "Start exploring our curated dataset marketplace",
+      "benchmark-packs": "Explore benchmark and eval packs tailored to your needs",
+      "scene-library": "Browse SimReady scenes that match your simulation goals",
+      "dataset-packs": "Find robotic policy trajectories and episodes for training",
+      "custom-capture": "Explore custom scene captures for your facilities",
       other: "Let's get you started with the right data",
     };
 


### PR DESCRIPTION
### Motivation
- Replace legacy data labels (labeling / RLHF / generic training-data) with current simulation-focused offerings (benchmark packs, SimReady scenes, dataset packs, custom capture) to match the site contact offerings and product terminology. 
- Ensure user metadata typing and marketplace personalization use the new primary-need values so onboarding and recommendations remain consistent. 
- Clarify Step 2 UI wording to instruct users to select all applicable primary needs.

### Description
- Updated the Step 2 primary-need choices in `client/src/pages/BusinessSignUpFlow.tsx` by replacing the old options with: `benchmark-packs`, `scene-library`, `dataset-packs`, `custom-capture`, and kept `other`, and updated the label helper text to: "What are your primary needs? Select all that apply.". 
- Aligned the `UserData.primaryNeeds` union type in `client/src/lib/firebase.ts` to `("benchmark-packs" | "scene-library" | "dataset-packs" | "custom-capture" | "other")[]`. 
- Updated personalization mappings in `client/src/hooks/useMarketplacePersonalization.ts` by replacing the old mapping/messages with entries for `benchmark-packs`, `scene-library`, `dataset-packs`, and `custom-capture` and adjusted suggested categories and welcome messages accordingly. 
- Updated onboarding messaging in `client/src/pages/OnboardingChecklist.tsx` to use the new primary-need keys and wording.

### Testing
- Attempted to start the dev server with `npm run dev`; the process failed to start due to a `pino-pretty` transport configuration error, so the app was not run for live verification. 
- A Playwright screenshot run was attempted against `http://127.0.0.1:4173/signup` but failed because the server was not running. 
- No automated unit or integration tests were executed successfully as part of this change due to the local dev server failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69694a8c3560832995ac01f0b2ad7f88)