### PR TITLE
Add server env validation and stricter Stripe config checks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,3 +30,9 @@ VITE_FIREBASE_MEASUREMENT_ID=G-7LHTQSRF9L
 # Stripe API keys for checkout integration
 # VITE_STRIPE_PUBLISHABLE_KEY=pk_test_your_stripe_publishable_key
 # STRIPE_SECRET_KEY=sk_test_your_stripe_secret_key
+# STRIPE_CONNECT_ACCOUNT_ID=acct_your_stripe_connect_account_id
+
+# Optional Stripe onboarding URLs (defaults to tryblueprint.io with standard paths)
+# STRIPE_PUBLIC_BASE_URL=https://www.tryblueprint.io
+# STRIPE_ONBOARDING_REFRESH_URL=https://www.tryblueprint.io/stripe/onboarding/refresh
+# STRIPE_ONBOARDING_RETURN_URL=https://www.tryblueprint.io/stripe/onboarding/return

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -25,6 +25,10 @@ These variables must be available in the build/runtime environment (Replit secre
 Stripe checkout and onboarding routes require the secret key at runtime:
 
 - `STRIPE_SECRET_KEY` (required; server startup fails fast if unset)
+- `STRIPE_CONNECT_ACCOUNT_ID` (required for Connect features; server startup fails fast if unset)
+
+The server validates required runtime variables at startup (`server/config/env.ts`). In production,
+missing required values will halt the process with a clear error message.
 
 ## Error tracking (Sentry)
 

--- a/server/config/env.ts
+++ b/server/config/env.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+
+const envSchema = z
+  .object({
+    NODE_ENV: z.enum(["development", "test", "production"]).default("development"),
+    PORT: z.coerce.number().int().positive().default(5000),
+    STRIPE_SECRET_KEY: z.string().trim().min(1).optional(),
+    STRIPE_CONNECT_ACCOUNT_ID: z.string().trim().min(1).optional(),
+    STRIPE_PUBLIC_BASE_URL: z.string().trim().url().optional(),
+    STRIPE_ONBOARDING_REFRESH_URL: z.string().trim().url().optional(),
+    STRIPE_ONBOARDING_RETURN_URL: z.string().trim().url().optional(),
+    RATE_LIMIT_REDIS_URL: z.string().trim().optional(),
+    REDIS_URL: z.string().trim().optional(),
+    ALLOWED_ORIGINS: z.string().trim().optional(),
+    API_BODY_LIMIT: z.string().trim().optional(),
+  })
+  .passthrough()
+  .superRefine((env, ctx) => {
+    if (env.NODE_ENV === "production") {
+      if (!env.STRIPE_SECRET_KEY) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["STRIPE_SECRET_KEY"],
+          message: "STRIPE_SECRET_KEY is required in production.",
+        });
+      }
+      if (!env.STRIPE_CONNECT_ACCOUNT_ID) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["STRIPE_CONNECT_ACCOUNT_ID"],
+          message: "STRIPE_CONNECT_ACCOUNT_ID is required in production.",
+        });
+      }
+    }
+  });
+
+export type Env = z.infer<typeof envSchema>;
+
+export function validateEnv(): Env {
+  const result = envSchema.safeParse(process.env);
+  if (result.success) {
+    return result.data;
+  }
+
+  const issues = result.error.issues
+    .map((issue) => {
+      const path = issue.path.join(".") || "env";
+      return `- ${path}: ${issue.message}`;
+    })
+    .join("\n");
+
+  throw new Error(`Environment validation failed:\n${issues}`);
+}

--- a/server/constants/stripe.ts
+++ b/server/constants/stripe.ts
@@ -1,15 +1,30 @@
 import Stripe from "stripe";
 
-const STRIPE_SECRET_KEY = process.env.STRIPE_SECRET_KEY?.trim() || "sk_test_placeholder_key_do_not_use_in_production";
+const STRIPE_SECRET_KEY = process.env.STRIPE_SECRET_KEY?.trim();
+const isProduction = process.env.NODE_ENV === "production";
 
