### PR TITLE
Connect forgot password to Firebase reset email

### DIFF
--- a/client/src/lib/firebase.ts
+++ b/client/src/lib/firebase.ts
@@ -7,6 +7,7 @@ import {
   GoogleAuthProvider,
   onAuthStateChanged,
   signOut,
+  sendPasswordResetEmail as firebaseSendPasswordResetEmail,
   User as FirebaseUser,
 } from "firebase/auth";
 import {
@@ -47,6 +48,7 @@ try {
 export const auth = getAuth(app);
 export const db = getFirestore(app);
 export const storage = getStorage(app);
+export const sendPasswordResetEmail = firebaseSendPasswordResetEmail;
 
 // Log Firebase service initialization
 console.log("[Firebase] Services initialized - Auth:", !!auth, "Firestore:", !!db, "Storage:", !!storage);


### PR DESCRIPTION
### Motivation
- Replace the placeholder TODO/timeout in the forgot-password flow with the real Firebase Auth password reset call so users actually receive reset emails.
- Surface success and failure states to the user instead of relying on `console.log` and artificial delays.

### Description
- Export `sendPasswordResetEmail` from the client Firebase module as `sendPasswordResetEmail` for reuse in the UI layer.
- Wire the forgot password form to call `sendPasswordResetEmail(auth, email)` in `client/src/pages/ForgotPassword.tsx` and remove the simulated timeout and `console.log`.
- Add `errorMessage` state and a visible error alert, clear errors when retrying, and keep the success state that shows the submitted email.
- Disable the email input and submit button during submission via `isLoading` and re-enable on error or after completion.

### Testing
- Attempted to start the dev server with `npm run dev`, but the server failed to start due to a `pino-pretty` transport error, so the app could not be run locally.
- Attempted a Playwright navigation to `http://127.0.0.1:4173/forgot-password`, which failed with `net::ERR_EMPTY_RESPONSE` because the dev server was not available.
- No automated unit tests were executed for these changes during this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696afae8b4448329a81b8c082c6940b7)