### PR TITLE
Improve Request Scene button copy

### DIFF
--- a/client/src/components/site/Header.tsx
+++ b/client/src/components/site/Header.tsx
@@ -88,7 +88,7 @@ export function Header() {
             href="/contact"
             className="rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-slate-700"
           >
-            Request a Scene
+            Request Data
           </a>
           {!currentUser ? (
             <>
@@ -159,7 +159,7 @@ export function Header() {
               className="mt-2 rounded-full bg-slate-900 px-4 py-2 text-center text-white"
               onClick={() => setOpen(false)}
             >
-              Request a Scene
+              Request Data
             </a>
             {!currentUser ? (
               <>


### PR DESCRIPTION
Changed 'Request a Scene' to 'Request Data' to better reflect the contact form's broader purpose. The form handles inquiries for scenes, datasets, synthetic data, and evaluation services - not just scenes.