### PR TITLE
Add client log sanitization and use server logger

### DIFF
--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -11,6 +11,9 @@ import { CookieConsent } from "./components/CookieConsent";
 import { Analytics } from "./components/Analytics";
 import { AuthProvider } from "./contexts/AuthContext";
 import ProtectedRoute from "./components/ProtectedRoute";
+import { installClientLogger } from "./utils/clientLogger";
+
+installClientLogger();
 
 const Home = lazy(() => import("./pages/Home"));
 const WhySimulation = lazy(() => import("./pages/WhySimulation"));

--- a/client/src/utils/clientLogger.ts
+++ b/client/src/utils/clientLogger.ts
@@ -1,0 +1,165 @@
+type LogLevel = "log" | "info" | "warn" | "error" | "debug";
+
+type LogEntry = {
+  level: LogLevel;
+  message: string;
+  context?: unknown;
+  timestamp: string;
+};
+
+const REDACT_KEYS = new Set([
+  "password",
+  "token",
+  "secret",
+  "apikey",
+  "apiKey",
+  "authorization",
+  "email",
+  "uid",
+]);
+
+const EMAIL_REGEX = /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi;
+const LONG_TOKEN_REGEX = /\b[A-Za-z0-9_-]{32,}\b/g;
+
+const isDev = import.meta.env.DEV;
+
+const nativeConsole = {
+  log: console.log.bind(console),
+  info: console.info.bind(console),
+  warn: console.warn.bind(console),
+  error: console.error.bind(console),
+  debug: console.debug.bind(console),
+  group: console.group?.bind(console),
+  groupCollapsed: console.groupCollapsed?.bind(console),
+  groupEnd: console.groupEnd?.bind(console),
+  table: console.table?.bind(console),
+};
+
+const redactString = (value: string): string => {
+  let redacted = value.replace(EMAIL_REGEX, "[redacted-email]");
+  redacted = redacted.replace(/Bearer\s+[^\s]+/gi, "Bearer [redacted]");
+  redacted = redacted.replace(LONG_TOKEN_REGEX, "[redacted-token]");
+  return redacted;
+};
+
+const sanitizeValue = (value: unknown, seen = new WeakSet<object>()): unknown => {
+  if (value === null || value === undefined) {
+    return value;
+  }
+
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: redactString(value.message),
+    };
+  }
+
+  if (typeof value === "string") {
+    return redactString(value);
+  }
+
+  if (typeof value === "number" || typeof value === "boolean") {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeValue(item, seen));
+  }
+
+  if (typeof value === "object") {
+    if (seen.has(value)) {
+      return "[circular]";
+    }
+    seen.add(value);
+    const result: Record<string, unknown> = {};
+    for (const [key, entryValue] of Object.entries(value)) {
+      if (REDACT_KEYS.has(key.toLowerCase())) {
+        result[key] = "[redacted]";
+        continue;
+      }
+      result[key] = sanitizeValue(entryValue, seen);
+    }
+    return result;
+  }
+
+  return value;
+};
+
+const buildEntry = (level: LogLevel, args: unknown[]): LogEntry => {
+  const [first, ...rest] = args;
+  const message =
+    typeof first === "string" ? redactString(first) : "Client log entry";
+  const context =
+    rest.length > 0
+      ? sanitizeValue(rest.length === 1 ? rest[0] : rest)
+      : typeof first === "string"
+        ? undefined
+        : sanitizeValue(first);
+  return {
+    level,
+    message,
+    context,
+    timestamp: new Date().toISOString(),
+  };
+};
+
+const emitLog = (level: LogLevel, args: unknown[]) => {
+  if (!isDev && (level === "log" || level === "info" || level === "debug")) {
+    return;
+  }
+
+  const entry = buildEntry(level, args);
+  if (level === "warn") {
+    nativeConsole.warn(entry);
+    return;
+  }
+
+  if (level === "error") {
+    nativeConsole.error(entry);
+    return;
+  }
+
+  nativeConsole.log(entry);
+};
+
+const emitGroup = (method: "group" | "groupCollapsed", args: unknown[]) => {
+  if (!isDev) {
+    return;
+  }
+  const entry = buildEntry("debug", args);
+  if (method === "groupCollapsed") {
+    nativeConsole.groupCollapsed?.(entry.message);
+  } else {
+    nativeConsole.group?.(entry.message);
+  }
+  if (entry.context) {
+    nativeConsole.log(entry.context);
+  }
+};
+
+export const installClientLogger = () => {
+  if ((window as { __clientLoggerInstalled?: boolean }).__clientLoggerInstalled) {
+    return;
+  }
+
+  (window as { __clientLoggerInstalled?: boolean }).__clientLoggerInstalled = true;
+
+  console.log = (...args: unknown[]) => emitLog("log", args);
+  console.info = (...args: unknown[]) => emitLog("info", args);
+  console.warn = (...args: unknown[]) => emitLog("warn", args);
+  console.error = (...args: unknown[]) => emitLog("error", args);
+  console.debug = (...args: unknown[]) => emitLog("debug", args);
+  console.group = (...args: unknown[]) => emitGroup("group", args);
+  console.groupCollapsed = (...args: unknown[]) => emitGroup("groupCollapsed", args);
+  console.groupEnd = () => {
+    if (isDev) {
+      nativeConsole.groupEnd?.();
+    }
+  };
+  console.table = (data?: unknown, columns?: readonly string[]) => {
+    if (!isDev) {
+      return;
+    }
+    nativeConsole.table?.(sanitizeValue(data), columns as string[] | undefined);
+  };
+};