-if (!process.env.STRIPE_SECRET_KEY) {
-  console.warn("Warning: STRIPE_SECRET_KEY environment variable is not set. Using placeholder key.");
+if (!STRIPE_SECRET_KEY) {
+  const message =
+    "STRIPE_SECRET_KEY environment variable is not set. Stripe routes will be unavailable.";
+  if (isProduction) {
+    throw new Error("STRIPE_SECRET_KEY is required in production.");
+  }
+  console.warn(message);
 }
 
-export const stripeClient = new Stripe(STRIPE_SECRET_KEY, { apiVersion: "2024-06-20" });
+export const stripeClient = STRIPE_SECRET_KEY
+  ? new Stripe(STRIPE_SECRET_KEY, { apiVersion: "2024-06-20" })
+  : null;
 
-export const STRIPE_CONNECT_ACCOUNT_ID =
-  process.env.STRIPE_CONNECT_ACCOUNT_ID?.trim() || "acct_1OE1ptPrtLGHqzOG";
+export const STRIPE_CONNECT_ACCOUNT_ID = process.env.STRIPE_CONNECT_ACCOUNT_ID?.trim();
+if (!STRIPE_CONNECT_ACCOUNT_ID) {
+  const message =
+    "STRIPE_CONNECT_ACCOUNT_ID environment variable is not set. Stripe Connect features will be unavailable.";
+  if (isProduction) {
+    throw new Error("STRIPE_CONNECT_ACCOUNT_ID is required in production.");
+  }
+  console.warn(message);
+}
 
 const DEFAULT_BASE_URL =
   process.env.STRIPE_PUBLIC_BASE_URL?.trim() ||

--- a/server/index.ts
+++ b/server/index.ts
@@ -11,10 +11,13 @@ import { setupVite, serveStatic } from "./vite";
 import geminiRouter from "./routes/gemini";
 import { attachRequestMeta, logger, generateTraceId, logSecurityEvent } from "./logger";
 import { incrementRequestCount, incrementErrorCount } from "./routes/health";
+import { validateEnv } from "./config/env";
+
+const env = validateEnv();
 
 const app = express();
 
-const rateLimitRedisUrl = process.env.RATE_LIMIT_REDIS_URL || process.env.REDIS_URL;
+const rateLimitRedisUrl = env.RATE_LIMIT_REDIS_URL || env.REDIS_URL;
 const redisClient =
   rateLimitRedisUrl && process.env.NODE_ENV === "production"
     ? createClient({ url: rateLimitRedisUrl })
@@ -117,13 +120,13 @@ const uploadLimiter = createRateLimiter({
 });
 
 // Configure middleware
-const defaultBodyLimit = process.env.API_BODY_LIMIT || "1mb";
+const defaultBodyLimit = env.API_BODY_LIMIT || "1mb";
 app.use(express.json({ limit: defaultBodyLimit }));
 app.use(express.urlencoded({ extended: false, limit: defaultBodyLimit }));
 
 // Configure CORS - restrict in production
-const allowedOrigins = process.env.ALLOWED_ORIGINS
-  ? process.env.ALLOWED_ORIGINS.split(",")
+const allowedOrigins = env.ALLOWED_ORIGINS
+  ? env.ALLOWED_ORIGINS.split(",")
   : ["http://localhost:5000", "http://localhost:3000", "https://tryblueprint.io"];
 
 app.use((req, res, next) => {
@@ -315,7 +318,7 @@ app.use((req, res, next) => {
     serveStatic(app);
   }
 
-  const PORT = Number(process.env.PORT) || 5000;
+  const PORT = env.PORT;
   server.listen(PORT, "0.0.0.0", () => {
     logger.info({ port: PORT }, "Server listening");
   });


### PR DESCRIPTION
### Motivation
- Ensure required runtime environment variables are validated early so the server fails fast with clear errors instead of silently using unsafe placeholders.
- Prevent accidental use of placeholder Stripe keys in production and make missing Stripe configuration an explicit startup failure.
- Centralize runtime env expectations so other server code can consume validated values instead of directly reading `process.env`.

### Description
- Add a Zod-based schema and validator at `server/config/env.ts` and expose a `validateEnv()` function that enforces production requirements (e.g., `STRIPE_SECRET_KEY` and `STRIPE_CONNECT_ACCOUNT_ID`).
- Call `validateEnv()` at server startup and use the returned `env` values in `server/index.ts` for `PORT`, `API_BODY_LIMIT`, `ALLOWED_ORIGINS`, and Redis `RATE_LIMIT_REDIS_URL`/`REDIS_URL`.
- Remove placeholder fallbacks for Stripe in `server/constants/stripe.ts`, make `stripeClient` nullable, warn in development, and throw during production if `STRIPE_SECRET_KEY` or `STRIPE_CONNECT_ACCOUNT_ID` are missing.
- Document required Stripe variables and onboarding URL options in `.env.example` and `DEPLOYMENT.md` and note that the server performs startup validation (`server/config/env.ts`).

### Testing
- No automated tests were run against these changes as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696afadca57c8329b6122453a0bbb4ea)