### PR TITLE
Mount /api/gemini behind CSRF and Firebase auth

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -8,7 +8,6 @@ import { createClient } from "redis";
 
 import { registerRoutes } from "./routes";
 import { setupVite, serveStatic } from "./vite";
-import geminiRouter from "./routes/gemini";
 import { attachRequestMeta, logger, generateTraceId, logSecurityEvent } from "./logger";
 import { incrementRequestCount, incrementErrorCount } from "./routes/health";
 
@@ -158,8 +157,7 @@ app.use((req, res, next) => {
 // Global rate limiting
 app.use(globalLimiter);
 
-// Mount the Gemini router
-app.use("/api/gemini", aiLimiter, geminiRouter);
+app.use("/api/gemini", aiLimiter);
 
 // Stricter limiters for sensitive routes
 app.use("/api/ai-studio", aiLimiter);

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -10,6 +10,7 @@ import uploadToB2Handler from "../client/src/pages/api/upload-to-b2";
 import postSignupWorkflowsHandler from "./routes/post-signup-workflows";
 import webhooksRouter from "./routes/webhooks";
 import aiStudioRouter from "./routes/ai-studio";
+import geminiRouter from "./routes/gemini";
 import qrLinkRouter from "./routes/qr-link";
 import appleAssociationRouter from "./routes/apple-app-site-association";
 import stripeAccountRouter from "./routes/stripe";
@@ -88,6 +89,7 @@ export function registerRoutes(app: Express) {
     verifyFirebaseToken,
     postSignupWorkflowsHandler,
   );
+  app.use("/api/gemini", csrfProtection, verifyFirebaseToken, geminiRouter);
   app.use("/api/ai-studio", csrfProtection, verifyFirebaseToken, aiStudioRouter);
   app.use("/api/qr", csrfProtection, verifyFirebaseToken, qrLinkRouter);
   app.use("/v1/stripe", csrfProtection, stripeAccountRouter);

--- a/server/tests/auth-middleware.test.ts
+++ b/server/tests/auth-middleware.test.ts
@@ -62,6 +62,7 @@ afterAll(async () => {
 });
 
 const protectedEndpoints = [
+  { method: "POST", path: "/api/submit-to-sheets" },
   { method: "POST", path: "/api/post-signup-workflows" },
   { method: "POST", path: "/api/upload-to-b2" },
   { method: "POST", path: "/api/ai-studio/chat" },


### PR DESCRIPTION
### Motivation
- Ensure the Gemini endpoints are protected by the same CSRF and Firebase auth middleware used by other sensitive API routes so AI features are not exposed without authorization.
- Keep rate limiting for Gemini in the centralized server setup while moving auth concerns into the route registration for consistent middleware ordering.

### Description
- Stop mounting the Gemini router directly in `server/index.ts` and remove the direct import there so only rate limiting remains (`app.use("/api/gemini", aiLimiter)` in `server/index.ts`).
- Import and mount `geminiRouter` in `registerRoutes` inside `server/routes.ts` with `csrfProtection` and `verifyFirebaseToken` via `app.use("/api/gemini", csrfProtection, verifyFirebaseToken, geminiRouter)`.
- Add `"/api/submit-to-sheets"` to the protected endpoints list in `server/tests/auth-middleware.test.ts` to validate missing-auth requests return `401`.
- Confirmed that `"/api/submit-to-sheets"`, `"/api/post-signup-workflows"`, and `"/api/ai-studio"` remain protected by `csrfProtection` and `verifyFirebaseToken` in `server/routes.ts`.

### Testing
- Added a unit test case in `server/tests/auth-middleware.test.ts` to include `"/api/submit-to-sheets"` in the missing-auth `401` checks, but no automated test suite was run as part of this change.
- Existing CSRF tests in `server/tests/csrf.test.ts` were left intact (not executed here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696afad92d8083298a858a232a49c2dc)