### PR TITLE
Fix benchmark environments heading color

### DIFF
--- a/client/src/pages/Evals.tsx
+++ b/client/src/pages/Evals.tsx
@@ -382,7 +382,7 @@ export default function Evals() {
             {/* --- Available Scene Types --- */}
             <section className="rounded-3xl bg-zinc-900 p-8 sm:p-10 text-white">
               <div className="text-center mb-10">
-                <h2 className="text-2xl font-bold sm:text-3xl">
+                <h2 className="text-2xl font-bold text-white sm:text-3xl">
                   Benchmark environments
                 </h2>
                 <p className="mt-3 text-zinc-400 max-w-xl mx-auto">


### PR DESCRIPTION
### Motivation
- Ensure the “Benchmark environments” heading is legible on the dark card by making the text white.

### Description
- Add `text-white` to the `h2` class in `client/src/pages/Evals.tsx` so the heading renders white on the dark background.

### Testing
- Attempted to validate by running `npm run dev -- --host 0.0.0.0 --port 4173`, but the dev server failed to start due to a `pino-pretty` transport error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696aa003694c8329a3dc632ce92d42d8)