### PR TITLE
Add blog routes, pages, SEO tags, and sitemap entries

### DIFF
--- a/client/public/sitemap.xml
+++ b/client/public/sitemap.xml
@@ -37,6 +37,60 @@
     <priority>0.7</priority>
   </url>
   <url>
+    <loc>https://tryblueprint.io/blog</loc>
+    <lastmod>2026-01-16</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://tryblueprint.io/blog/robotics-os</loc>
+    <lastmod>2026-01-16</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://tryblueprint.io/blog/workplace-os</loc>
+    <lastmod>2026-01-16</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://tryblueprint.io/blog/restaurant-os</loc>
+    <lastmod>2026-01-16</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://tryblueprint.io/blog/hospitality-os</loc>
+    <lastmod>2026-01-16</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://tryblueprint.io/blog/museum-os</loc>
+    <lastmod>2026-01-16</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://tryblueprint.io/blog/property-os</loc>
+    <lastmod>2026-01-16</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://tryblueprint.io/blog/retail-os</loc>
+    <lastmod>2026-01-16</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://tryblueprint.io/blog/warehouse-os</loc>
+    <lastmod>2026-01-16</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
     <loc>https://tryblueprint.io/docs</loc>
     <lastmod>2026-01-16</lastmod>
     <changefreq>monthly</changefreq>

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -22,6 +22,15 @@ const EnvironmentDetail = lazy(() => import("./pages/EnvironmentDetail"));
 const Solutions = lazy(() => import("./pages/Solutions"));
 const Pricing = lazy(() => import("./pages/Pricing"));
 const Learn = lazy(() => import("./pages/Learn"));
+const Blog = lazy(() => import("./pages/Blog"));
+const RoboticsOS = lazy(() => import("./pages/blog/RoboticsOS"));
+const WorkplaceOS = lazy(() => import("./pages/blog/WorkplaceOS"));
+const RestaurantOS = lazy(() => import("./pages/blog/RestaurantOS"));
+const HospitalityOS = lazy(() => import("./pages/blog/HospitalityOS"));
+const MuseumOS = lazy(() => import("./pages/blog/MuseumOS"));
+const PropertyOS = lazy(() => import("./pages/blog/PropertyOS"));
+const RetailOS = lazy(() => import("./pages/blog/RetailOS"));
+const WarehouseOS = lazy(() => import("./pages/blog/WarehouseOS"));
 // const Capture = lazy(() => import("./pages/Capture")); // Capture service coming Q2 2026
 const Docs = lazy(() => import("./pages/Docs"));
 const Evals = lazy(() => import("./pages/Evals"));
@@ -88,6 +97,15 @@ function Router() {
         <Route path="/solutions" component={withLayout(Solutions)} />
         <Route path="/pricing" component={withLayout(Pricing)} />
         <Route path="/learn" component={withLayout(Learn)} />
+        <Route path="/blog" component={Blog} />
+        <Route path="/blog/robotics-os" component={RoboticsOS} />
+        <Route path="/blog/workplace-os" component={WorkplaceOS} />
+        <Route path="/blog/restaurant-os" component={RestaurantOS} />
+        <Route path="/blog/hospitality-os" component={HospitalityOS} />
+        <Route path="/blog/museum-os" component={MuseumOS} />
+        <Route path="/blog/property-os" component={PropertyOS} />
+        <Route path="/blog/retail-os" component={RetailOS} />
+        <Route path="/blog/warehouse-os" component={WarehouseOS} />
         <Route path="/docs" component={withLayout(Docs)} />
         <Route path="/evals" component={withLayout(Evals)} />
         <Route path="/benchmarks" component={withLayout(Evals)} />

--- a/client/src/pages/Blog.tsx
+++ b/client/src/pages/Blog.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Link } from "wouter";
 import Nav from "@/components/Nav";
 import Footer from "@/components/Footer";
