### PR TITLE
Redact email fields in logger

### DIFF
--- a/server/logger.ts
+++ b/server/logger.ts
@@ -15,6 +15,10 @@ const REDACTED_FIELDS = [
   "body.cardNumber",
   "body.cvv",
   "body.ssn",
+  "body.email",
+  "contact.email",
+  "user.email",
+  "req.body.email",
   "error.config.headers.Authorization",
   "error.config.headers.authorization",
 ];


### PR DESCRIPTION
### Motivation
- Prevent raw email addresses from appearing in logs by adding common email paths to the redaction list.

### Description
- Added `body.email`, `contact.email`, `user.email`, and `req.body.email` to the `REDACTED_FIELDS` array in `server/logger.ts`, leveraging Pino's `redact` option with `censor: "[REDACTED]"`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696afdb771888329bf8efdef2e475d08)