--- a/server/constants/stripe.ts
+++ b/server/constants/stripe.ts
@@ -1,4 +1,5 @@
 import Stripe from "stripe";
+import { logger } from "../logger";
 
 const STRIPE_SECRET_KEY = process.env.STRIPE_SECRET_KEY?.trim();
 const isProduction = process.env.NODE_ENV === "production";
@@ -9,7 +10,7 @@ if (!STRIPE_SECRET_KEY) {
   if (isProduction) {
     throw new Error("STRIPE_SECRET_KEY is required in production.");
   }
-  console.warn(message);
+  logger.warn(message);
 }
 
 export const stripeClient = STRIPE_SECRET_KEY
@@ -23,7 +24,7 @@ if (!STRIPE_CONNECT_ACCOUNT_ID) {
   if (isProduction) {
     throw new Error("STRIPE_CONNECT_ACCOUNT_ID is required in production.");
   }
-  console.warn(message);
+  logger.warn(message);
 }
 
 const DEFAULT_BASE_URL =

--- a/server/routes/gemini.ts
+++ b/server/routes/gemini.ts
@@ -1,5 +1,6 @@
-import express from 'express';
+import express from "express";
 import { GoogleGenerativeAI } from "@google/generative-ai";
+import { logger } from "../logger";
 
 const router = express.Router();
 
@@ -43,7 +44,7 @@ router.post('/analyze', async (req, res) => {
 
     res.json({ analysis });
   } catch (error) {
-    console.error('Error analyzing floor plan:', error);
+    logger.error({ err: error }, "Error analyzing floor plan");
     res.status(500).json({ 
       error: error instanceof Error ? error.message : 'Failed to analyze floor plan' 
     });

--- a/server/utils/data-extraction.ts
+++ b/server/utils/data-extraction.ts
@@ -1,3 +1,5 @@
+import { logger } from "../logger";
+
 /**
  * Extracts structured data from an AI response string based on predefined markers.
  * @param {string} responseText The raw text response from the AI.
@@ -9,7 +11,7 @@ export function extractDataFromAIResponse(responseText: string): {
 } {
   const extractedData: { [key: string]: string } = {};
   if (typeof responseText !== "string" || !responseText.trim()) {
-    console.warn(
+    logger.warn(
       "extractDataFromAIResponse received invalid input or empty string.",
     );
     return extractedData; // Return empty if no valid text


### PR DESCRIPTION
### Motivation
- Reduce noisy or sensitive console output from the client by providing a structured, sanitized logger that prevents accidental leakage of tokens/emails and limits non-critical logs to development builds.
- Replace ad-hoc `console.warn`/`console.error` usage on the server with the centralized server `logger` to ensure consistent structured logging and context.

### Description
- Add a client-side logger (`client/src/utils/clientLogger.ts`) that sanitizes strings and objects (redacts emails, long tokens and sensitive keys), builds structured log entries, gates `log`/`info`/`debug` to dev builds, and overrides `console` methods when installed.
- Initialize the client logger at app startup by calling `installClientLogger()` from `client/src/main.tsx` so console calls are normalized across the UI.
- Replace direct `console.warn`/`console.error` calls with `logger.warn`/`logger.error` in `server/constants/stripe.ts`, `server/routes/gemini.ts`, and `server/utils/data-extraction.ts` to use the existing server logging facilities.

### Testing
- No automated tests were run for this change.
- Manual sanity: console override is installed at app startup and will limit non-dev logs; server routes now emit structured logs via the existing `logger` (no runtime tests executed).
- No test failures reported (no test suite executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696afda33d088329822ab738184d41cd)