### PR TITLE
Capture project budget range in business signup (rename expectedVolume → budgetRange)

### DIFF
--- a/client/src/lib/firebase.ts
+++ b/client/src/lib/firebase.ts
@@ -127,7 +127,7 @@ export interface UserData {
   primaryNeeds?: ("training-data" | "labeling" | "rlhf" | "collection" | "marketplace" | "other")[];
   companySize?: "1-10" | "11-50" | "51-200" | "201-1000" | "1000+";
   projectDescription?: string;
-  expectedVolume?: "exploring" | "small" | "medium" | "large" | "enterprise";
+  budgetRange?: "<$50K" | "$50K-$300K" | "$300K-$1M" | ">$1M" | "Undecided/Unsure";
   referralSource?: "google" | "linkedin" | "twitter" | "referral" | "event" | "other";
 
   // Onboarding state

--- a/client/src/pages/BusinessSignUpFlow.tsx
+++ b/client/src/pages/BusinessSignUpFlow.tsx
@@ -4,7 +4,7 @@
 // 3-step flow:
 // Step 1: Account Basics (organization name, email, password, OAuth)
 // Step 2: Business Context (name, title, phone, primary need, company size)
-// Step 3: Project Details (description, volume, referral source)
+// Step 3: Project Details (description, budget, referral source)
 
 "use client";
 
@@ -73,13 +73,13 @@ const COMPANY_SIZE_OPTIONS = [
   { value: "1000+", label: "1000+" },
 ] as const;
 
-// Expected volume options
-const EXPECTED_VOLUME_OPTIONS = [
-  { value: "exploring", label: "Just exploring" },
-  { value: "small", label: "Small (< 1,000 annotations)" },
-  { value: "medium", label: "Medium (1K - 10K)" },
-  { value: "large", label: "Large (10K - 100K)" },
-  { value: "enterprise", label: "Enterprise (100K+)" },
+// Budget range options
+const BUDGET_RANGE_OPTIONS = [
+  "<$50K",
+  "$50K-$300K",
+  "$300K-$1M",
+  ">$1M",
+  "Undecided/Unsure",
 ] as const;
 
 // Referral source options
@@ -94,7 +94,7 @@ const REFERRAL_SOURCE_OPTIONS = [
 
 type PrimaryNeed = typeof PRIMARY_NEED_OPTIONS[number]["value"];
 type CompanySize = typeof COMPANY_SIZE_OPTIONS[number]["value"];
-type ExpectedVolume = typeof EXPECTED_VOLUME_OPTIONS[number]["value"];
+type BudgetRange = typeof BUDGET_RANGE_OPTIONS[number];
 type ReferralSource = typeof REFERRAL_SOURCE_OPTIONS[number]["value"];
 
 // Step indicator component
@@ -171,7 +171,7 @@ export default function BusinessSignUpFlow() {
 
   // Step 3: Project Details
   const [projectDescription, setProjectDescription] = useState("");
-  const [expectedVolume, setExpectedVolume] = useState<ExpectedVolume | "">("");
+  const [budgetRange, setBudgetRange] = useState<BudgetRange | "">("");
   const [referralSource, setReferralSource] = useState<ReferralSource | "">("");
 
   // Step validations
@@ -188,7 +188,7 @@ export default function BusinessSignUpFlow() {
     companySize !== "";
 
   const step3Valid =
-    expectedVolume !== "" &&
+    budgetRange !== "" &&
     referralSource !== "";
 
   const handleNext = useCallback(() => {
@@ -260,8 +260,8 @@ export default function BusinessSignUpFlow() {
 
   const handleSubmit = useCallback(async () => {
     if (!step3Valid) {
-      if (!expectedVolume) {
-        setErrorMessage("Please select your expected volume.");
+      if (!budgetRange) {
+        setErrorMessage("Please select your project budget.");
       } else if (!referralSource) {
         setErrorMessage("Please tell us how you heard about us.");
       }
@@ -363,7 +363,7 @@ export default function BusinessSignUpFlow() {
         primaryNeeds: primaryNeeds as PrimaryNeed[],
         companySize: companySize as CompanySize,
         projectDescription: projectDescription || undefined,
-        expectedVolume: expectedVolume as ExpectedVolume,
+        budgetRange: budgetRange as BudgetRange,
         referralSource: referralSource as ReferralSource,
 
         // Onboarding state
@@ -401,7 +401,7 @@ export default function BusinessSignUpFlow() {
     }
   }, [
     step3Valid,
-    expectedVolume,
+    budgetRange,
     referralSource,
     email,
     password,
@@ -821,22 +821,22 @@ export default function BusinessSignUpFlow() {
                       </p>
                     </div>
 
-                    {/* Expected Volume */}
+                    {/* Project Budget */}
                     <div>
-                      <Label htmlFor="expectedVolume" className="text-sm font-medium text-zinc-700">
-                        Expected monthly volume <span className="text-red-500">*</span>
+                      <Label htmlFor="budgetRange" className="text-sm font-medium text-zinc-700">
+                        Project budget <span className="text-red-500">*</span>
                       </Label>
-                      <Select value={expectedVolume} onValueChange={(v) => setExpectedVolume(v as ExpectedVolume)}>
+                      <Select value={budgetRange} onValueChange={(v) => setBudgetRange(v as BudgetRange)}>
                         <SelectTrigger className="mt-1">
                           <div className="flex items-center gap-2">
                             <BarChart3 className="h-4 w-4 text-zinc-400" />
-                            <SelectValue placeholder="Select expected volume" />
+                            <SelectValue placeholder="Select project budget" />
                           </div>
                         </SelectTrigger>
                         <SelectContent>
-                          {EXPECTED_VOLUME_OPTIONS.map((option) => (
-                            <SelectItem key={option.value} value={option.value}>
-                              {option.label}
+                          {BUDGET_RANGE_OPTIONS.map((option) => (
+                            <SelectItem key={option} value={option}>
+                              {option}
                             </SelectItem>
                           ))}
                         </SelectContent>


### PR DESCRIPTION
### Motivation
- Align the business signup flow with the contact form by collecting a project budget range instead of an ambiguous expected monthly volume.
- Make stored Firestore payloads and TypeScript types clearer by renaming the field from `expectedVolume` to `budgetRange` to avoid ambiguity.

### Description
- Replaced the old `EXPECTED_VOLUME_OPTIONS` select with `BUDGET_RANGE_OPTIONS` that match the `budgetRanges` values used in `client/src/components/site/ContactForm.tsx` (e.g. `<$50K`, `$50K-$300K`, `$300K-$1M`, `>$1M`, `Undecided/Unsure`).
- Renamed UI/state/validation identifiers: `expectedVolume` → `budgetRange`, `setExpectedVolume` → `setBudgetRange`, and updated the Step 3 label/placeholder from "Expected monthly volume" to "Project budget" and adjusted the validation error copy to "Please select your project budget." in `client/src/pages/BusinessSignUpFlow.tsx`.
- Updated the Firestore payload and TypeScript user interface by adding `budgetRange` to the `UserData` interface and storing `budgetRange` in the `users` document instead of the old `expectedVolume` key in `client/src/lib/firebase.ts`.
- Files changed: `client/src/pages/BusinessSignUpFlow.tsx`, `client/src/lib/firebase.ts` (values intentionally matched to `client/src/components/site/ContactForm.tsx`).

### Testing
- Attempted to run the dev server with `npm run dev -- --host 0.0.0.0 --port 4173`; startup failed due to a logging transport issue (`pino-pretty`) so the server did not fully start (failed).
- Attempted an automated UI screenshot with Playwright to verify the updated form at `/business-signup`, but the Chromium run crashed in this environment and the screenshot attempt failed (error: headless Chromium crash / TargetClosedError).
- No other automated tests were executed; type checks/build were not completed because the dev server and Playwright runs did not complete successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69694a943ddc8329929f7ac5ec6b4226)