### PR TITLE
Add firebaseUser to Express locals and use res.locals in admin routes

### DIFF
--- a/server/routes/admin-leads.ts
+++ b/server/routes/admin-leads.ts
@@ -22,8 +22,8 @@ const ADMIN_EMAILS = [
 /**
  * Middleware to check if user is admin
  */
-async function requireAdmin(req: Request, res: Response, next: () => void) {
-  const user = (req as any).user;
+async function requireAdmin(_req: Request, res: Response, next: () => void) {
+  const user = res.locals.firebaseUser;
 
   if (!user) {
     return res.status(401).json({ error: "Authentication required" });
@@ -233,7 +233,7 @@ router.patch(
 
       const { requestId } = req.params;
       const { status, note } = req.body as UpdateRequestStatusPayload;
-      const user = (req as any).user;
+      const user = res.locals.firebaseUser;
 
       const validStatuses: RequestStatus[] = [
         "new",
@@ -315,7 +315,7 @@ router.patch(
 
       const { requestId } = req.params;
       const { owner } = req.body as AssignRequestOwnerPayload;
-      const user = (req as any).user;
+      const user = res.locals.firebaseUser;
 
       const docRef = db.collection("inboundRequests").doc(requestId);
       const doc = await docRef.get();
@@ -371,7 +371,7 @@ router.post(
 
       const { requestId } = req.params;
       const { content } = req.body as AddRequestNotePayload;
-      const user = (req as any).user;
+      const user = res.locals.firebaseUser;
 
       if (!content || !content.trim()) {
         return res.status(400).json({ error: "Note content is required" });

--- a/server/types/express.d.ts
+++ b/server/types/express.d.ts
@@ -1,0 +1,7 @@
+import type { DecodedIdToken } from "firebase-admin/auth";
+
+declare module "express-serve-static-core" {
+  interface Locals {
+    firebaseUser?: DecodedIdToken;
+  }
+}


### PR DESCRIPTION
### Motivation
- Ensure the Firebase decoded token stored by the auth middleware is typed on the Express response object so handlers can access it without `any` casts.
- Replace ad-hoc `req.user` access with the typed `res.locals.firebaseUser` to centralize auth data and improve type safety.

### Description
- Add an Express type augmentation at `server/types/express.d.ts` that declares `locals.firebaseUser?: DecodedIdToken` from `firebase-admin/auth`.
- Update `server/routes/admin-leads.ts` to read the authenticated user from `res.locals.firebaseUser` instead of `(req as any).user` in the admin-check middleware and in all handlers that previously used `req.user`.
- Rename the unused `req` parameter in the `requireAdmin` middleware to `_req` to reflect that the middleware uses `res.locals` instead.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696aff1cf13083298af0b0f4f5f0ea7f)