### PR TITLE
Add “Request Exclusive Dataset” CTAs to marketplace cards, listing toolbar, and detail pages

### DIFF
--- a/client/src/components/site/MarketplaceCard.tsx
+++ b/client/src/components/site/MarketplaceCard.tsx
@@ -47,6 +47,7 @@ export function MarketplaceCard({ item, type }: MarketplaceCardProps) {
   const description = item.description;
   const thumbnail = isDataset ? dataset!.heroImage : isTraining ? training!.heroImage : scene!.thumbnail;
   const tags = item.tags;
+  const exclusiveDatasetUrl = `/contact?interest=exclusive-dataset&product=${encodeURIComponent(slug)}`;
 
   const handleCheckout = useCallback(
     async (event?: MouseEvent<HTMLButtonElement>) => {
@@ -454,6 +455,26 @@ export function MarketplaceCard({ item, type }: MarketplaceCardProps) {
             </>
           )}
         </button>
+        {(isDataset || isTraining) && (
+          <a
+            href={exclusiveDatasetUrl}
+            onClick={(event) => event.stopPropagation()}
+            className="mt-2 flex w-full items-center justify-center gap-2 rounded-xl border border-zinc-200 bg-zinc-50 px-4 py-2.5 text-xs font-semibold text-zinc-900 transition hover:bg-zinc-100"
+          >
+            Request Exclusive Dataset
+            <ChevronRight className="h-3.5 w-3.5" />
+          </a>
+        )}
+        {isScene && (
+          <a
+            href={exclusiveDatasetUrl}
+            onClick={(event) => event.stopPropagation()}
+            className="mt-3 inline-flex items-center justify-center gap-1 text-[11px] font-semibold text-zinc-500 hover:text-zinc-700 transition-colors"
+          >
+            Request Exclusive Dataset
+            <ChevronRight className="h-3 w-3" />
+          </a>
+        )}
       </div>
     </article>
   );

--- a/client/src/pages/EnvironmentDetail.tsx
+++ b/client/src/pages/EnvironmentDetail.tsx
@@ -314,6 +314,7 @@ export default function EnvironmentDetail({ params }: EnvironmentDetailProps) {
     const bundlePrice = marketplaceScene!.bundlePrice || marketplaceScene!.price;
     const sceneOnlyPrice = marketplaceScene!.sceneOnlyPrice || Math.round(marketplaceScene!.price * 0.45);
     const episodesOnlyPrice = marketplaceScene!.episodesOnlyPrice || Math.round(marketplaceScene!.price * 0.65);
+    const exclusiveDatasetUrl = `/contact?interest=exclusive-dataset&product=${encodeURIComponent(marketplaceItem.slug)}`;
 
     // Calculate savings for bundle
     const separateTotal = sceneOnlyPrice + episodesOnlyPrice;
@@ -733,6 +734,13 @@ export default function EnvironmentDetail({ params }: EnvironmentDetailProps) {
                   ? "Redirecting..."
                   : `Buy Now — $${totalPrice?.toLocaleString()}`}
               </button>
+              <a
+                href={exclusiveDatasetUrl}
+                className="mt-3 flex w-full items-center justify-center gap-2 rounded-xl border border-zinc-200 bg-zinc-50 px-4 py-2.5 text-xs font-semibold text-zinc-900 transition hover:bg-zinc-100"
+              >
+                Request Exclusive Dataset
+                <ChevronRight className="h-3.5 w-3.5" />
+              </a>
             </div>
 
             {/* What's Included Card */}
@@ -907,6 +915,7 @@ export default function EnvironmentDetail({ params }: EnvironmentDetailProps) {
       day: "numeric",
       year: "numeric",
     }).format(new Date(trainingDataset.releaseDate));
+    const exclusiveDatasetUrl = `/contact?interest=exclusive-dataset&product=${encodeURIComponent(trainingDataset.slug)}`;
 
     const trainingProductStructuredData = {
       "@context": "https://schema.org",
@@ -1369,6 +1378,13 @@ export default function EnvironmentDetail({ params }: EnvironmentDetailProps) {
                         selectedExclusivity
                       ).toLocaleString()}`}
                 </button>
+                <a
+                  href={exclusiveDatasetUrl}
+                  className="mt-3 flex w-full items-center justify-center gap-2 rounded-xl border border-zinc-200 bg-zinc-50 px-4 py-2.5 text-xs font-semibold text-zinc-900 transition hover:bg-zinc-100"
+                >
+                  Request Exclusive Dataset
+                  <ChevronRight className="h-3.5 w-3.5" />
+                </a>
               </div>
 
               <div className="rounded-3xl border border-zinc-200 bg-white p-5 shadow-sm space-y-3">

--- a/client/src/pages/Environments.tsx
+++ b/client/src/pages/Environments.tsx
@@ -811,34 +811,44 @@ export default function Environments() {
         <section className="rounded-3xl border border-zinc-200 bg-white/80 shadow-sm backdrop-blur-xl">
           <div className="border-b border-zinc-100 p-6">
             <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-              {/* Search */}
-              <div className="relative w-full md:max-w-sm">
-                <Search className="absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-zinc-400" />
-                <input
-                  type="search"
-                  value={searchQuery}
-                  onChange={(event) => setSearchQuery(event.target.value)}
-                  placeholder="Search name, policy, or object..."
-                  className="w-full rounded-xl border border-zinc-200 bg-zinc-50 py-2.5 pl-10 pr-4 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-zinc-900 focus:outline-none focus:ring-1 focus:ring-zinc-900"
-                />
+              <div className="flex flex-col gap-4 md:flex-row md:items-center md:gap-4 md:flex-1">
+                {/* Search */}
+                <div className="relative w-full md:max-w-sm">
+                  <Search className="absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-zinc-400" />
+                  <input
+                    type="search"
+                    value={searchQuery}
+                    onChange={(event) => setSearchQuery(event.target.value)}
+                    placeholder="Search name, policy, or object..."
+                    className="w-full rounded-xl border border-zinc-200 bg-zinc-50 py-2.5 pl-10 pr-4 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-zinc-900 focus:outline-none focus:ring-1 focus:ring-zinc-900"
+                  />
+                </div>
+
+                {/* Sort Options */}
+                <div className="flex gap-1 rounded-lg border border-zinc-200 p-1">
+                  {sortOptions.map((option) => (
+                    <button
+                      key={option.value}
+                      onClick={() => setSortOption(option.value)}
+                      className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+                        sortOption === option.value
+                          ? "bg-zinc-900 text-white shadow-sm"
+                          : "text-zinc-600 hover:bg-zinc-100"
+                      }`}
+                    >
+                      {option.label}
+                    </button>
+                  ))}
+                </div>
               </div>
 
