### PR TITLE
Add Marketplace Scenes/Datasets tabs with tab-aware routing and scoped SEO

### DIFF
--- a/client/src/components/site/Header.tsx
+++ b/client/src/components/site/Header.tsx
@@ -12,7 +12,8 @@ import {
 } from "@/components/ui/dropdown-menu";
 
 const navLinks = [
-  { href: "/marketplace", label: "Marketplace" },
+  { href: "/marketplace/scenes", label: "Scenes" },
+  { href: "/marketplace/datasets", label: "Datasets" },
   { href: "/evals", label: "Benchmarks" },
   { href: "/partners", label: "Partners" },
   { href: "/careers", label: "Careers" },
@@ -26,10 +27,18 @@ export function Header() {
   const isActive = useMemo(
     () =>
       (href: string) => {
-        // Handle /marketplace also matching /environments for backwards compatibility
-        if (href === "/marketplace") {
-          return location === "/marketplace" || location.startsWith("/marketplace/") ||
-                 location === "/environments" || location.startsWith("/environments/");
+        if (href === "/marketplace/scenes") {
+          return (
+            location === "/marketplace" ||
+            location.startsWith("/marketplace/scenes") ||
+            (location.startsWith("/marketplace/") &&
+              !location.startsWith("/marketplace/datasets")) ||
+            location === "/environments" ||
+            location.startsWith("/environments/")
+          );
+        }
+        if (href === "/marketplace/datasets") {
+          return location.startsWith("/marketplace/datasets");
         }
         return location === href || (href !== "/" && location.startsWith(href));
       },

--- a/client/src/components/site/MarketplaceCard.tsx
+++ b/client/src/components/site/MarketplaceCard.tsx
@@ -24,6 +24,8 @@ export function MarketplaceCard({ item, type }: MarketplaceCardProps) {
   const scene = isScene ? (item as MarketplaceScene) : null;
   const training = isTraining ? (item as TrainingDataset) : null;
   const slug = item.slug;
+  const detailBasePath = isTraining ? "/marketplace/datasets" : "/marketplace/scenes";
+  const detailPath = `${detailBasePath}/${slug}`;
 
   // Calculate savings for datasets
   const savingsPercent = dataset?.standardPricePerScene
@@ -83,8 +85,8 @@ export function MarketplaceCard({ item, type }: MarketplaceCardProps) {
           headers: await withCsrfHeader({ "Content-Type": "application/json" }),
           body: JSON.stringify({
             sessionType: "marketplace",
-            successPath: `/marketplace/${slug}?checkout=success`,
-            cancelPath: `/marketplace/${slug}?checkout=cancel`,
+            successPath: `${detailPath}?checkout=success`,
+            cancelPath: `${detailPath}?checkout=cancel`,
             marketplaceItem: checkoutItem,
           }),
         });
@@ -134,18 +136,17 @@ export function MarketplaceCard({ item, type }: MarketplaceCardProps) {
         setIsRedirecting(false);
       }
     },
-    [dataset, isDataset, isTraining, isRedirecting, scene, training, slug],
+    [dataset, detailPath, isDataset, isTraining, isRedirecting, scene, training],
   );
 
   const handleCardClick = useCallback(() => {
-    const targetPath = `/marketplace/${slug}`;
     if (!currentUser) {
-      sessionStorage.setItem("redirectAfterAuth", targetPath);
+      sessionStorage.setItem("redirectAfterAuth", detailPath);
       navigate("/login");
       return;
     }
-    navigate(targetPath);
-  }, [currentUser, navigate, slug]);
+    navigate(detailPath);
+  }, [currentUser, detailPath, navigate]);
 
   return (
     <article

--- a/client/src/components/site/SceneCard.tsx
+++ b/client/src/components/site/SceneCard.tsx
@@ -12,7 +12,7 @@ export function SceneCard({ scene }: SceneCardProps) {
   const [, navigate] = useLocation();
 
   const handleCardClick = () => {
-    const targetPath = `/marketplace/${scene.slug}`;
+    const targetPath = `/marketplace/scenes/${scene.slug}`;
     if (!currentUser) {
       sessionStorage.setItem("redirectAfterAuth", targetPath);
       navigate("/login");

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -65,7 +65,17 @@ function Router() {
         <Route path="/why-simulation" component={withLayout(WhySimulation)} />
         {/* Primary route: /marketplace (canonical), /environments kept for backwards compatibility */}
         <Route path="/marketplace" component={withLayout(Environments)} />
+        <Route path="/marketplace/scenes" component={withLayout(Environments)} />
+        <Route path="/marketplace/datasets" component={withLayout(Environments)} />
         <Route path="/environments" component={withLayout(Environments)} />
+        <Route
+          path="/marketplace/scenes/:slug"
+          component={withProtectedLayout(EnvironmentDetail)}
+        />
+        <Route
+          path="/marketplace/datasets/:slug"
+          component={withProtectedLayout(EnvironmentDetail)}
+        />
         <Route
           path="/marketplace/:slug"
           component={withProtectedLayout(EnvironmentDetail)}

--- a/client/src/pages/EnvironmentDetail.tsx
+++ b/client/src/pages/EnvironmentDetail.tsx
@@ -132,6 +132,9 @@ export default function EnvironmentDetail({ params }: EnvironmentDetailProps) {
 
   const isTraining = Boolean(trainingDataset);
   const detailSlug = marketplaceItem?.slug || trainingDataset?.slug;
+  const detailBasePath = isTraining ? "/marketplace/datasets" : "/marketplace/scenes";
+  const detailPath = detailSlug ? `${detailBasePath}/${detailSlug}` : detailBasePath;
+  const detailUrl = `https://tryblueprint.io${detailPath}`;
 
   // Redirect benchmark suites to the benchmarks page
   useEffect(() => {
@@ -203,13 +206,13 @@ export default function EnvironmentDetail({ params }: EnvironmentDetailProps) {
       const response = await fetch("/api/create-checkout-session", {
         method: "POST",
         headers: await withCsrfHeader({ "Content-Type": "application/json" }),
-        body: JSON.stringify({
-          sessionType: "marketplace",
-          successPath: `/marketplace/${detailSlug}?checkout=success`,
-          cancelPath: `/marketplace/${detailSlug}?checkout=cancel`,
-          marketplaceItem: checkoutItem,
-        }),
-      });
+          body: JSON.stringify({
+            sessionType: "marketplace",
+            successPath: `${detailPath}?checkout=success`,
+            cancelPath: `${detailPath}?checkout=cancel`,
+            marketplaceItem: checkoutItem,
+          }),
+        });
 
       const data = await response.json();
       if (!response.ok || !data?.sessionId) {
@@ -255,7 +258,15 @@ export default function EnvironmentDetail({ params }: EnvironmentDetailProps) {
     } finally {
       setIsRedirecting(false);
     }
-  }, [detailSlug, isRedirecting, marketplaceItem, marketplaceScene, selectedOption, selectedAddons, totalPrice]);
+  }, [
+    detailPath,
+    isRedirecting,
+    marketplaceItem,
+    marketplaceScene,
+    selectedOption,
+    selectedAddons,
+    totalPrice,
+  ]);
 
   if (marketplaceItem) {
     const heroImage = marketplaceScene!.thumbnail;
@@ -303,7 +314,7 @@ export default function EnvironmentDetail({ params }: EnvironmentDetailProps) {
           />
           <meta name="robots" content="index, follow" />
           <meta property="og:type" content="product" />
-          <meta property="og:url" content={`https://tryblueprint.io/marketplace/${detailSlug}`} />
+          <meta property="og:url" content={detailUrl} />
           <meta property="og:title" content={`${marketplaceItem.title} | Blueprint`} />
           <meta property="og:description" content={marketplaceItem.description} />
           <meta
@@ -313,14 +324,14 @@ export default function EnvironmentDetail({ params }: EnvironmentDetailProps) {
           <meta name="twitter:card" content="summary_large_image" />
           <meta name="twitter:title" content={`${marketplaceItem.title} | Blueprint`} />
           <meta name="twitter:description" content={marketplaceItem.description} />
-          <link rel="canonical" href={`https://tryblueprint.io/marketplace/${detailSlug}`} />
+          <link rel="canonical" href={detailUrl} />
           <script type="application/ld+json">
             {JSON.stringify(productStructuredData)}
           </script>
         </Helmet>
         <div className="mx-auto max-w-6xl space-y-12 px-4 pb-24 pt-16 sm:px-6">
           <a
-            href="/marketplace"
+            href={detailBasePath}
             className="inline-flex items-center gap-2 text-sm font-semibold text-indigo-600 hover:text-indigo-700"
           >
             <ArrowLeft className="h-4 w-4" /> Back to Marketplace
@@ -842,8 +853,8 @@ export default function EnvironmentDetail({ params }: EnvironmentDetailProps) {
           headers: await withCsrfHeader({ "Content-Type": "application/json" }),
           body: JSON.stringify({
             sessionType: "marketplace",
-            successPath: `/marketplace/${trainingDataset.slug}?checkout=success`,
-            cancelPath: `/marketplace/${trainingDataset.slug}?checkout=cancel`,
+            successPath: `${detailPath}?checkout=success`,
+            cancelPath: `${detailPath}?checkout=cancel`,
             marketplaceItem: checkoutItem,
           }),
         });
@@ -901,7 +912,7 @@ export default function EnvironmentDetail({ params }: EnvironmentDetailProps) {
           <meta name="description" content={trainingDataset.description} />
           <meta name="robots" content="index, follow" />
           <meta property="og:type" content="product" />
-          <meta property="og:url" content={`https://tryblueprint.io/marketplace/${trainingDataset.slug}`} />
+          <meta property="og:url" content={detailUrl} />
           <meta property="og:title" content={`${trainingDataset.title} | Blueprint`} />
           <meta property="og:description" content={trainingDataset.description} />
           <meta
@@ -911,14 +922,14 @@ export default function EnvironmentDetail({ params }: EnvironmentDetailProps) {
           <meta name="twitter:card" content="summary_large_image" />
           <meta name="twitter:title" content={`${trainingDataset.title} | Blueprint`} />
           <meta name="twitter:description" content={trainingDataset.description} />
-          <link rel="canonical" href={`https://tryblueprint.io/marketplace/${trainingDataset.slug}`} />
+          <link rel="canonical" href={detailUrl} />
           <script type="application/ld+json">
             {JSON.stringify(trainingProductStructuredData)}
           </script>
         </Helmet>
         <div className="mx-auto max-w-6xl space-y-12 px-4 pb-24 pt-16 sm:px-6">
           <a
-            href="/marketplace"
+            href={detailBasePath}
             className="inline-flex items-center gap-2 text-sm font-semibold text-indigo-600 hover:text-indigo-700"
           >
             <ArrowLeft className="h-4 w-4" /> Back to Marketplace
@@ -1262,7 +1273,7 @@ export default function EnvironmentDetail({ params }: EnvironmentDetailProps) {
           The environment you are looking for isn't in our network yet. Browse other scenes or contact us to request a custom build.
         </p>
         <a
-          href="/marketplace"
+          href="/marketplace/scenes"
           className="mt-6 inline-flex rounded-full border border-slate-300 px-6 py-3 text-sm font-semibold text-slate-900"
         >
           Back to Marketplace
@@ -1293,14 +1304,14 @@ export default function EnvironmentDetail({ params }: EnvironmentDetailProps) {
         <meta name="description" content={scene.seo} />
         <meta name="robots" content="index, follow" />
         <meta property="og:type" content="product" />
-        <meta property="og:url" content={`https://tryblueprint.io/marketplace/${scene.slug}`} />
+        <meta property="og:url" content={`https://tryblueprint.io/marketplace/scenes/${scene.slug}`} />
         <meta property="og:title" content={`${scene.title} | Blueprint`} />
         <meta property="og:description" content={scene.seo} />
         <meta property="og:image" content={sceneImage} />
         <meta name="twitter:card" content="summary_large_image" />
         <meta name="twitter:title" content={`${scene.title} | Blueprint`} />
         <meta name="twitter:description" content={scene.seo} />
-        <link rel="canonical" href={`https://tryblueprint.io/marketplace/${scene.slug}`} />
+        <link rel="canonical" href={`https://tryblueprint.io/marketplace/scenes/${scene.slug}`} />
       </Helmet>
       <div className="mx-auto max-w-6xl space-y-12 px-4 pb-24 pt-16 sm:px-6">
         <header className="grid gap-10 lg:grid-cols-[1.2fr_0.8fr]">

--- a/client/src/pages/Environments.tsx
+++ b/client/src/pages/Environments.tsx
@@ -238,7 +238,7 @@ function PersonalizedWelcomeBanner({
 
 export default function Environments() {
   // --- State ---
-  const [, setLocation] = useLocation();
+  const [location, setLocation] = useLocation();
   const searchString = useSearch();
   const [checkoutStatus, setCheckoutStatus] = useState<"success" | "cancel" | null>(null);
 
@@ -275,6 +275,38 @@ export default function Environments() {
   >([]);
   const [sortOption, setSortOption] = useState<string>("newest");
   const [searchQuery, setSearchQuery] = useState("");
+
+  const tabType = useMemo<MarketplaceItemType | null>(() => {
+    if (location.startsWith("/marketplace/scenes")) {
+      return "scenes";
+    }
+    if (location.startsWith("/marketplace/datasets")) {
+      return "training";
+    }
+    return null;
+  }, [location]);
+
+  const basePath = useMemo(() => {
+    if (location.startsWith("/marketplace/scenes")) {
+      return "/marketplace/scenes";
+    }
+    if (location.startsWith("/marketplace/datasets")) {
+      return "/marketplace/datasets";
+    }
+    if (location.startsWith("/environments")) {
+      return "/environments";
+    }
+    return "/marketplace";
+  }, [location]);
+
+  const showTypeFilter = tabType === null;
+
+  useEffect(() => {
+    if (tabType) {
+      setItemTypeFilter(tabType);
+      setCurrentPage(1);
+    }
+  }, [tabType]);
 
   // --- Initialize filters from URL ---
   useEffect(() => {
@@ -340,7 +372,9 @@ export default function Environments() {
     }
 
     // Apply current state
-    if (itemTypeFilter !== "all") params.set("type", itemTypeFilter);
+    if (showTypeFilter && itemTypeFilter !== "all") {
+      params.set("type", itemTypeFilter);
+    }
     if (locationFilter) params.set("location", locationFilter);
     if (policyFilter) params.set("policy", policyFilter);
     if (sortOption !== "newest") params.set("sort", sortOption);
@@ -349,6 +383,9 @@ export default function Environments() {
 
     // Apply updates
     for (const [key, value] of Object.entries(updates)) {
+      if (!showTypeFilter && key === "type") {
+        continue;
+      }
       if (value === null) {
         params.delete(key);
       } else {
@@ -357,7 +394,7 @@ export default function Environments() {
     }
 
     const newSearch = params.toString();
-    setLocation(`/marketplace${newSearch ? `?${newSearch}` : ""}`, { replace: true });
+    setLocation(`${basePath}${newSearch ? `?${newSearch}` : ""}`, { replace: true });
   };
 
   // Filter change handlers with URL sync
@@ -413,7 +450,7 @@ export default function Environments() {
       // Clear the query param from URL without page reload
       params.delete("checkout");
       const newSearch = params.toString();
-      setLocation(`/marketplace${newSearch ? `?${newSearch}` : ""}`, { replace: true });
+      setLocation(`${basePath}${newSearch ? `?${newSearch}` : ""}`, { replace: true });
 
       // Auto-dismiss after 10 seconds for success, 8 for cancel
       const timeout = setTimeout(() => {
@@ -422,7 +459,7 @@ export default function Environments() {
 
       return () => clearTimeout(timeout);
     }
-  }, [searchString, setLocation]);
+  }, [basePath, searchString, setLocation]);
 
   // --- Logic ---
 
@@ -579,9 +616,56 @@ export default function Environments() {
     );
   };
 
+  const tabContent = useMemo(() => {
+    if (tabType === "scenes") {
+      return {
+        badge: "Scene Library",
+        title: "Scene Library",
+        subtitle:
+          "SimReady scenes built for robotics policy development. Each scene includes physics-accurate USD assets, articulation, collision meshes, and domain randomization.",
+        seoTitle: "Scene Library | Blueprint",
+        seoDescription:
+          "Browse SimReady scenes for robotics. Isaac-ready USD environments with physics, articulation, and task logic.",
+        canonicalUrl: "https://tryblueprint.io/marketplace/scenes",
+      };
+    }
+    if (tabType === "training") {
+      return {
+        badge: "Dataset Packs",
+        title: "Dataset Packs",
+        subtitle:
+          "Training-ready dataset packs with pre-generated trajectories, sensor streams, and annotations. Plug into your policy training pipeline quickly.",
+        seoTitle: "Dataset Packs | Blueprint",
+        seoDescription:
+          "Explore dataset packs for robotics training. Pre-generated trajectories, LeRobot-ready data, and Isaac-compatible formats.",
+        canonicalUrl: "https://tryblueprint.io/marketplace/datasets",
+      };
+    }
+    return {
+      badge: "Marketplace",
+      title: "Scene Library & Dataset Packs",
+      subtitle:
+        "SimReady scenes and training datasets for robotics policy development. Each item includes physics-accurate USD scenes with articulation, collision meshes, and domain randomization.",
+      seoTitle: "Marketplace | Blueprint - Scene Library & Dataset Packs",
+      seoDescription:
+        "Browse SimReady scenes and training datasets for robotics. Isaac-ready USD packages with physics, articulation, and task logic for policy training.",
+      canonicalUrl: "https://tryblueprint.io/marketplace",
+    };
+  }, [tabType]);
+
+  const seoItems = useMemo(() => {
+    if (tabType === "scenes") {
+      return allMarketplaceItems.filter((item) => item.type === "scene");
+    }
+    if (tabType === "training") {
+      return allMarketplaceItems.filter((item) => item.type === "training");
+    }
+    return allMarketplaceItems;
+  }, [allMarketplaceItems, tabType]);
+
   // --- Structured Data for SEO ---
   const structuredData = useMemo(() => {
-    const products = allMarketplaceItems.slice(0, 10).map((item) => ({
+    const products = seoItems.slice(0, 10).map((item) => ({
       "@type": "Product",
       name: item.data.title,
       description: item.data.description,
@@ -596,16 +680,16 @@ export default function Environments() {
     return {
       "@context": "https://schema.org",
       "@type": "CollectionPage",
-      name: "Blueprint Marketplace",
-      description: "SimReady scenes and training datasets for robotics. Isaac-ready USD packages with randomizers and task logic.",
-      url: "https://tryblueprint.io/marketplace",
+      name: tabContent.title,
+      description: tabContent.seoDescription,
+      url: tabContent.canonicalUrl,
       mainEntity: {
         "@type": "ItemList",
-        numberOfItems: allMarketplaceItems.length,
+        numberOfItems: seoItems.length,
         itemListElement: products,
       },
     };
-  }, [allMarketplaceItems]);
+  }, [seoItems, tabContent]);
 
   // --- Render ---
   return (
@@ -619,28 +703,28 @@ export default function Environments() {
       )}
 
       <Helmet>
-        <title>Marketplace | Blueprint - Scene Library & Dataset Packs</title>
+        <title>{tabContent.seoTitle}</title>
         <meta
           name="description"
-          content="Browse SimReady scenes and training datasets for robotics. Isaac-ready USD packages with physics, articulation, and task logic for policy training."
+          content={tabContent.seoDescription}
         />
         <meta name="robots" content="index, follow" />
         <meta property="og:type" content="website" />
-        <meta property="og:url" content="https://tryblueprint.io/marketplace" />
-        <meta property="og:title" content="Marketplace | Blueprint" />
+        <meta property="og:url" content={tabContent.canonicalUrl} />
+        <meta property="og:title" content={tabContent.seoTitle} />
         <meta
           property="og:description"
-          content="SimReady scenes and training datasets for robotics. Isaac-ready USD packages with physics and articulation."
+          content={tabContent.seoDescription}
         />
         <meta property="og:image" content="https://tryblueprint.io/images/Gemini_EnvironentsBanner.png" />
         <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:title" content="Marketplace | Blueprint" />
+        <meta name="twitter:title" content={tabContent.seoTitle} />
         <meta
           name="twitter:description"
-          content="SimReady scenes and datasets for robotics. Isaac-ready USD packages for policy training."
+          content={tabContent.seoDescription}
         />
         <meta name="twitter:image" content="https://tryblueprint.io/images/Gemini_EnvironentsBanner.png" />
-        <link rel="canonical" href="https://tryblueprint.io/marketplace" />
+        <link rel="canonical" href={tabContent.canonicalUrl} />
         <script type="application/ld+json">
           {JSON.stringify(structuredData)}
         </script>
@@ -654,18 +738,15 @@ export default function Environments() {
           <div className="space-y-6">
             <div className="inline-flex items-center gap-2 rounded-full border border-indigo-100 bg-indigo-50/50 px-3 py-1 text-xs font-medium uppercase tracking-wider text-indigo-600 backdrop-blur-sm">
               <Database className="h-3 w-3" />
-              Marketplace
+              {tabContent.badge}
             </div>
 
             <div className="max-w-4xl">
               <h1 className="text-4xl font-bold tracking-tight text-zinc-950 sm:text-5xl lg:text-6xl">
-                Scene Library & Dataset Packs
+                {tabContent.title}
               </h1>
               <p className="mt-6 max-w-2xl text-lg text-zinc-600">
-                SimReady scenes and training datasets for robotics policy development.
-                Each item includes physics-accurate USD scenes with articulation, collision
-                meshes, and domain randomization. Browse scenes for custom training pipelines
-                or grab dataset packs with pre-generated trajectories.
+                {tabContent.subtitle}
               </p>
             </div>
           </div>
@@ -762,26 +843,28 @@ export default function Environments() {
           </div>
 
           {/* Item Type Filter */}
-          <div className="border-b border-zinc-100 bg-zinc-50/50 px-6 py-4">
-            <div className="flex flex-wrap items-center gap-2">
-              <span className="text-xs font-bold uppercase tracking-widest text-zinc-400 mr-2">
-                Type:
-              </span>
-              {itemTypeOptions.map((option) => (
-                <button
-                  key={option.value}
-                  onClick={() => setItemTypeFilter(option.value)}
-                  className={`rounded-full border px-4 py-1.5 text-xs font-medium transition ${
-                    itemTypeFilter === option.value
-                      ? "border-indigo-600 bg-indigo-600 text-white"
-                      : "border-zinc-200 bg-white text-zinc-600 hover:border-zinc-300"
-                  }`}
-                >
-                  {option.label}
-                </button>
-              ))}
+          {showTypeFilter && (
+            <div className="border-b border-zinc-100 bg-zinc-50/50 px-6 py-4">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="text-xs font-bold uppercase tracking-widest text-zinc-400 mr-2">
+                  Type:
+                </span>
+                {itemTypeOptions.map((option) => (
+                  <button
+                    key={option.value}
+                    onClick={() => handleTypeFilterChange(option.value)}
+                    className={`rounded-full border px-4 py-1.5 text-xs font-medium transition ${
+                      itemTypeFilter === option.value
+                        ? "border-indigo-600 bg-indigo-600 text-white"
+                        : "border-zinc-200 bg-white text-zinc-600 hover:border-zinc-300"
+                    }`}
+                  >
+                    {option.label}
+                  </button>
+                ))}
+              </div>
             </div>
-          </div>
+          )}
 
           <div className="grid gap-px bg-zinc-100 md:grid-cols-3">
             {/* Location Filter */}

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -786,7 +786,7 @@ export default function Home() {
             </p>
           </div>
           <a
-            href="/marketplace"
+            href="/marketplace/datasets"
             className="group flex items-center gap-1 text-sm font-semibold text-indigo-600 hover:text-indigo-700"
           >
             Explore full marketplace

--- a/client/src/pages/Pricing.tsx
+++ b/client/src/pages/Pricing.tsx
@@ -134,7 +134,7 @@ export default function Pricing() {
                 Each listing includes pricing, variations, and episode counts.
               </p>
               <a
-                href="/marketplace"
+                href="/marketplace/scenes"
                 className="inline-flex items-center gap-2 text-sm font-semibold text-zinc-900 hover:text-zinc-700"
               >
                 Browse Marketplace
@@ -185,7 +185,7 @@ export default function Pricing() {
                       <ChevronRight className="ml-1 h-4 w-4" />
                     </a>
                     <a
-                      href="/marketplace"
+                      href="/marketplace/scenes"
                       className="inline-flex items-center justify-center rounded-xl border border-zinc-200 bg-white px-6 py-3 text-sm font-semibold text-zinc-900 transition hover:bg-zinc-50"
                     >
                       Browse Scenes
@@ -439,7 +439,7 @@ export default function Pricing() {
                   Talk to Sales
                 </a>
                 <a
-                  href="/marketplace"
+                  href="/marketplace/scenes"
                   className="inline-flex items-center justify-center rounded-xl border border-zinc-200 bg-white px-8 py-3 text-sm font-semibold text-zinc-900 transition hover:bg-zinc-50"
                 >
                   Browse Marketplace


### PR DESCRIPTION
### Motivation

- Split the single Marketplace entry into two first-class tabs (Scenes / Datasets) so users can land directly on a focused view and links keep them on the correct context. 
- Keep backwards compatibility for the existing `/marketplace` and `/environments` paths while making filters, hero copy, and SEO reflect the active tab.

### Description

- Updated header navigation and active-state logic in `client/src/components/site/Header.tsx` to expose `Scenes` and `Datasets` tabs and treat marketplace routes as tab-aware active links. 
- Added explicit routes in `client/src/main.tsx` for `/marketplace/scenes`, `/marketplace/datasets` and their `:slug` detail variants while preserving the existing `/marketplace` route. 
- Made `client/src/pages/Environments.tsx` tab-aware by reading `location` with `useLocation()`, setting a `tabType`/`basePath`, defaulting `itemTypeFilter` based on the path, hiding the global "Type" pill row for tab-scoped views, and routing filter sync to the tab `basePath`. 
- Scoped hero/title/description/structured-data and canonical/OG/Twitter metadata to the active tab in `Environments.tsx` so SEO and header copy match `Scenes` vs `Datasets`. 
- Kept detail and CTA links on the correct tab by changing card/detail paths and checkout return paths in `client/src/components/site/MarketplaceCard.tsx`, `client/src/components/site/SceneCard.tsx`, and `client/src/pages/EnvironmentDetail.tsx`. 
- Updated marketing/internal links that should point to a specific tab (examples in `client/src/pages/Home.tsx` and `client/src/pages/Pricing.tsx`).

### Testing

- Attempted to start the dev server with `npm run dev` to smoke-test the pages, but the server failed to start due to a logger/transport error: "unable to determine transport target for \"pino-pretty\"" (dev server failed). 
- Attempted a browser smoke-run (Playwright) against `http://127.0.0.1:4173/marketplace/scenes`, but navigation failed because the server was not responding (no screenshot captured). 
- No automated unit or E2E test suite completed against these changes because the local dev server did not start; further validation required once the logging/transport issue is resolved.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696956cc2e8483299cb47777fbd24d1e)