### PR TITLE
Replace em dashes in copy with clearer separators

### DIFF
--- a/client/public/llms-full.txt
+++ b/client/public/llms-full.txt
@@ -1,4 +1,4 @@
-# Blueprint — long-form overview
+# Blueprint: long-form overview
 
 ## Product overview
 Blueprint is a robotics data platform for creating, delivering, and validating simulation-ready assets. It provides SimReady 3D environments, datasets, and evaluation tooling so robotics teams can train, benchmark, and deploy AI systems with confidence. Blueprint also offers on-site capture and custom scene production to transform real locations into reusable digital twins for simulation.
@@ -31,7 +31,7 @@ Blueprint is a robotics data platform for creating, delivering, and validating s
 ## FAQs (canonical)
 - **What is Blueprint?** A robotics data platform for building simulation-ready digital twins and datasets, delivering the assets, data, and tools needed to train and validate AI systems.
 - **How are assets delivered?** Through the Marketplace and custom capture projects, with standardized specs for simulation pipelines.
-- **Do you offer custom scenes?** Yes—teams can request on-site capture and custom SimReady environments.
+- **Do you offer custom scenes?** Yes, teams can request on-site capture and custom SimReady environments.
 - **Who is Blueprint for?** Robotics teams, simulation engineers, and organizations building AI systems that need high-quality 3D environments and data.
 - **How do I get started?** Browse the Marketplace, review documentation, and contact the team for tailored datasets or services.
 
@@ -47,4 +47,3 @@ Blueprint is a robotics data platform for creating, delivering, and validating s
 - /careers
 - /privacy
 - /terms
-

--- a/client/src/components/Footer.jsx
+++ b/client/src/components/Footer.jsx
@@ -46,7 +46,7 @@ export default function Footer() {
             </div>
             <p className="text-slate-400 max-w-xl">
               Simulation data that complements your real-world capture. Physics-accurate
-              environments with domain randomization and sim2real validation—designed to
+              environments with domain randomization and sim2real validation, designed to
               boost your models by up to 38%.
             </p>
             <div className="flex items-center gap-4 mt-5 text-slate-400">

--- a/client/src/components/ThreeViewer.tsx
+++ b/client/src/components/ThreeViewer.tsx
@@ -2112,7 +2112,7 @@ const ThreeViewer = React.memo(
                 alphaTest: 0.1,
               });
 
-              // 6) Same PlaneGeometry—UVs stay perfect
+              // 6) Same PlaneGeometry - UVs stay perfect
               const geometry = new THREE.PlaneGeometry(planeWidth, planeHeight);
               const imagePlane = new THREE.Mesh(geometry, material);
 

