### PR TITLE
Add idempotency for apply and waitlist routes

### DIFF
--- a/server/routes/apply.ts
+++ b/server/routes/apply.ts
@@ -3,6 +3,11 @@ import multer from "multer";
 import path from "path";
 
 import { sendEmail } from "../utils/email";
+import {
+  buildIdempotencyKey,
+  fetchIdempotencyResponse,
+  storeIdempotencyResponse,
+} from "../utils/idempotency";
 import { isValidEmailAddress } from "../utils/validation";
 
 const allowedResumeMimeTypes = new Set([
@@ -96,6 +101,26 @@ export default function applyHandler(req: Request, res: Response) {
       }
 
       const file = (req as RequestWithFile).file ?? null;
+      const { key: idempotencyKey, ttlMs: idempotencyTtlMs } = buildIdempotencyKey({
+        scope: "apply",
+        email: applicantEmail,
+        payload: {
+          name: applicantName,
+          portfolio: applicantPortfolio,
+          notes: applicantNotes,
+          role: jobRole,
+          jobEmail,
+          resumeName: file?.originalname ?? null,
+          resumeType: file?.mimetype ?? null,
+          resumeSize: file?.size ?? null,
+        },
+      });
+
+      const cachedResponse = await fetchIdempotencyResponse(idempotencyKey);
+      if (cachedResponse) {
+        return res.status(cachedResponse.status).json(cachedResponse.body);
+      }
+
       const attachmentSummary = file ? file.originalname : "No file attached";
 
       if (file) {
@@ -185,9 +210,20 @@ export default function applyHandler(req: Request, res: Response) {
         replyTo: "ohstnhunt@gmail.com",
       });
 
-      return res
-        .status(sent ? 200 : 202)
-        .json({ success: true, sent, confirmationSent: confirmationResult.sent });
+      const responseStatus = sent ? 200 : 202;
+      const responseBody = {
+        success: true,
+        sent,
+        confirmationSent: confirmationResult.sent,
+      };
+
+      await storeIdempotencyResponse({
+        key: idempotencyKey,
+        response: { status: responseStatus, body: responseBody },
+        ttlMs: idempotencyTtlMs,
+      });
+
+      return res.status(responseStatus).json(responseBody);
     } catch (error) {
       console.error(error);
       return res.status(500).json({ error: "Failed to process application" });

--- a/server/routes/waitlist.ts
+++ b/server/routes/waitlist.ts
@@ -1,5 +1,10 @@
 import { Request, Response } from "express";
 import { sendEmail } from "../utils/email";
+import {
+  buildIdempotencyKey,
+  fetchIdempotencyResponse,
+  storeIdempotencyResponse,
+} from "../utils/idempotency";
 import { isValidEmailAddress } from "../utils/validation";
 
 export default async function waitlistHandler(req: Request, res: Response) {
@@ -18,11 +23,34 @@ export default async function waitlistHandler(req: Request, res: Response) {
     return res.status(400).json({ error: "Invalid email format" });
   }
 
+  const { key: idempotencyKey, ttlMs: idempotencyTtlMs } = buildIdempotencyKey({
+    scope: "waitlist",
+    email: emailValue,
+    payload: {
+      email: emailValue,
+      locationType,
+    },
+  });
+
+  const cachedResponse = await fetchIdempotencyResponse(idempotencyKey);
+  if (cachedResponse) {
+    return res.status(cachedResponse.status).json(cachedResponse.body);
+  }
+
   const to = process.env.WAITLIST_TO ?? "ops@tryblueprint.io";
   const subject = "New on-site capture waitlist submission";
   const text = `Email: ${emailValue}\nLocation type: ${locationType}`;
 
   const { sent } = await sendEmail({ to, subject, text });
 
-  return res.status(sent ? 200 : 202).json({ success: true, sent });
+  const responseStatus = sent ? 200 : 202;
+  const responseBody = { success: true, sent };
+
+  await storeIdempotencyResponse({
+    key: idempotencyKey,
+    response: { status: responseStatus, body: responseBody },
+    ttlMs: idempotencyTtlMs,
+  });
+
+  return res.status(responseStatus).json(responseBody);
 }

--- a/server/utils/idempotency.ts
+++ b/server/utils/idempotency.ts
@@ -1,0 +1,148 @@
+import crypto from "crypto";
+
+import admin, { dbAdmin as db } from "../../client/src/lib/firebaseAdmin";
+import { getRateLimitRedisClient } from "./rate-limit-redis";
+
+const DEFAULT_IDEMPOTENCY_WINDOW_MS = 10 * 60 * 1000;
+const IDEMPOTENCY_COLLECTION = "idempotencyKeys";
+
+type IdempotencyResponse = {
+  status: number;
+  body: Record<string, unknown>;
+};
+
+type IdempotencyRecord = IdempotencyResponse & {
+  expiresAt?: admin.firestore.Timestamp | Date | number;
+};
+
+const stableStringify = (value: unknown): string => {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(",")}]`;
+  }
+
+  const entries = Object.entries(value as Record<string, unknown>)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, nestedValue]) => `${JSON.stringify(key)}:${stableStringify(nestedValue)}`);
+
+  return `{${entries.join(",")}}`;
+};
+
+export const buildIdempotencyKey = ({
+  scope,
+  email,
+  payload,
+  windowMs = DEFAULT_IDEMPOTENCY_WINDOW_MS,
+}: {
+  scope: string;
+  email: string;
+  payload: Record<string, unknown>;
+  windowMs?: number;
+}) => {
+  const windowId = Math.floor(Date.now() / windowMs);
+  const normalizedEmail = email.trim().toLowerCase();
+  const hash = crypto
+    .createHash("sha256")
+    .update(`${normalizedEmail}|${windowId}|${stableStringify(payload)}`)
+    .digest("hex");
+
+  return {
+    key: `idempotency:${scope}:${hash}`,
+    ttlMs: windowMs,
+  };
+};
+
+const isRecordExpired = (record?: IdempotencyRecord | null) => {
+  if (!record?.expiresAt) {
+    return false;
+  }
+
+  const expiresAt =
+    record.expiresAt instanceof admin.firestore.Timestamp
+      ? record.expiresAt.toMillis()
+      : record.expiresAt instanceof Date
+        ? record.expiresAt.getTime()
+        : record.expiresAt;
+
+  return Date.now() > expiresAt;
+};
+
+export const fetchIdempotencyResponse = async (
+  key: string,
+): Promise<IdempotencyResponse | null> => {
+  const redisClient = getRateLimitRedisClient();
+
+  if (redisClient) {
+    try {
+      const cached = await redisClient.get(key);
+      if (cached) {
+        return JSON.parse(cached) as IdempotencyResponse;
+      }
+    } catch (error) {
+      console.warn("Failed to read idempotency key from Redis:", error);
+    }
+  }
+
+  if (!db) {
+    return null;
+  }
+
+  try {
+    const snapshot = await db.collection(IDEMPOTENCY_COLLECTION).doc(key).get();
+    if (!snapshot.exists) {
+      return null;
+    }
+
+    const data = snapshot.data() as IdempotencyRecord | undefined;
+    if (!data || isRecordExpired(data)) {
+      return null;
+    }
+
+    return {
+      status: data.status,
+      body: data.body,
+    };
+  } catch (error) {
+    console.warn("Failed to read idempotency key from Firestore:", error);
+    return null;
+  }
+};
+
+export const storeIdempotencyResponse = async ({
+  key,
+  response,
+  ttlMs,
+}: {
+  key: string;
+  response: IdempotencyResponse;
+  ttlMs: number;
+}) => {
+  const redisClient = getRateLimitRedisClient();
+
+  if (redisClient) {
+    try {
+      await redisClient.set(key, JSON.stringify(response), {
+        PX: ttlMs,
+      });
+    } catch (error) {
+      console.warn("Failed to store idempotency key in Redis:", error);
+    }
+  }
+
+  if (!db) {
+    return;
+  }
+
+  try {
+    await db.collection(IDEMPOTENCY_COLLECTION).doc(key).set({
+      ...response,
+      createdAt: admin.firestore.FieldValue.serverTimestamp(),
+      expiresAt: admin.firestore.Timestamp.fromMillis(Date.now() + ttlMs),
+    });
+  } catch (error) {
+    console.warn("Failed to store idempotency key in Firestore:", error);
+  }
+};


### PR DESCRIPTION
### Motivation
- Prevent duplicate submissions for `apply` and `waitlist` endpoints by returning a stable response for repeated requests within a short time window.
- Prefer a cheap cache (Redis) and fall back to Firestore for environments without Redis to keep responses short-lived and queryable.

### Description
- Add `server/utils/idempotency.ts` which implements `buildIdempotencyKey`, `fetchIdempotencyResponse`, and `storeIdempotencyResponse`, hashing `email + payload + time window` and using a default TTL of 10 minutes; it attempts Redis first and then Firestore.
- Update `server/routes/apply.ts` to compute an idempotency key from applicant email and payload, return a cached response if present, and store the final response after processing (including email send results).
- Update `server/routes/waitlist.ts` to compute and check an idempotency key for waitlist submissions and persist the stable response after sending email.
- Use a deterministic `stableStringify` to normalize payloads when building the idempotency hash and store `expiresAt` in Firestore for expiration checks.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696aff218f308329b5b61d8bd3827f67)