### PR TITLE
Prefill contact form from auth and convert inputs to controlled state

### DIFF
--- a/client/src/components/site/ContactForm.tsx
+++ b/client/src/components/site/ContactForm.tsx
@@ -1,6 +1,7 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { CheckCircle2 } from "lucide-react";
 import { withCsrfHeader } from "@/lib/csrf";
+import { useAuth } from "@/contexts/AuthContext";
 
 const budgetRanges = [
   "<$50K",
@@ -18,10 +19,46 @@ const offerings = [
 ] as const;
 
 export function ContactForm() {
+  const { currentUser, userData } = useAuth();
   const [status, setStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
   const [message, setMessage] = useState("");
   const [selectedBudget, setSelectedBudget] = useState<string>("");
   const [selectedOfferings, setSelectedOfferings] = useState<string[]>([]);
+  const [firstName, setFirstName] = useState("");
+  const [lastName, setLastName] = useState("");
+  const [company, setCompany] = useState("");
+  const [jobTitle, setJobTitle] = useState("");
+  const [email, setEmail] = useState("");
+
+  useEffect(() => {
+    const displayName = userData?.name || currentUser?.displayName || "";
+    const trimmedName = displayName.trim();
+    const [defaultFirstName, ...restName] = trimmedName ? trimmedName.split(/\s+/) : [];
+    const defaultLastName = restName.join(" ");
+    const defaultCompany = userData?.company || userData?.organizationName || "";
+    const defaultJobTitle = userData?.jobTitle || "";
+    const defaultEmail = currentUser?.email || "";
+
+    if (!firstName && defaultFirstName) {
+      setFirstName(defaultFirstName);
+    }
+
+    if (!lastName && defaultLastName) {
+      setLastName(defaultLastName);
+    }
+
+    if (!company && defaultCompany) {
+      setCompany(defaultCompany);
+    }
+
+    if (!jobTitle && defaultJobTitle) {
+      setJobTitle(defaultJobTitle);
+    }
+
+    if (!email && defaultEmail) {
+      setEmail(defaultEmail);
+    }
+  }, [company, currentUser, email, firstName, jobTitle, lastName, userData]);
 
   const handleOfferingToggle = (value: string) => {
     setSelectedOfferings((prev) =>
@@ -93,6 +130,11 @@ export function ContactForm() {
 
       setStatus("success");
       form.reset();
+      setFirstName("");
+      setLastName("");
+      setCompany("");
+      setJobTitle("");
+      setEmail("");
       setSelectedBudget("");
       setSelectedOfferings([]);
       setMessage("");
@@ -140,6 +182,8 @@ export function ContactForm() {
             name="firstName"
             placeholder="First name*"
             required
+            value={firstName}
+            onChange={(event) => setFirstName(event.target.value)}
             className="w-full rounded-xl border border-zinc-200 bg-zinc-50 px-4 py-3 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-indigo-500 focus:bg-white focus:outline-none focus:ring-1 focus:ring-indigo-500"
           />
         </div>
@@ -151,6 +195,8 @@ export function ContactForm() {
             name="lastName"
             placeholder="Last name*"
             required
+            value={lastName}
+            onChange={(event) => setLastName(event.target.value)}
             className="w-full rounded-xl border border-zinc-200 bg-zinc-50 px-4 py-3 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-indigo-500 focus:bg-white focus:outline-none focus:ring-1 focus:ring-indigo-500"
           />
         </div>
@@ -162,6 +208,8 @@ export function ContactForm() {
             name="company"
             placeholder="Company name*"
             required
+            value={company}
+            onChange={(event) => setCompany(event.target.value)}
             className="w-full rounded-xl border border-zinc-200 bg-zinc-50 px-4 py-3 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-indigo-500 focus:bg-white focus:outline-none focus:ring-1 focus:ring-indigo-500"
           />
         </div>
@@ -172,6 +220,8 @@ export function ContactForm() {
             type="text"
             name="jobTitle"
             placeholder="Job title*"
+            value={jobTitle}
+            onChange={(event) => setJobTitle(event.target.value)}
             className="w-full rounded-xl border border-zinc-200 bg-zinc-50 px-4 py-3 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-indigo-500 focus:bg-white focus:outline-none focus:ring-1 focus:ring-indigo-500"
           />
         </div>
@@ -184,6 +234,8 @@ export function ContactForm() {
           name="email"
           placeholder="Work email*"
           required
+          value={email}
+          onChange={(event) => setEmail(event.target.value)}
           className="w-full rounded-xl border border-zinc-200 bg-zinc-50 px-4 py-3 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-indigo-500 focus:bg-white focus:outline-none focus:ring-1 focus:ring-indigo-500"
         />
       </div>


### PR DESCRIPTION
### Motivation
- Initialize contact form fields from authenticated profile data so the form is prefilled for signed-in users. 
- Ensure defaults do not overwrite user edits after they start typing by only applying auth defaults when fields are empty. 

### Description
- Imported `useAuth` and `useEffect`, read `currentUser` and `userData`, and added controlled state for `firstName`, `lastName`, `company`, `jobTitle`, and `email` in `client/src/components/site/ContactForm.tsx`. 
- Added a `useEffect` to compute defaults (prefer `userData.name` or `currentUser.displayName` for name, split into first/last; prefer `currentUser.email` for email; prefer `userData.company` or `userData.organizationName` for company; use `userData.jobTitle` for job title) and set them only when the corresponding field is empty. 
- Wired the name/company/job title/email inputs to the new controlled state with `value` and `onChange`, and cleared the controlled fields on successful submit. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a6e61e4608329aa7ef71062e62fe3)