--- a/client/src/components/pilotCopy.ts
+++ b/client/src/components/pilotCopy.ts
@@ -4,7 +4,7 @@ export type FAQ = { q: string; a: string };
 export const PILOT_FAQ: FAQ[] = [
   {
     q: "What is Blueprint in one sentence?",
-    a: "It’s an AI glasses concierge for your physical space—scan a QR code, and visitors instantly get guided answers, stories, and offers hands-free.",
+    a: "It’s an AI glasses concierge for your physical space, so scan a QR code and visitors instantly get guided answers, stories, and offers hands-free.",
   },
   {
     q: "What does the pilot cost?",
@@ -20,7 +20,7 @@ export const PILOT_FAQ: FAQ[] = [
   },
   {
     q: "What do you need from us?",
-    a: "Access for mapping, some basic business info, and your feedback after demo day. We handle the rest—design, setup, and analytics.",
+    a: "Access for mapping, some basic business info, and your feedback after demo day. We handle the rest, including design, setup, and analytics.",
   },
   {
     q: "Is the AR experience live for more than a day?",

--- a/client/src/components/sections/Hero.jsx
+++ b/client/src/components/sections/Hero.jsx
@@ -23,7 +23,7 @@ export default function Hero({ onPrimaryCta }) {
       k: "pitch",
       pre: "The simple pitch:",
       highlight: "Turn your location into an AI-powered place people love.",
-      sub: "Blueprint adds a ‘glasses concierge’ that answers questions, gives directions, and triggers tasks—without you building an app.",
+      sub: "Blueprint adds a ‘glasses concierge’ that answers questions, gives directions, and triggers tasks without you building an app.",
     },
     {
       k: "how",
@@ -35,7 +35,7 @@ export default function Hero({ onPrimaryCta }) {
       k: "why",
       pre: "Why now:",
       highlight: "AI + glasses are moving from novelty to normal.",
-      sub: "Be ready as staff and visitors start wearing them on-site—Blueprint makes it easy to start, learn, and scale.",
+      sub: "Be ready as staff and visitors start wearing them on-site, and Blueprint makes it easy to start, learn, and scale.",
     },
     {
       k: "compat",
@@ -289,7 +289,7 @@ export default function Hero({ onPrimaryCta }) {
 //       k: "what",
 //       pre: "Blueprint in one line:",
 //       highlight:
-//         "Turn your space into a guided, interactive AR layer—just by scanning a QR code.",
+//         "Turn your space into a guided, interactive AR layer, just by scanning a QR code.",
 //       sub: "Guests use their headsets (or smart glasses). No app to install. No hardware to buy.",
 //     },
 //     {
@@ -486,7 +486,7 @@ export default function Hero({ onPrimaryCta }) {
 //       k: "what",
 //       pre: "Blueprint in one line:",
 //       highlight:
-//         "Turn your space into a guided, interactive AR layer—just by scanning a QR code.",
+//         "Turn your space into a guided, interactive AR layer, just by scanning a QR code.",
 //       sub: "Guests use their headsets (or smart glasses). No app to install. No hardware to buy.",
 //     },
 //     {

--- a/client/src/components/sections/LocationShowcase.jsx
+++ b/client/src/components/sections/LocationShowcase.jsx
@@ -175,7 +175,7 @@ export default function LocationShowcase() {
             </span>
           </h2>
           <p className="mt-2 text-slate-300 max-w-2xl mx-auto text-sm md:text-base">
-            Scrub to compare before/after — how visitors experience your space
+            Scrub to compare before/after to see how visitors experience your space
             with AI overlays, guidance, and bite-size info.
           </p>
         </div>
@@ -333,7 +333,7 @@ export default function LocationShowcase() {
             onClick={scrollToContact}
             className="rounded-xl bg-gradient-to-r from-emerald-500 to-cyan-600 text-white border-0 h-12 px-6 hover:shadow-2xl hover:scale-[1.02] transition"
           >
-            Join the AI glasses pilot — Free Setup
+            Join the AI glasses pilot, free setup
           </Button>
         </div>
       </div>
@@ -518,7 +518,7 @@ export default function LocationShowcase() {
 //             </span>
 //           </h2>
 //           <p className="mt-2 text-slate-300 max-w-2xl mx-auto text-sm md:text-base">
-//             Scrub to compare before/after — how visitors experience your space
+//             Scrub to compare before/after to see how visitors experience your space
 //             with AR overlays, guidance, and bite-size info.
 //           </p>
 //         </div>
@@ -676,7 +676,7 @@ export default function LocationShowcase() {
 //             onClick={scrollToContact}
 //             className="rounded-xl bg-gradient-to-r from-emerald-500 to-cyan-600 text-white border-0 h-12 px-6 hover:shadow-2xl hover:scale-[1.02] transition"
 //           >
-//             Join the Durham Pilot — Free Setup
+//             Join the Durham Pilot, free setup
 //           </Button>
 //         </div>
 //       </div>

--- a/client/src/components/site/ApplyForm.tsx
+++ b/client/src/components/site/ApplyForm.tsx
@@ -128,7 +128,7 @@
 //           aria-describedby={`${portfolioId}-hint`}
 //         />
 //         <span id={`${portfolioId}-hint`} className="text-xs text-slate-500">
-//           Share your best work—reels, breakdowns, or project sites.
+//           Share your best work, including reels, breakdowns, or project sites.
 //         </span>
 //       </label>
 //       <label className="flex flex-col gap-2 text-sm text-slate-600" htmlFor={resumeId}>

--- a/client/src/components/site/Footer.tsx
+++ b/client/src/components/site/Footer.tsx
@@ -19,7 +19,7 @@ export function Footer() {
             Blueprint
           </a>
           <p className="text-sm text-slate-500">
-            Complete robotics data platform with SimReady scenes, policy evaluation, and $320k+ in premium analytics—all included by default.
+            Complete robotics data platform with SimReady scenes, policy evaluation, and $320k+ in premium analytics, all included by default.
           </p>
         </div>
         <nav className="grid flex-1 grid-cols-2 gap-3 text-sm text-slate-600 sm:grid-cols-3">

--- a/client/src/pages/BusinessSignUpFlow.tsx
+++ b/client/src/pages/BusinessSignUpFlow.tsx
@@ -1,4 +1,4 @@
-// BusinessSignUpFlow — Multi-step business signup with context gathering
+// BusinessSignUpFlow - Multi-step business signup with context gathering
 // Based on SIGNUP_ONBOARDING_SPEC.md
 //
 // 3-step flow:

--- a/client/src/pages/EnvironmentDetail.tsx
+++ b/client/src/pages/EnvironmentDetail.tsx
@@ -732,7 +732,7 @@ export default function EnvironmentDetail({ params }: EnvironmentDetailProps) {
                 <ShoppingCart className="h-4 w-4" />
                 {isRedirecting
                   ? "Redirecting..."
-                  : `Buy Now — $${totalPrice?.toLocaleString()}`}
+                  : `Buy Now - $${totalPrice?.toLocaleString()}`}
               </button>
               <a
                 href={exclusiveDatasetUrl}
@@ -1368,7 +1368,7 @@ export default function EnvironmentDetail({ params }: EnvironmentDetailProps) {
                   <ShoppingCart className="h-4 w-4" />
                   {isRedirecting
                     ? "Redirecting..."
-                    : `Buy Now — $${calculateTotalPrice(
+                    : `Buy Now - $${calculateTotalPrice(
                         selectedTier === 'basic'
                           ? (trainingDataset.basicPrice || Math.round(trainingDataset.price * 0.4))
                           : selectedTier === 'premium'
@@ -1593,7 +1593,7 @@ export default function EnvironmentDetail({ params }: EnvironmentDetailProps) {
                     </span>
                   </div>
                   <p className="mt-2 text-xs text-slate-500">
-                    Axis {interaction.axis || "—"} • Limits {interaction.limits || "N/A"}
+                    Axis {interaction.axis || "N/A"} • Limits {interaction.limits || "N/A"}
                   </p>
                   {interaction.notes ? (
                     <p className="mt-2 text-xs text-slate-500">{interaction.notes}</p>

--- a/client/src/pages/Evals.tsx
+++ b/client/src/pages/Evals.tsx
@@ -211,9 +211,9 @@ export default function Evals() {
 
               <p className="mx-auto max-w-2xl text-lg text-zinc-600">
                 Send us your policy. We'll run it through our{" "}
-                <strong>reserved benchmark scenes</strong> — environments we
-                don't sell as data — and tell you how it performs on tasks like
-                picking objects, opening doors, and organizing spaces.
+                <strong>reserved benchmark scenes</strong>, which we don't sell
+                as data, and tell you how it performs on tasks like picking
+                objects, opening doors, and organizing spaces.
               </p>
 
               <div className="flex flex-col gap-4 sm:flex-row sm:justify-center pt-4">
@@ -244,8 +244,8 @@ export default function Evals() {
                   </div>
                   <h3 className="font-semibold text-zinc-900">Reserved Scenes</h3>
                   <p className="text-sm text-zinc-600">
-                    Our benchmark environments aren't sold as training data — no
-                    risk of overfitting to our test set.
+                    Our benchmark environments aren't sold as training data, so
+                    there is no risk of overfitting to our test set.
                   </p>
                 </div>
                 <div className="text-center space-y-3">
@@ -387,8 +387,8 @@ export default function Evals() {
                 </h2>
                 <p className="mt-3 text-zinc-400 max-w-xl mx-auto">
                   Our reserved evaluation scenes span multiple domains. These
-                  environments are exclusively for benchmarking — we don't sell
-                  them as training data.
+                  environments are exclusively for benchmarking, and we don't
+                  sell them as training data.
                 </p>
               </div>
 

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -78,8 +78,8 @@
 //             </h1>
 //             <p className="max-w-xl text-lg text-slate-600">
 //               High-fidelity scenes, physics-clean assets, delivered fast. Pick
-//               from our synthetic marketplace—new datasets publish daily with
-//               frames, randomizers, and plug-and-play USD—or send us to your
+//               from our synthetic marketplace, where new datasets publish daily with
+//               frames, randomizers, and plug-and-play USD, or send us to your
 //               actual site and we’ll return a SimReady digital twin tuned to your
 //               deployment stack. Either path keeps labs out of DCC tools so they
 //               can focus on training and proving ROI sooner.
@@ -581,10 +581,10 @@ function DotPattern() {
 }
 
 const heroDescriptionWithCapture =
-  "SimReady scenes, expert trajectories, and standardized benchmarks—plus $320k+ in premium analytics included. Everything you need to train, evaluate, and deploy robotic policies that transfer to the real world.";
+  "SimReady scenes, expert trajectories, and standardized benchmarks, plus $320k+ in premium analytics included. Everything you need to train, evaluate, and deploy robotic policies that transfer to the real world.";
 
 const heroDescriptionWithoutCapture =
-  "SimReady scenes, expert trajectories, and standardized benchmarks—plus $320k+ in premium analytics included. Everything you need to train, evaluate, and deploy robotic policies that transfer to the real world.";
+  "SimReady scenes, expert trajectories, and standardized benchmarks, plus $320k+ in premium analytics included. Everything you need to train, evaluate, and deploy robotic policies that transfer to the real world.";
 
 const facilitySupportCopy = SHOW_REAL_WORLD_CAPTURE
   ? "Need exact facility matching? Request a custom SimReady scene built from your specifications. We'll deliver a physics-accurate environment with Isaac Lab configs and QA validation."

--- a/client/src/pages/Learn.tsx
+++ b/client/src/pages/Learn.tsx
@@ -31,7 +31,7 @@ const glossaryTerms = [
   {
     term: "Sim2Real Transfer",
     definition:
-      "The process of transferring a policy or model trained in simulation to a real-world robot. Success depends on how well the simulation matches reality—including physics accuracy, visual fidelity, and sensor noise modeling.",
+      "The process of transferring a policy or model trained in simulation to a real-world robot. Success depends on how well the simulation matches reality, including physics accuracy, visual fidelity, and sensor noise modeling.",
     category: "Training",
     icon: <ArrowRight className="h-5 w-5" />,
   },
@@ -228,7 +228,7 @@ export default function Learn() {
                 </h2>
                 <p className="mt-4 text-lg text-zinc-600 leading-relaxed">
                   The most successful robotics teams don't choose between simulation and
-                  real-world data—they use both. Simulation provides the scale and diversity
+                  real-world data, and they use both. Simulation provides the scale and diversity
                   your models need, while real data anchors them to reality.
                 </p>
                 <ul className="mt-6 space-y-3">

--- a/client/src/pages/OffWaitlistSignUpFlow.tsx
+++ b/client/src/pages/OffWaitlistSignUpFlow.tsx
@@ -1,4 +1,4 @@
-// OffWaitlistSignUpFlow — Revamped UI in Blueprint's emerald/cyan dark theme
+// OffWaitlistSignUpFlow - Revamped UI in Blueprint's emerald/cyan dark theme
 // Keeps all existing functionality (token validation, Firebase auth, Firestore writes,
 // Places Autocomplete, mapping + demo scheduling, webhook call, confirmation redirect).
 //
@@ -2055,7 +2055,7 @@ export default function OffWaitlistSignUpFlow() {
                           <div>
                             <p className="text-slate-400">Organization</p>
                             <p className="text-white">
-                              {organizationName || "—"}
+                              {organizationName || "N/A"}
                             </p>
                           </div>
                         </div>
@@ -2064,7 +2064,7 @@ export default function OffWaitlistSignUpFlow() {
                           <div>
                             <p className="text-slate-400">Email</p>
                             <p className="text-white break-all">
-                              {email || "—"}
+                              {email || "N/A"}
                             </p>
                           </div>
                         </div>
@@ -2073,7 +2073,7 @@ export default function OffWaitlistSignUpFlow() {
                           <div>
                             <p className="text-slate-400">Contact</p>
                             <p className="text-white">
-                              {contactName || "—"}{" "}
+                              {contactName || "N/A"}{" "}
                               {phoneNumber ? `• ${phoneNumber}` : ""}
                             </p>
                           </div>
@@ -2083,7 +2083,7 @@ export default function OffWaitlistSignUpFlow() {
                           <div className="min-w-0">
                             <p className="text-slate-400">Address</p>
                             <p className="text-white break-words">
-                              {address || "—"}
+                              {address || "N/A"}
                             </p>
                           </div>
                         </div>
@@ -2091,7 +2091,7 @@ export default function OffWaitlistSignUpFlow() {
                           <Ruler className="w-4 h-4 text-emerald-300 mt-0.5" />
                           <div>
                             <p className="text-slate-400">Sq Ft</p>
-                            <p className="text-white">{squareFootage || "—"}</p>
+                            <p className="text-white">{squareFootage || "N/A"}</p>
                           </div>
                         </div>
                         <div className="flex items-start gap-2">
@@ -2101,8 +2101,8 @@ export default function OffWaitlistSignUpFlow() {
                             <p className="text-white">
                               {scheduleDate
                                 ? scheduleDate.toLocaleDateString()
-                                : "—"}{" "}
-                              • {scheduleTime || "—"}
+                                : "N/A"}{" "}
+                              • {scheduleTime || "N/A"}
                             </p>
                           </div>
                         </div>
@@ -2111,8 +2111,8 @@ export default function OffWaitlistSignUpFlow() {
                           <div>
                             <p className="text-slate-400">Next-Day Demo</p>
                             <p className="text-white">
-                              {demoDate ? demoDate.toLocaleDateString() : "—"} •{" "}
-                              {demoTime || "—"}
+                              {demoDate ? demoDate.toLocaleDateString() : "N/A"} •{" "}
+                              {demoTime || "N/A"}
                             </p>
                           </div>
                         </div>
@@ -2204,46 +2204,46 @@ export default function OffWaitlistSignUpFlow() {
                       <div>
                         Organization:{" "}
                         <span className="text-white">
-                          {organizationName || "—"}
+                          {organizationName || "N/A"}
                         </span>
                       </div>
                       <div>
                         Email:{" "}
                         <span className="text-white break-all">
-                          {email || "—"}
+                          {email || "N/A"}
                         </span>
                       </div>
                       <div>
                         Contact:{" "}
                         <span className="text-white">
-                          {contactName || "—"}{" "}
+                          {contactName || "N/A"}{" "}
                           {phoneNumber ? `• ${phoneNumber}` : ""}
                         </span>
                       </div>
                       <div>
                         Address:{" "}
                         <span className="text-white break-words">
-                          {address || "—"}
+                          {address || "N/A"}
                         </span>
                       </div>
                       <div>
                         Sq Ft:{" "}
                         <span className="text-white">
-                          {squareFootage || "—"}
+                          {squareFootage || "N/A"}
                         </span>
                       </div>
                       <div>
                         Mapping:{" "}
                         <span className="text-white">
-                          {scheduleDate?.toLocaleDateString() || "—"} •{" "}
-                          {scheduleTime || "—"}
+                          {scheduleDate?.toLocaleDateString() || "N/A"} •{" "}
+                          {scheduleTime || "N/A"}
                         </span>
                       </div>
                       <div>
                         Next-Day Demo:{" "}
                         <span className="text-white">
-                          {demoDate?.toLocaleDateString() || "—"} •{" "}
-                          {demoTime || "—"}
+                          {demoDate?.toLocaleDateString() || "N/A"} •{" "}
+                          {demoTime || "N/A"}
                         </span>
                       </div>
                     </div>

--- a/client/src/pages/OnboardingChecklist.tsx
+++ b/client/src/pages/OnboardingChecklist.tsx
@@ -1,4 +1,4 @@
-// OnboardingChecklist — Minimalist onboarding checklist page
+// OnboardingChecklist - Minimalist onboarding checklist page
 // Based on SIGNUP_ONBOARDING_SPEC.md
 //
 // Shows progress after signup with checklist items:

--- a/client/src/pages/OutboundSignUpFlow.tsx
+++ b/client/src/pages/OutboundSignUpFlow.tsx
@@ -1,4 +1,4 @@
-// OutboundSignUpFlow — Revamped UI in Blueprint's emerald/cyan dark theme
+// OutboundSignUpFlow - Revamped UI in Blueprint's emerald/cyan dark theme
 // Keeps all existing functionality (Firebase auth, Firestore writes, Places Autocomplete,
 // booking + demo scheduling, webhook call, confirmation redirect).
 //
@@ -133,7 +133,7 @@ export default function OutboundSignUpFlow() {
   const [address, setAddress] = useState("");
   const [squareFootage, setSquareFootage] = useState<number | null>(null);
 
-  // Step 3 — Mapping
+  // Step 3 - Mapping
   const [scheduleDate, setScheduleDate] = useState(new Date());
   const [scheduleTime, setScheduleTime] = useState("08:00");
 
@@ -146,13 +146,13 @@ export default function OutboundSignUpFlow() {
     );
   }, [scheduleDate]);
 
-  // Step 4 — Demo
+  // Step 4 - Demo
   // const [demoDate, setDemoDate] = useState(() => {
   //   const d = new Date();
   //   d.setDate(d.getDate() + 7);
   //   return d;
   // });
-  // Step 4 — Demo
+  // Step 4 - Demo
   const [demoDate, setDemoDate] = useState(new Date()); // effect will snap to the next day
 
   const [demoTime, setDemoTime] = useState("11:00");
@@ -1847,7 +1847,7 @@ export default function OutboundSignUpFlow() {
         <section className="pb-16">
           <div className="container mx-auto px-4 sm:px-6 max-w-7xl">
             <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
-              {/* Left Rail — persuasion + trust */}
+              {/* Left Rail - persuasion + trust */}
               <aside className="lg:col-span-1">
                 <div className="sticky top-28 space-y-6">
                   {/* Live summary */}
@@ -1864,7 +1864,7 @@ export default function OutboundSignUpFlow() {
                         <div>
                           <p className="text-slate-400">Organization</p>
                           <p className="text-white">
-                            {organizationName || "—"}
+                            {organizationName || "N/A"}
                           </p>
                         </div>
                       </div>
@@ -1872,7 +1872,7 @@ export default function OutboundSignUpFlow() {
                         <Mail className="w-4 h-4 text-emerald-300 mt-0.5" />
                         <div>
                           <p className="text-slate-400">Email</p>
-                          <p className="text-white break-all">{email || "—"}</p>
+                          <p className="text-white break-all">{email || "N/A"}</p>
                         </div>
                       </div>
                       <div className="flex items-start gap-2">
@@ -1880,7 +1880,7 @@ export default function OutboundSignUpFlow() {
                         <div>
                           <p className="text-slate-400">Contact</p>
                           <p className="text-white">
-                            {contactName || "—"}{" "}
+                            {contactName || "N/A"}{" "}
                             {phoneNumber ? `• ${phoneNumber}` : ""}
                           </p>
                         </div>
@@ -1890,7 +1890,7 @@ export default function OutboundSignUpFlow() {
                         <div className="min-w-0">
                           <p className="text-slate-400">Address</p>
                           <p className="text-white break-words">
-                            {address || "—"}
+                            {address || "N/A"}
                           </p>
                         </div>
                       </div>
@@ -1898,7 +1898,7 @@ export default function OutboundSignUpFlow() {
                         <Ruler className="w-4 h-4 text-emerald-300 mt-0.5" />
                         <div>
                           <p className="text-slate-400">Sq Ft</p>
-                          <p className="text-white">{squareFootage || "—"}</p>
+                          <p className="text-white">{squareFootage || "N/A"}</p>
                         </div>
                       </div>
                       <div className="flex items-start gap-2">
@@ -1908,8 +1908,8 @@ export default function OutboundSignUpFlow() {
                           <p className="text-white">
                             {scheduleDate
                               ? scheduleDate.toLocaleDateString()
-                              : "—"}{" "}
-                            • {scheduleTime || "—"}
+                              : "N/A"}{" "}
+                            • {scheduleTime || "N/A"}
                           </p>
                         </div>
                       </div>
@@ -1918,8 +1918,8 @@ export default function OutboundSignUpFlow() {
                           <div>
                             <p className="text-slate-400">Next-Day Demo</p>
                             <p className="text-white">
-                              {demoDate ? demoDate.toLocaleDateString() : "—"} •{" "}
-                              {demoTime || "—"}
+                              {demoDate ? demoDate.toLocaleDateString() : "N/A"} •{" "}
+                              {demoTime || "N/A"}
                             </p>
                           </div>
                         </div>
@@ -2011,44 +2011,44 @@ export default function OutboundSignUpFlow() {
                     <div>
                       Organization:{" "}
                       <span className="text-white">
-                        {organizationName || "—"}
+                        {organizationName || "N/A"}
                       </span>
                     </div>
                     <div>
                       Email:{" "}
                       <span className="text-white break-all">
-                        {email || "—"}
+                        {email || "N/A"}
                       </span>
                     </div>
                     <div>
                       Contact:{" "}
                       <span className="text-white">
-                        {contactName || "—"}{" "}
+                        {contactName || "N/A"}{" "}
                         {phoneNumber ? `• ${phoneNumber}` : ""}
                       </span>
                     </div>
                     <div>
                       Address:{" "}
                       <span className="text-white break-words">
-                        {address || "—"}
+                        {address || "N/A"}
                       </span>
                     </div>
                     <div>
                       Sq Ft:{" "}
-                      <span className="text-white">{squareFootage || "—"}</span>
+                      <span className="text-white">{squareFootage || "N/A"}</span>
                     </div>
                     <div>
                       Mapping:{" "}
                       <span className="text-white">
-                        {scheduleDate?.toLocaleDateString() || "—"} •{" "}
-                        {scheduleTime || "—"}
+                        {scheduleDate?.toLocaleDateString() || "N/A"} •{" "}
+                        {scheduleTime || "N/A"}
                       </span>
                     </div>
                       <div>
                         Next-Day Demo:{" "}
                         <span className="text-white">
-                          {demoDate?.toLocaleDateString() || "—"} •{" "}
-                          {demoTime || "—"}
+                          {demoDate?.toLocaleDateString() || "N/A"} •{" "}
+                          {demoTime || "N/A"}
                         </span>
                       </div>
                   </div>

--- a/client/src/pages/PartnerProgram.tsx
+++ b/client/src/pages/PartnerProgram.tsx
@@ -47,7 +47,7 @@ export default function PartnerProgram() {
               <div className="border-l-2 border-slate-200 pl-6">
                 <h3 className="font-semibold text-slate-900">Training Data Generation</h3>
                 <p className="text-sm text-slate-600">
-                  Thousands of automatically generated robot training examples — camera views, positions, success/failure, everything your AI needs.
+                  Thousands of automatically generated robot training examples, including camera views, positions, success/failure, and everything your AI needs.
                 </p>
               </div>
 
@@ -107,7 +107,7 @@ export default function PartnerProgram() {
               </div>
 
               <div>
-                <h3 className="mb-2 font-semibold text-slate-900">Founding Partner pricing — forever</h3>
+                <h3 className="mb-2 font-semibold text-slate-900">Founding Partner pricing - forever</h3>
                 <p className="text-slate-600">
                   Lock in early-access rates permanently. When we raise prices for new customers, yours stays the same.
                 </p>
@@ -133,7 +133,7 @@ export default function PartnerProgram() {
                 <Check className="mt-0.5 h-4 w-4 shrink-0 text-slate-900" />
                 <div>
                   <p className="font-semibold text-slate-900">Teams with real robot hardware</p>
-                  <p className="text-sm text-slate-600">Robot arms, mobile robots, humanoids — we prioritize partners who can validate sim-to-real transfer</p>
+                  <p className="text-sm text-slate-600">Robot arms, mobile robots, and humanoids are welcome, and we prioritize partners who can validate sim-to-real transfer</p>
                 </div>
               </div>
 
@@ -166,7 +166,7 @@ export default function PartnerProgram() {
                 </div>
                 <div>
                   <h3 className="font-semibold text-slate-900">Apply</h3>
-                  <p className="text-sm text-slate-600">Fill out the form below — takes 2 minutes</p>
+                  <p className="text-sm text-slate-600">Fill out the form below, it takes 2 minutes</p>
                 </div>
               </div>
 

--- a/client/src/pages/Pricing.tsx
+++ b/client/src/pages/Pricing.tsx
@@ -363,7 +363,7 @@ export default function Pricing() {
                   Already collecting real-world data?
                 </h2>
                 <p className="text-zinc-600">
-                  Simulation doesn't replace your real-world capture—it amplifies it.
+                  Simulation doesn't replace your real-world capture; it amplifies it.
                   Research shows teams that combine simulation with even small amounts
                   of real data see significantly better real-world performance.
                 </p>

--- a/client/src/pages/RLTraining.tsx
+++ b/client/src/pages/RLTraining.tsx
@@ -34,7 +34,7 @@ const whatWeDeliver = [
   },
   {
     title: "Training Curves & Metrics",
-    desc: "Full visibility into how your policy learned — reward progression, success rates, and convergence data.",
+    desc: "Full visibility into how your policy learned, including reward progression, success rates, and convergence data.",
     icon: <LineChart className="h-6 w-6" />,
     color: "emerald",
   },
@@ -46,7 +46,7 @@ const whatWeDeliver = [
   },
   {
     title: "Sim-to-Real Indicators",
-    desc: "Metrics that predict real-world performance — action smoothness, jerk analysis, and transfer gap estimates.",
+    desc: "Metrics that predict real-world performance, including action smoothness, jerk analysis, and transfer gap estimates.",
     icon: <Target className="h-6 w-6" />,
     color: "rose",
   },
@@ -68,7 +68,7 @@ const howItWorks = [
   {
     step: "03",
     title: "Policy Learns from Experience",
-    desc: "Using reinforcement learning (PPO), your robot's brain improves through trial and error — millions of attempts compressed into hours.",
+    desc: "Using reinforcement learning (PPO), your robot's brain improves through trial and error, with millions of attempts compressed into hours.",
     icon: <RefreshCw className="h-6 w-6" />,
   },
   {
@@ -94,7 +94,7 @@ const whyRLTraining = [
   },
   {
     title: "Infinite Variations",
-    desc: "Train across thousands of scene variations — different object positions, lighting, physics randomization — so your policy generalizes.",
+    desc: "Train across thousands of scene variations, including different object positions, lighting, and physics randomization, so your policy generalizes.",
     stat: "4096+",
     statLabel: "Parallel environments",
   },
@@ -225,7 +225,7 @@ export default function RLTraining() {
                 <p className="max-w-2xl text-lg leading-relaxed text-zinc-600">
                   You bring the simulation scene. We run thousands of virtual robots in parallel,
                   learning through trial and error. You receive a trained policy ready for
-                  real-world deployment — no ML infrastructure required.
+                  real-world deployment, with no ML infrastructure required.
                 </p>
               </div>
 
@@ -347,7 +347,7 @@ export default function RLTraining() {
                   </h2>
                   <p className="text-zinc-600 leading-relaxed">
                     Traditional robotics requires engineers to manually program every movement.
-                    <strong> Reinforcement Learning (RL)</strong> is different — your robot learns
+                    <strong> Reinforcement Learning (RL)</strong> is different, and your robot learns
                     by trying things, getting feedback on what works, and improving over time.
                     Think of it like how humans learn to ride a bike: through practice, not instruction manuals.
                   </p>
@@ -406,7 +406,7 @@ export default function RLTraining() {
                     <div className="rounded-lg bg-zinc-50 p-4 text-xs text-zinc-600">
                       <p className="font-semibold text-zinc-900">The key insight:</p>
                       <p className="mt-1">
-                        We run this loop <strong>millions of times</strong> in simulation —
+                        We run this loop <strong>millions of times</strong> in simulation,
                         what would take years on a real robot happens in hours on our GPU cluster.
                       </p>
                     </div>
@@ -496,7 +496,7 @@ export default function RLTraining() {
                   What You Receive
                 </h2>
                 <p className="mt-4 max-w-2xl mx-auto text-zinc-600">
-                  Every RL training job delivers a complete analysis package — trained policy,
+                  Every RL training job delivers a complete analysis package, including a trained policy,
                   detailed training history, benchmark reports, and premium analytics showing
                   how well your policy will perform in the real world.
                 </p>
@@ -701,7 +701,7 @@ export default function RLTraining() {
                   </h2>
                   <p className="text-zinc-600 leading-relaxed">
                     Every scene from the Blueprint marketplace already includes Isaac Lab task
-                    configurations — reward functions, observation spaces, action configs, and
+                    configurations, including reward functions, observation spaces, action configs, and
                     domain randomization settings. Just select a scene and task, and RL Training
                     handles the rest.
                   </p>

--- a/client/src/pages/Settings.jsx
+++ b/client/src/pages/Settings.jsx
@@ -29,7 +29,7 @@ export default function SettingsPage() {
   const createdDateLabel = useMemo(() => {
     const createdDate = userData?.createdDate;
     if (!createdDate) {
-      return "—";
+      return "N/A";
     }
     if (typeof createdDate === "object" && createdDate !== null) {
       if (typeof createdDate.toDate === "function") {
@@ -254,7 +254,7 @@ export default function SettingsPage() {
                           Primary email
                         </p>
                         <p className="mt-2 text-sm font-medium text-zinc-900">
-                          {currentUser.email || userData?.email || "—"}
+                          {currentUser.email || userData?.email || "N/A"}
                         </p>
                       </div>
                     </div>
@@ -300,10 +300,10 @@ export default function SettingsPage() {
                               >
                                 <div>
                                   <p className="text-sm font-semibold text-zinc-900">
-                                    {method.brand || "Card"} •••• {method.last4 || "—"}
+                                    {method.brand || "Card"} •••• {method.last4 || "N/A"}
                                   </p>
                                   <p className="text-xs text-zinc-500">
-                                    Expires {method.expiryDate || "—"}
+                                    Expires {method.expiryDate || "N/A"}
                                   </p>
                                   {method.isDefault && (
                                     <span className="mt-2 inline-flex w-fit rounded-full bg-emerald-100 px-2 py-1 text-xs font-semibold text-emerald-700">
@@ -444,7 +444,7 @@ export default function SettingsPage() {
                               >
                                 <div>
                                   <p className="font-semibold text-zinc-900">
-                                    {entry.amount ? `$${entry.amount}` : "—"}
+                                    {entry.amount ? `$${entry.amount}` : "N/A"}
                                   </p>
                                   <p className="text-xs text-zinc-500">
                                     {formatBillingDate(entry.date)}

--- a/client/src/pages/WhySimulation.tsx
+++ b/client/src/pages/WhySimulation.tsx
@@ -105,7 +105,7 @@ const complementarySteps = [
     step: "03",
     title: "Co-Training Maximizes Both",
     description:
-      "Train on a mixture of sim and real data in each batch. Research shows ~99% sim / ~1% real often works best—your real data anchors the policy while sim provides robustness.",
+      "Train on a mixture of sim and real data in each batch. Research shows ~99% sim / ~1% real often works best; your real data anchors the policy while sim provides robustness.",
     icon: <RefreshCw className="h-6 w-6" />,
     color: "amber",
   },
@@ -158,7 +158,7 @@ const objections = [
   {
     objection: "We already have enough real data",
     response:
-      "Your real data is invaluable—but is it diverse enough? Simulation lets you stress-test your policy against variations you haven't collected yet: different lighting, clutter, object positions, and failure modes. It's insurance against the scenarios you haven't seen.",
+      "Your real data is invaluable, but is it diverse enough? Simulation lets you stress-test your policy against variations you haven't collected yet: different lighting, clutter, object positions, and failure modes. It's insurance against the scenarios you haven't seen.",
   },
   {
     objection: "Simulation is too expensive to set up",
@@ -191,7 +191,7 @@ export default function WhySimulation() {
               </h1>
               <p className="mt-6 text-lg leading-relaxed text-zinc-600 sm:text-xl">
                 The world's best robotics teams don't choose between simulation and real-world data.
-                They use simulation to <strong>complement</strong> their real-world capture—and their
+                They use simulation to <strong>complement</strong> their real-world capture, and their
                 models perform better because of it.
               </p>
               <div className="mt-10 flex flex-col justify-center gap-4 sm:flex-row">
@@ -221,7 +221,7 @@ export default function WhySimulation() {
                 The Complement Model
               </h2>
               <p className="mt-4 max-w-2xl mx-auto text-lg text-zinc-600">
-                Real-world data is irreplaceable—but it's also slow and expensive.
+                Real-world data is irreplaceable, but it's also slow and expensive.
                 Simulation fills the gaps that real capture can't cover economically.
               </p>
             </div>
@@ -334,7 +334,7 @@ export default function WhySimulation() {
                   "Mixing simulation with even a small amount of real data can improve real-world task performance by <strong>38% on average</strong> compared to real-only training."
                 </p>
                 <p className="mt-3 text-sm text-emerald-100">
-                  — Sim-and-Real Co-Training Research, 2025
+                  - Sim-and-Real Co-Training Research, 2025
                 </p>
               </div>
             </div>
@@ -487,7 +487,7 @@ export default function WhySimulation() {
                 Common Questions from Real-Data Teams
               </h2>
               <p className="mt-4 text-lg text-zinc-400">
-                We get it—simulation skepticism is healthy. Here's how we address it.
+                We get it, simulation skepticism is healthy. Here's how we address it.
               </p>
             </div>
 

--- a/server/routes/ai-studio.ts
+++ b/server/routes/ai-studio.ts
@@ -135,14 +135,14 @@ function connectorSummary(
 ) {
   const lines = connectors.map((connector) => {
     const status = state[connector.id] ?? false;
-    return `${connector.name} — ${status ? "enabled" : "disabled"}${
+    return `${connector.name} - ${status ? "enabled" : "disabled"}${
       connector.description ? ` (${connector.description})` : ""
     }`;
   });
 
   const unknown = Object.entries(state)
     .filter(([id]) => !connectors.some((connector) => connector.id === id))
-    .map(([id, enabled]) => `${id} — ${enabled ? "enabled" : "disabled"}`);
+    .map(([id, enabled]) => `${id} - ${enabled ? "enabled" : "disabled"}`);
 
   const combined = [...lines, ...unknown];
   return combined.length ? combined.join("\n") : "None";
@@ -154,14 +154,14 @@ function capabilitySummary(
 ) {
   const lines = capabilities.map((capability) => {
     const status = state[capability.id] ?? false;
-    return `${capability.name} — ${status ? "enabled" : "disabled"}${
+    return `${capability.name} - ${status ? "enabled" : "disabled"}${
       capability.description ? ` (${capability.description})` : ""
     }`;
   });
 
   const unknown = Object.entries(state)
     .filter(([id]) => !capabilities.some((capability) => capability.id === id))
-    .map(([id, enabled]) => `${id} — ${enabled ? "enabled" : "disabled"}`);
+    .map(([id, enabled]) => `${id} - ${enabled ? "enabled" : "disabled"}`);
 
   const combined = [...lines, ...unknown];
   return combined.length ? combined.join("\n") : "None";
@@ -319,7 +319,7 @@ function buildSystemInstruction(options: {
         `- ${source.title}`,
         source.category ? ` [${source.category}]` : "",
         `: ${source.url}`,
-        source.description ? ` — ${source.description}` : "",
+        source.description ? ` (${source.description})` : "",
       ].join(""),
     )
     .join("\n");
@@ -381,7 +381,7 @@ function buildRetrievalContext(sources: SourceReference[]) {
       const header = `Source ${index + 1}: ${source.title} (${source.url})`;
       const distance =
         typeof source.distance === "number"
-          ? ` — similarity ${(1 - source.distance).toFixed(3)}`
+          ? ` - similarity ${(1 - source.distance).toFixed(3)}`
           : "";
       return `${header}${distance}\n${source.snippet}`;
     })

--- a/server/routes/apply.ts
+++ b/server/routes/apply.ts
@@ -81,7 +81,7 @@ export default function applyHandler(req: Request, res: Response) {
         "",
         "Appreciate you taking the time to share your work.",
         "",
-        "— The Blueprint Team",
+        "The Blueprint Team",
       ].join("\n");
 
       const confirmationHtml = `<!DOCTYPE html>
@@ -109,7 +109,7 @@ export default function applyHandler(req: Request, res: Response) {
                   Thanks for applying to collaborate with Blueprint. We’ll review your materials for the ${jobRole} role and reach out if the fit is right.
                 </p>
                 <p style="margin:0 0 12px;font-size:16px;color:#cbd5f5;">Appreciate you taking the time to share your work.</p>
-                <p style="margin:0;font-size:16px;color:#cbd5f5;">— The Blueprint Team</p>
+                <p style="margin:0;font-size:16px;color:#cbd5f5;">The Blueprint Team</p>
               </td>
             </tr>
           </table>

--- a/server/utils/ai-prompts.ts
+++ b/server/utils/ai-prompts.ts
@@ -566,7 +566,7 @@ export function buildPostSignupSystemInstructionsPrompt(
   ]
 }`,
     ``,
-    `Strictness: Output JSON object only — no extra text, no markdown.`,
+    `Strictness: Output JSON object only, no extra text or markdown.`,
   ];
 
   return body.join("\n");


### PR DESCRIPTION
### Motivation
- Remove the em dash glyph (—) from user-facing and server-side copy to improve readability and use clearer separators where appropriate.
- Prefer commas, parentheses, or a spaced hyphen (` - `) for appositions and use `N/A` for missing-value placeholders where the em dash was being used as a placeholder.
- Target both server prompts/email templates and client UI copy so runtime prompts and the site copy stay consistent.

### Description
- Replaced em dashes in server code: updated the application confirmation text in `server/routes/apply.ts`, normalized connector/capability lines and retrieval context formatting in `server/routes/ai-studio.ts`, and adjusted prompt strictness phrasing in `server/utils/ai-prompts.ts`.
- Updated client copy across multiple components and pages: adjusted hero lines, CTAs, footers, pilot copy, signup flows, settings placeholders, environment/pricing buttons, and other microcopy in files under `client/src/*` and `client/public/llms-full.txt` to use commas/parentheses/` - ` or `N/A` instead of em dashes.
- Replaced placeholder instances of `"—"` with `"N/A"` in signup/summary components to make missing-field text explicit and changed a long-form header from `# Blueprint —` to `# Blueprint:` for clarity.

### Testing
- Searched the repository for remaining em dashes with `rg -n "—"` after the edits and found no matches, indicating the replacements removed em dash occurrences (success).
- Attempted to run the dev server with `npm run dev` to smoke-test the app, but the run failed due to a missing `pino-pretty` transport configuration (`pino` error), so the application start verification did not complete (failure).
- All edits were staged and committed; no automated test suite was run beyond the developer commands above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a9e1308b0832993c87cd48ee73890)