-              {/* Sort Options */}
-              <div className="flex gap-1 rounded-lg border border-zinc-200 p-1">
-                {sortOptions.map((option) => (
-                  <button
-                    key={option.value}
-                    onClick={() => setSortOption(option.value)}
-                    className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
-                      sortOption === option.value
-                        ? "bg-zinc-900 text-white shadow-sm"
-                        : "text-zinc-600 hover:bg-zinc-100"
-                    }`}
-                  >
-                    {option.label}
-                  </button>
-                ))}
-              </div>
+              <a
+                href="/contact?interest=exclusive-dataset"
+                className="inline-flex items-center justify-center gap-2 rounded-xl bg-zinc-900 px-4 py-2.5 text-xs font-semibold text-white transition-colors hover:bg-indigo-600"
+              >
+                Request Exclusive Dataset
+                <ArrowRight className="h-3.5 w-3.5" />
+              </a>
             </div>
           </div>
 


### PR DESCRIPTION
### Motivation
- Provide an easy way for visitors to request exclusive/dedicated dataset offerings via the existing contact flow at `/contact?interest=exclusive-dataset` and include `product=<slug>` when available.
- Surface the CTA in recommended places: marketplace listing cards, the marketplace listing toolbar, and product detail pages (both scenes and dataset packs).
- Keep visual consistency by reusing existing CTA/button patterns used for checkout and enterprise CTAs.

### Description
- Added product-aware `exclusiveDatasetUrl` links (`/contact?interest=exclusive-dataset&product=<slug>`) and CTAs to the marketplace card component at `client/src/components/site/MarketplaceCard.tsx`, showing a full button for dataset/training items and a smaller inline link for scenes.
- Added a toolbar CTA to the marketplace listing page in `client/src/pages/Environments.tsx` to route users to `/contact?interest=exclusive-dataset` from the filters/search area.
- Placed `Request Exclusive Dataset` CTAs near the checkout controls on scene detail and dataset pack detail pages in `client/src/pages/EnvironmentDetail.tsx`, including the `product` query parameter when available.
- Reused existing styles and icons (button classes, `ChevronRight`/`ArrowRight`) to match current CTA visuals.

### Testing
- Attempted to start the dev server with `npm run dev`, but the server failed to initialize due to a missing `pino-pretty` transport error, so the app could not be run locally (dev server error: "unable to determine transport target for \"pino-pretty\"").
- Attempted a headless screenshot using Playwright against the local dev server, but the navigation failed with `net::ERR_EMPTY_RESPONSE` because the server was not running.
- No automated unit or integration tests were run against these changes (no tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a6e5c4f6483299a926e10579a43b1)