+import { SEO } from "@/components/SEO";
 import {
   Card,
   CardHeader,
@@ -69,6 +70,12 @@ export default function Blog() {
 
   return (
     <div className="min-h-screen flex flex-col bg-[#0B1220] text-slate-100">
+      <SEO
+        title="Blueprint Blog"
+        description="Blueprint product updates, OS phases, and spatial computing insights across robotics, workplace, and industry verticals."
+        canonical="/blog"
+        type="website"
+      />
       {/* BACKGROUND: subtle dot grid + emerald→cyan wash */}
       <div className="pointer-events-none fixed inset-0 -z-10 overflow-hidden">
         <div

--- a/client/src/pages/blog/HospitalityOS.tsx
+++ b/client/src/pages/blog/HospitalityOS.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { Link } from "wouter";
+import Nav from "@/components/Nav";
+import Footer from "@/components/Footer";
+import { SEO } from "@/components/SEO";
+
+export default function HospitalityOS() {
+  return (
+    <div className="min-h-screen flex flex-col bg-[#0B1220] text-slate-100">
+      <SEO
+        title="hospitalityOS – our fifth vertical"
+        description="Wayfinding, amenity cues, and in-room overlays for guests, plus staff tools that lift satisfaction and service efficiency."
+        canonical="/blog/hospitality-os"
+        type="article"
+      />
+      <div className="pointer-events-none fixed inset-0 -z-10 overflow-hidden">
+        <div
+          className="absolute inset-0 opacity-[0.08]"
+          style={{
+            background:
+              "radial-gradient(circle at 1px 1px, rgba(255,255,255,0.18) 1px, transparent 1px)",
+            backgroundSize: "32px 32px",
+          }}
+        />
+        <div className="absolute inset-0 bg-gradient-to-b from-emerald-500/[0.10] via-cyan-500/[0.08] to-transparent mix-blend-screen" />
+      </div>
+
+      <Nav />
+
+      <main className="flex-1 pt-24 px-4 md:px-8">
+        <div className="max-w-3xl mx-auto">
+          <div className="rounded-3xl border border-white/10 bg-white/[0.05] p-6 md:p-8 shadow-xl">
+            <article className="prose prose-invert prose-slate md:prose-lg max-w-none">
+              <h1 className="mb-4 font-black bg-clip-text text-transparent bg-gradient-to-r from-emerald-400 to-cyan-400">
+                hospitalityOS – our fifth vertical
+              </h1>
+              <p>
+                Wayfinding, amenity cues, and in-room overlays for guests, plus
+                staff tools that lift satisfaction and service efficiency.
+              </p>
+              <p>More details on hospitalityOS are coming soon.</p>
+              <p>
+                <Link
+                  href="/blog"
+                  className="inline-flex items-center gap-2 text-emerald-300 hover:text-cyan-300"
+                >
+                  &larr; Back to all posts
+                </Link>
+              </p>
+            </article>
+          </div>
+        </div>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/client/src/pages/blog/MuseumOS.tsx
+++ b/client/src/pages/blog/MuseumOS.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { Link } from "wouter";
+import Nav from "@/components/Nav";
+import Footer from "@/components/Footer";
+import { SEO } from "@/components/SEO";
+
+export default function MuseumOS() {
+  return (
+    <div className="min-h-screen flex flex-col bg-[#0B1220] text-slate-100">
+      <SEO
+        title="museumOS – our fourth vertical"
+        description="Immersive storytelling, AI guides, and accessible wayfinding that deepen engagement and learning in cultural spaces."
+        canonical="/blog/museum-os"
+        type="article"
+      />
+      <div className="pointer-events-none fixed inset-0 -z-10 overflow-hidden">
+        <div
+          className="absolute inset-0 opacity-[0.08]"
+          style={{
+            background:
+              "radial-gradient(circle at 1px 1px, rgba(255,255,255,0.18) 1px, transparent 1px)",
+            backgroundSize: "32px 32px",
+          }}
+        />
+        <div className="absolute inset-0 bg-gradient-to-b from-emerald-500/[0.10] via-cyan-500/[0.08] to-transparent mix-blend-screen" />
+      </div>
+
+      <Nav />
+
+      <main className="flex-1 pt-24 px-4 md:px-8">
+        <div className="max-w-3xl mx-auto">
+          <div className="rounded-3xl border border-white/10 bg-white/[0.05] p-6 md:p-8 shadow-xl">
+            <article className="prose prose-invert prose-slate md:prose-lg max-w-none">
+              <h1 className="mb-4 font-black bg-clip-text text-transparent bg-gradient-to-r from-emerald-400 to-cyan-400">
+                museumOS – our fourth vertical
+              </h1>
+              <p>
+                Immersive storytelling, AI guides, and accessible wayfinding
+                that deepen engagement and learning in cultural spaces.
+              </p>
+              <p>More details on museumOS are coming soon.</p>
+              <p>
+                <Link
+                  href="/blog"
+                  className="inline-flex items-center gap-2 text-emerald-300 hover:text-cyan-300"
+                >
+                  &larr; Back to all posts
+                </Link>
+              </p>
+            </article>
+          </div>
+        </div>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/client/src/pages/blog/PropertyOS.tsx
+++ b/client/src/pages/blog/PropertyOS.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { Link } from "wouter";
+import Nav from "@/components/Nav";
+import Footer from "@/components/Footer";
+import { SEO } from "@/components/SEO";
+
+export default function PropertyOS() {
+  return (
+    <div className="min-h-screen flex flex-col bg-[#0B1220] text-slate-100">
+      <SEO
+        title="propertyOS – our third era"
+        description="How Blueprint uses AI glasses + AI to personalize your own space beyond the limits of the physical world."
+        canonical="/blog/property-os"
+        type="article"
+      />
+      <div className="pointer-events-none fixed inset-0 -z-10 overflow-hidden">
+        <div
+          className="absolute inset-0 opacity-[0.08]"
+          style={{
+            background:
+              "radial-gradient(circle at 1px 1px, rgba(255,255,255,0.18) 1px, transparent 1px)",
+            backgroundSize: "32px 32px",
+          }}
+        />
+        <div className="absolute inset-0 bg-gradient-to-b from-emerald-500/[0.10] via-cyan-500/[0.08] to-transparent mix-blend-screen" />
+      </div>
+
+      <Nav />
+
+      <main className="flex-1 pt-24 px-4 md:px-8">
+        <div className="max-w-3xl mx-auto">
+          <div className="rounded-3xl border border-white/10 bg-white/[0.05] p-6 md:p-8 shadow-xl">
+            <article className="prose prose-invert prose-slate md:prose-lg max-w-none">
+              <h1 className="mb-4 font-black bg-clip-text text-transparent bg-gradient-to-r from-emerald-400 to-cyan-400">
+                propertyOS – our third era
+              </h1>
+              <p>
+                How Blueprint uses AI glasses + AI to personalize your own space
+                beyond the limits of the physical world.
+              </p>
+              <p>More details on propertyOS are coming soon.</p>
+              <p>
+                <Link
+                  href="/blog"
+                  className="inline-flex items-center gap-2 text-emerald-300 hover:text-cyan-300"
+                >
+                  &larr; Back to all posts
+                </Link>
+              </p>
+            </article>
+          </div>
+        </div>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/client/src/pages/blog/RestaurantOS.tsx
+++ b/client/src/pages/blog/RestaurantOS.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { Link } from "wouter";
+import Nav from "@/components/Nav";
+import Footer from "@/components/Footer";
+import { SEO } from "@/components/SEO";
+
+export default function RestaurantOS() {
+  return (
+    <div className="min-h-screen flex flex-col bg-[#0B1220] text-slate-100">
+      <SEO
+        title="restaurantOS – our sixth phase"
+        description="Guest-centric AI glasses: photoreal 3D menus, chef stories, smart recs, and contactless flows that enhance the meal."
+        canonical="/blog/restaurant-os"
+        type="article"
+      />
+      <div className="pointer-events-none fixed inset-0 -z-10 overflow-hidden">
+        <div
+          className="absolute inset-0 opacity-[0.08]"
+          style={{
+            background:
+              "radial-gradient(circle at 1px 1px, rgba(255,255,255,0.18) 1px, transparent 1px)",
+            backgroundSize: "32px 32px",
+          }}
+        />
+        <div className="absolute inset-0 bg-gradient-to-b from-emerald-500/[0.10] via-cyan-500/[0.08] to-transparent mix-blend-screen" />
+      </div>
+
+      <Nav />
+
+      <main className="flex-1 pt-24 px-4 md:px-8">
+        <div className="max-w-3xl mx-auto">
+          <div className="rounded-3xl border border-white/10 bg-white/[0.05] p-6 md:p-8 shadow-xl">
+            <article className="prose prose-invert prose-slate md:prose-lg max-w-none">
+              <h1 className="mb-4 font-black bg-clip-text text-transparent bg-gradient-to-r from-emerald-400 to-cyan-400">
+                restaurantOS – our sixth phase
+              </h1>
+              <p>
+                Guest-centric AI glasses: photoreal 3D menus, chef stories, smart
+                recs, and contactless flows that enhance the meal.
+              </p>
+              <p>More details on restaurantOS are coming soon.</p>
+              <p>
+                <Link
+                  href="/blog"
+                  className="inline-flex items-center gap-2 text-emerald-300 hover:text-cyan-300"
+                >
+                  &larr; Back to all posts
+                </Link>
+              </p>
+            </article>
+          </div>
+        </div>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/client/src/pages/blog/RetailOS.tsx
+++ b/client/src/pages/blog/RetailOS.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { Link } from "wouter";
+import Nav from "@/components/Nav";
+import Footer from "@/components/Footer";
+import { SEO } from "@/components/SEO";
+
+export default function RetailOS() {
+  return (
+    <div className="min-h-screen flex flex-col bg-[#0B1220] text-slate-100">
+      <SEO
+        title="retailOS – our second phase"
+        description="How Blueprint uses AI glasses + AI to elevate in-store ops and customer experience in retail."
+        canonical="/blog/retail-os"
+        type="article"
+      />
+      <div className="pointer-events-none fixed inset-0 -z-10 overflow-hidden">
+        <div
+          className="absolute inset-0 opacity-[0.08]"
+          style={{
+            background:
+              "radial-gradient(circle at 1px 1px, rgba(255,255,255,0.18) 1px, transparent 1px)",
+            backgroundSize: "32px 32px",
+          }}
+        />
+        <div className="absolute inset-0 bg-gradient-to-b from-emerald-500/[0.10] via-cyan-500/[0.08] to-transparent mix-blend-screen" />
+      </div>
+
+      <Nav />
+
+      <main className="flex-1 pt-24 px-4 md:px-8">
+        <div className="max-w-3xl mx-auto">
+          <div className="rounded-3xl border border-white/10 bg-white/[0.05] p-6 md:p-8 shadow-xl">
+            <article className="prose prose-invert prose-slate md:prose-lg max-w-none">
+              <h1 className="mb-4 font-black bg-clip-text text-transparent bg-gradient-to-r from-emerald-400 to-cyan-400">
+                retailOS – our second phase
+              </h1>
+              <p>
+                How Blueprint uses AI glasses + AI to elevate in-store ops and
+                customer experience in retail.
+              </p>
+              <p>More details on retailOS are coming soon.</p>
+              <p>
+                <Link
+                  href="/blog"
+                  className="inline-flex items-center gap-2 text-emerald-300 hover:text-cyan-300"
+                >
+                  &larr; Back to all posts
+                </Link>
+              </p>
+            </article>
+          </div>
+        </div>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/client/src/pages/blog/RoboticsOS.tsx
+++ b/client/src/pages/blog/RoboticsOS.tsx
@@ -2,10 +2,17 @@ import React from "react";
 import { Link } from "wouter";
 import Nav from "@/components/Nav";
 import Footer from "@/components/Footer";
+import { SEO } from "@/components/SEO";
 
 export default function RoboticsOS() {
   return (
     <div className="min-h-screen flex flex-col bg-[#0B1220] text-slate-100">
+      <SEO
+        title="roboticsOS – spatial context for autonomous crews"
+        description="Living digital twins give humanoids and mobile robots instant context the moment they reach a new site."
+        canonical="/blog/robotics-os"
+        type="article"
+      />
       {/* BACKGROUND: aurora wash + subtle dot/grid */}
       <div className="pointer-events-none fixed inset-0 -z-10 overflow-hidden">
         {/* dots/grid via radial-gradient */}

--- a/client/src/pages/blog/WarehouseOS.tsx
+++ b/client/src/pages/blog/WarehouseOS.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { Link } from "wouter";
+import Nav from "@/components/Nav";
+import Footer from "@/components/Footer";
+import { SEO } from "@/components/SEO";
+
+export default function WarehouseOS() {
+  return (
+    <div className="min-h-screen flex flex-col bg-[#0B1220] text-slate-100">
+      <SEO
+        title="warehouseOS – our first vertical"
+        description="How Blueprint brings AI glasses and AI to warehouses for faster, safer operations."
+        canonical="/blog/warehouse-os"
+        type="article"
+      />
+      <div className="pointer-events-none fixed inset-0 -z-10 overflow-hidden">
+        <div
+          className="absolute inset-0 opacity-[0.08]"
+          style={{
+            background:
+              "radial-gradient(circle at 1px 1px, rgba(255,255,255,0.18) 1px, transparent 1px)",
+            backgroundSize: "32px 32px",
+          }}
+        />
+        <div className="absolute inset-0 bg-gradient-to-b from-emerald-500/[0.10] via-cyan-500/[0.08] to-transparent mix-blend-screen" />
+      </div>
+
+      <Nav />
+
+      <main className="flex-1 pt-24 px-4 md:px-8">
+        <div className="max-w-3xl mx-auto">
+          <div className="rounded-3xl border border-white/10 bg-white/[0.05] p-6 md:p-8 shadow-xl">
+            <article className="prose prose-invert prose-slate md:prose-lg max-w-none">
+              <h1 className="mb-4 font-black bg-clip-text text-transparent bg-gradient-to-r from-emerald-400 to-cyan-400">
+                warehouseOS – our first vertical
+              </h1>
+              <p>
+                How Blueprint brings AI glasses and AI to warehouses for faster,
+                safer operations.
+              </p>
+              <p>More details on warehouseOS are coming soon.</p>
+              <p>
+                <Link
+                  href="/blog"
+                  className="inline-flex items-center gap-2 text-emerald-300 hover:text-cyan-300"
+                >
+                  &larr; Back to all posts
+                </Link>
+              </p>
+            </article>
+          </div>
+        </div>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/client/src/pages/blog/WorkplaceOS.tsx
+++ b/client/src/pages/blog/WorkplaceOS.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { Link } from "wouter";
+import Nav from "@/components/Nav";
+import Footer from "@/components/Footer";
+import { SEO } from "@/components/SEO";
+
+export default function WorkplaceOS() {
+  return (
+    <div className="min-h-screen flex flex-col bg-[#0B1220] text-slate-100">
+      <SEO
+        title="workplaceOS – our seventh phase"
+        description="AI glasses + AI for offices and frontline hubs: live KPIs for managers, guided work and instant answers for teams."
+        canonical="/blog/workplace-os"
+        type="article"
+      />
+      <div className="pointer-events-none fixed inset-0 -z-10 overflow-hidden">
+        <div
+          className="absolute inset-0 opacity-[0.08]"
+          style={{
+            background:
+              "radial-gradient(circle at 1px 1px, rgba(255,255,255,0.18) 1px, transparent 1px)",
+            backgroundSize: "32px 32px",
+          }}
+        />
+        <div className="absolute inset-0 bg-gradient-to-b from-emerald-500/[0.10] via-cyan-500/[0.08] to-transparent mix-blend-screen" />
+      </div>
+
+      <Nav />
+
+      <main className="flex-1 pt-24 px-4 md:px-8">
+        <div className="max-w-3xl mx-auto">
+          <div className="rounded-3xl border border-white/10 bg-white/[0.05] p-6 md:p-8 shadow-xl">
+            <article className="prose prose-invert prose-slate md:prose-lg max-w-none">
+              <h1 className="mb-4 font-black bg-clip-text text-transparent bg-gradient-to-r from-emerald-400 to-cyan-400">
+                workplaceOS – our seventh phase
+              </h1>
+              <p>
+                AI glasses + AI for offices and frontline hubs: live KPIs for
+                managers, guided work and instant answers for teams.
+              </p>
+              <p>More details on workplaceOS are coming soon.</p>
+              <p>
+                <Link
+                  href="/blog"
+                  className="inline-flex items-center gap-2 text-emerald-300 hover:text-cyan-300"
+                >
+                  &larr; Back to all posts
+                </Link>
+              </p>
+            </article>
+          </div>
+        </div>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation
- Expose the blog index and each post slug in the client router so `/blog` and `/blog/<slug>` resolve in the SPA.
- Ensure blog pages emit crawler-friendly metadata (`index, follow`) so search engines can index posts.
- Add the public blog URLs to the sitemap so crawlers can discover them automatically.

### Description
- Register new lazy page imports and routes for `/blog` and each slug in `client/src/main.tsx` and wire them into the existing router.
- Add the `SEO` component to `client/src/pages/Blog.tsx` and to the existing `RoboticsOS` post so pages emit `index, follow` and canonical meta.
- Add new placeholder blog post pages (`WorkplaceOS`, `RestaurantOS`, `HospitalityOS`, `MuseumOS`, `PropertyOS`, `RetailOS`, `WarehouseOS`) under `client/src/pages/blog/` each using `SEO` with `type=

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696aebcd48a48329bc7c017d87b98bc7)