### PR TITLE
Hide hybrid license preview on dataset cards

### DIFF
--- a/client/src/components/site/MarketplaceCard.tsx
+++ b/client/src/components/site/MarketplaceCard.tsx
@@ -319,20 +319,22 @@ export function MarketplaceCard({ item, type }: MarketplaceCardProps) {
           )}
 
           {/* License Tier Preview - Hybrid Marketplace */}
-          <div className="mt-3 flex items-center justify-between rounded-lg border border-zinc-100 bg-zinc-50 px-3 py-2">
-            <div className="flex items-center gap-3">
-              <div className="flex items-center gap-1.5 text-[10px] text-zinc-500">
-                <GraduationCap className="h-3 w-3" />
-                <span>From ${calculateLicensePrice(isDataset ? (dataset!.bundlePrice || 0) : isTraining ? training!.price : (scene!.bundlePrice || scene!.price), 'research').toLocaleString()}</span>
+          {!isDataset && (
+            <div className="mt-3 flex items-center justify-between rounded-lg border border-zinc-100 bg-zinc-50 px-3 py-2">
+              <div className="flex items-center gap-3">
+                <div className="flex items-center gap-1.5 text-[10px] text-zinc-500">
+                  <GraduationCap className="h-3 w-3" />
+                  <span>From ${calculateLicensePrice(isDataset ? (dataset!.bundlePrice || 0) : isTraining ? training!.price : (scene!.bundlePrice || scene!.price), 'research').toLocaleString()}</span>
+                </div>
+                <div className="h-3 w-px bg-zinc-200" />
+                <div className="flex items-center gap-1.5 text-[10px] font-medium text-indigo-600">
+                  <Building2 className="h-3 w-3" />
+                  <span>Commercial</span>
+                </div>
               </div>
-              <div className="h-3 w-px bg-zinc-200" />
-              <div className="flex items-center gap-1.5 text-[10px] font-medium text-indigo-600">
-                <Building2 className="h-3 w-3" />
-                <span>Commercial</span>
-              </div>
+              <ProvenanceBadge />
             </div>
-            <ProvenanceBadge />
-          </div>
+          )}
         </div>
 
         {/* Stats Grid */}


### PR DESCRIPTION
### Motivation
- Prevent dataset marketplace cards from showing the generic hybrid license preview in addition to the dataset-specific license preview so dataset cards only render a single license row while keeping the generic preview for scene/environment (and training) cards.

### Description
- Gate the hybrid marketplace license preview in `client/src/components/site/MarketplaceCard.tsx` behind `!isDataset` so the generic preview is not rendered for datasets.

### Testing
- Attempted to start the dev server with `npm run dev` to validate the UI, but the server failed to start due to a missing `pino-pretty` transport, so no automated UI tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a7233ed8883299a332ee20427f889)