### PR TITLE
Tighten email validation across endpoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -110,6 +110,7 @@
         "three": "^0.158.0",
         "three-transform-controls": "^1.0.4",
         "uuid": "^11.1.0",
+        "validator": "^13.15.26",
         "vaul": "^1.1.0",
         "wouter": "^3.3.5",
         "ws": "^8.18.0",
@@ -15345,6 +15346,15 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.15.26",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.26.tgz",
+      "integrity": "sha512-spH26xU080ydGggxRyR1Yhcbgx+j3y5jbNXk/8L+iRvdIEQ4uTRH2Sgf2dokud6Q4oAtsbNvJ1Ft+9xmm6IZcA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "three": "^0.158.0",
     "three-transform-controls": "^1.0.4",
     "uuid": "^11.1.0",
+    "validator": "^13.15.26",
     "vaul": "^1.1.0",
     "wouter": "^3.3.5",
     "ws": "^8.18.0",

--- a/server/routes/apply.ts
+++ b/server/routes/apply.ts
@@ -3,6 +3,7 @@ import multer from "multer";
 import path from "path";
 
 import { sendEmail } from "../utils/email";
+import { isValidEmailAddress } from "../utils/validation";
 
 const allowedResumeMimeTypes = new Set([
   "application/pdf",
@@ -88,6 +89,10 @@ export default function applyHandler(req: Request, res: Response) {
 
       if (!applicantName || !applicantPortfolio || !jobRole || !jobEmail || !applicantEmail) {
         return res.status(400).json({ error: "Missing required fields" });
+      }
+
+      if (!isValidEmailAddress(jobEmail) || !isValidEmailAddress(applicantEmail)) {
+        return res.status(400).json({ error: "Invalid email format" });
       }
 
       const file = (req as RequestWithFile).file ?? null;

--- a/server/routes/contact.ts
+++ b/server/routes/contact.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from "express";
 import admin, { dbAdmin as db } from "../../client/src/lib/firebaseAdmin";
 import { sendEmail } from "../utils/email";
+import { isValidEmailAddress } from "../utils/validation";
 
 export default async function contactHandler(req: Request, res: Response) {
   if (req.method !== "POST") {
@@ -57,6 +58,11 @@ export default async function contactHandler(req: Request, res: Response) {
     });
   }
 
+  const emailValue = typeof email === "string" ? email.trim() : "";
+  if (!emailValue || !isValidEmailAddress(emailValue)) {
+    return res.status(400).json({ error: "Invalid email format" });
+  }
+
   const useCaseList = Array.isArray(useCases)
     ? useCases
     : useCases
@@ -81,7 +87,7 @@ export default async function contactHandler(req: Request, res: Response) {
   const requesterName = String(name);
   const summaryLines = [
     `Name: ${requesterName}`,
-    `Email: ${email}`,
+    `Email: ${emailValue}`,
     `Company: ${company}`,
     `Job title: ${jobTitle}`,
     `Country: ${country}`,

--- a/server/routes/inbound-request.ts
+++ b/server/routes/inbound-request.ts
@@ -4,6 +4,7 @@ import admin, { dbAdmin as db } from "../../client/src/lib/firebaseAdmin";
 import { sendEmail } from "../utils/email";
 import { notifySlackInboundRequest } from "../utils/slack";
 import { logger } from "../logger";
+import { isValidEmailAddress } from "../utils/validation";
 import type {
   InboundRequestPayload,
   InboundRequest,
@@ -136,8 +137,7 @@ function computeOwner(
  * Validate email format and check for disposable domains
  */
 function validateEmail(email: string): { valid: boolean; error?: string } {
-  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-  if (!emailRegex.test(email)) {
+  if (!isValidEmailAddress(email)) {
     return { valid: false, error: "Invalid email format" };
   }
 

--- a/server/routes/waitlist.ts
+++ b/server/routes/waitlist.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from "express";
 import { sendEmail } from "../utils/email";
+import { isValidEmailAddress } from "../utils/validation";
 
 export default async function waitlistHandler(req: Request, res: Response) {
   if (req.method !== "POST") {
@@ -12,9 +13,14 @@ export default async function waitlistHandler(req: Request, res: Response) {
     return res.status(400).json({ error: "Missing required fields" });
   }
 
+  const emailValue = typeof email === "string" ? email.trim() : "";
+  if (!emailValue || !isValidEmailAddress(emailValue)) {
+    return res.status(400).json({ error: "Invalid email format" });
+  }
+
   const to = process.env.WAITLIST_TO ?? "ops@tryblueprint.io";
   const subject = "New on-site capture waitlist submission";
-  const text = `Email: ${email}\nLocation type: ${locationType}`;
+  const text = `Email: ${emailValue}\nLocation type: ${locationType}`;
 
   const { sent } = await sendEmail({ to, subject, text });
 

--- a/server/tests/validation.test.ts
+++ b/server/tests/validation.test.ts
@@ -1,0 +1,36 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+
+import { isValidEmailAddress, validateWaitlistData } from "../utils/validation";
+
+describe("email validation", () => {
+  it("rejects known invalid email formats", () => {
+    const invalidEmails = [
+      "plainaddress",
+      "missing-at-sign.net",
+      "user@@example.com",
+      "user@.com",
+      "user@domain",
+      "user@domain..com",
+      "user@domain,com",
+      " user@domain.com",
+    ];
+
+    for (const email of invalidEmails) {
+      expect(isValidEmailAddress(email)).toBe(false);
+    }
+  });
+
+  it("flags invalid emails in waitlist validation", () => {
+    const errors = validateWaitlistData({
+      name: "Test User",
+      email: "user@domain..com",
+      company: "Example Co",
+      city: "Durham",
+      state: "NC",
+      offWaitlistUrl: "https://example.com",
+    });
+
+    expect(errors.some((error) => error.field === "email")).toBe(true);
+  });
+});

--- a/server/utils/validation.ts
+++ b/server/utils/validation.ts
@@ -1,3 +1,5 @@
+import validator from "validator";
+
 export interface WaitlistData {
   name?: string;
   email?: string;
@@ -20,6 +22,18 @@ export interface WaitlistData {
 export interface ValidationError { // Added export to make it available if needed by other modules, and JSDoc
   field: string;
   message: string;
+}
+
+export const EMAIL_VALIDATION_OPTIONS: validator.IsEmailOptions = {
+  allow_display_name: false,
+  allow_ip_domain: false,
+  allow_utf8_local_part: false,
+  domain_specific_validation: true,
+  require_tld: true,
+};
+
+export function isValidEmailAddress(email: string): boolean {
+  return validator.isEmail(email, EMAIL_VALIDATION_OPTIONS);
 }
 
 /**
@@ -55,9 +69,8 @@ export function validateWaitlistData(
   }
 
   if (requestBody.email && typeof requestBody.email === 'string') {
-    // Basic email format validation
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    if (!emailRegex.test(requestBody.email)) {
+    const emailValue = requestBody.email.trim();
+    if (!isValidEmailAddress(emailValue)) {
       errors.push({ field: 'email', message: 'Invalid email format.' });
     }
   } else if (requiredFields.includes('email') && (!requestBody.email || !String(requestBody.email).trim())) {


### PR DESCRIPTION
### Motivation
- Strengthen and unify email validation to reject malformed and disposable addresses and reduce spam/invalid leads across routes that accept emails.

### Description
- Add `validator` and introduce a shared `isValidEmailAddress` helper with strict `IsEmailOptions` in `server/utils/validation.ts`.
- Replace the basic regex checks in `validateWaitlistData` and `server/routes/inbound-request.ts` with the shared validator and preserve disposable-domain rejection logic.
- Apply consistent validation to `server/routes/waitlist.ts`, `server/routes/contact.ts`, and `server/routes/apply.ts` so all email inputs use the same check.
- Add unit tests at `server/tests/validation.test.ts` covering several known invalid email formats and a waitlist validation case.

### Testing
- Installed the new dependency with `npm install validator` successfully.
- Added automated tests in `server/tests/validation.test.ts` but did not run the test suite as part of this change (no test runs were executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696afda85b98832980321ccd785c38bf)