### PR TITLE
Use Redis-backed inbound request rate limiting

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -3,39 +3,19 @@ import fs from "fs";
 import path from "path";
 import { createServer } from "http";
 import rateLimit from "express-rate-limit";
-import { RedisStore } from "rate-limit-redis";
-import { createClient } from "redis";
 
 import { registerRoutes } from "./routes";
 import { setupVite, serveStatic } from "./vite";
 import { attachRequestMeta, logger, generateTraceId, logSecurityEvent } from "./logger";
 import { incrementRequestCount, incrementErrorCount } from "./routes/health";
 import { validateEnv } from "./config/env";
+import { createRateLimitRedisStore } from "./utils/rate-limit-redis";
 
 const env = validateEnv();
 
 const app = express();
 
-const rateLimitRedisUrl = env.RATE_LIMIT_REDIS_URL || env.REDIS_URL;
-const redisClient =
-  rateLimitRedisUrl && process.env.NODE_ENV === "production"
-    ? createClient({ url: rateLimitRedisUrl })
-    : null;
-
-if (redisClient) {
-  redisClient.on("error", (error) => {
-    logger.warn({ error }, "Redis rate limit store error");
-  });
-  void redisClient.connect();
-}
-
-const createRateLimitStore = (prefix: string) =>
-  redisClient
-    ? new RedisStore({
-        sendCommand: (...args: string[]) => redisClient.sendCommand(args),
-        prefix,
-      })
-    : undefined;
+const createRateLimitStore = (prefix: string) => createRateLimitRedisStore(prefix);
 
 // Known crawler/bot User-Agents that should bypass rate limiting
 const CRAWLER_USER_AGENTS = [

--- a/server/utils/rate-limit-redis.ts
+++ b/server/utils/rate-limit-redis.ts
@@ -1,0 +1,31 @@
+import { RedisStore } from "rate-limit-redis";
+import { createClient, type RedisClientType } from "redis";
+
+import { validateEnv } from "../config/env";
+import { logger } from "../logger";
+
+const env = validateEnv();
+const rateLimitRedisUrl = env.RATE_LIMIT_REDIS_URL || env.REDIS_URL;
+
+const rateLimitRedisClient: RedisClientType | null =
+  rateLimitRedisUrl && process.env.NODE_ENV === "production"
+    ? createClient({ url: rateLimitRedisUrl })
+    : null;
+
+if (rateLimitRedisClient) {
+  rateLimitRedisClient.on("error", (error) => {
+    logger.warn({ error }, "Redis rate limit store error");
+  });
+  void rateLimitRedisClient.connect();
+}
+
+export const getRateLimitRedisClient = (): RedisClientType | null =>
+  rateLimitRedisClient;
+
+export const createRateLimitRedisStore = (prefix: string) =>
+  rateLimitRedisClient
+    ? new RedisStore({
+        sendCommand: (...args: string[]) => rateLimitRedisClient.sendCommand(args),
+        prefix,
+      })
+    : undefined;


### PR DESCRIPTION
### Motivation
- Replace ephemeral in-memory maps used for inbound request rate limiting with a Redis-backed solution so limits are enforced consistently across nodes and persist across restarts.
- Reuse the shared Redis store/client used by other rate limiters to centralize configuration and error handling.
- Ensure graceful fallback (allowing requests) if Redis is unavailable while surfacing warnings in production.

### Description
- Add `server/utils/rate-limit-redis.ts` to create and expose a shared Redis client and a `createRateLimitRedisStore`/`getRateLimitRedisClient` helper for reuse with `express-rate-limit` and other code.
- Update `server/index.ts` to use `createRateLimitRedisStore` so existing `express-rate-limit` limiters can use the centralized Redis store.
- Replace the in-memory `rateLimitByIp` and `rateLimitByEmail` maps in `server/routes/inbound-request.ts` with a Redis-backed counter approach using the `RATE_LIMIT_SCRIPT` Lua script and atomic `INCR`+`PEXPIRE`; keys are namespaced with the `rl:inbound:` prefix and use `rl:inbound:ip:<hash>` and `rl:inbound:email:<domain>`.
- Make the rate check `async` and add a fallback that logs a warning and allows requests when the Redis client is unavailable, with the warning restricted to production.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696afd976c5c8329976e98a98dc7f0c1)