### PR TITLE
Harden CSRF cookie settings

### DIFF
--- a/server/middleware/csrf.ts
+++ b/server/middleware/csrf.ts
@@ -24,7 +24,7 @@ export const csrfCookieHandler = (_req: Request, res: Response) => {
   const token = crypto.randomBytes(32).toString("hex");
 
   res.cookie(CSRF_COOKIE_NAME, token, {
-    httpOnly: false,
+    httpOnly: true,
     sameSite: "lax",
     secure: process.env.NODE_ENV === "production",
     path: "/",


### PR DESCRIPTION
### Motivation
- Prevent client-side JavaScript from reading the CSRF cookie by marking the cookie `HttpOnly` while still providing the CSRF token in the `/api/csrf` response so legitimate clients can set the `X-CSRF-Token` header.

### Description
- Set `httpOnly: true` in `server/middleware/csrf.ts` and keep the `/api/csrf` handler returning `{ csrfToken }` in the JSON response; client code in `client/src/lib/csrf.ts` continues to fetch and use that response token to populate the `X-CSRF-Token` header.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696afb01daf08329988d37f1b26a2419)