### PR TITLE
Allow placeholder Stripe env in production and gracefully disable Stripe

### DIFF
--- a/server/config/env.ts
+++ b/server/config/env.ts
@@ -1,5 +1,10 @@
 import { z } from "zod";
 
+const PLACEHOLDER_VALUES = new Set(["PLACEHOLDER", "DUMMY"]);
+
+const isPlaceholderValue = (value: string | undefined) =>
+  Boolean(value && PLACEHOLDER_VALUES.has(value.trim().toUpperCase()));
+
 const envSchema = z
   .object({
     NODE_ENV: z.enum(["development", "test", "production"]).default("development"),
@@ -24,7 +29,7 @@ const envSchema = z
           message: "STRIPE_SECRET_KEY is required in production.",
         });
       }
-      if (!env.STRIPE_CONNECT_ACCOUNT_ID) {
+      if (!env.STRIPE_CONNECT_ACCOUNT_ID && !isPlaceholderValue(env.STRIPE_SECRET_KEY)) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           path: ["STRIPE_CONNECT_ACCOUNT_ID"],


### PR DESCRIPTION
### Motivation
- Allow using placeholder values (e.g. `PLACEHOLDER`, `DUMMY`) for Stripe configuration in production so deployments can disable Stripe without failing env validation. 
- Avoid throwing at startup when Stripe credentials are missing or intentionally placeholdered. 
- Prevent runtime errors in Stripe routes by short-circuiting requests when Stripe is disabled and returning a 503-style response.

### Description
- Add placeholder detection helpers and a `PLACEHOLDER_VALUES` set and update `server/config/env.ts` to skip requiring `STRIPE_CONNECT_ACCOUNT_ID` when the Stripe secret is a placeholder. 
- Update `server/constants/stripe.ts` to treat missing or placeholder `STRIPE_SECRET_KEY` (and placeholder `STRIPE_CONNECT_ACCOUNT_ID`) as disabled, log a warning, and export `stripeClient` as `null` instead of throwing. 
- Introduce `stripeConnectAccountConfigured` to reflect whether a non-placeholder connect ID is present. 
- Change `server/routes/stripe.ts` so `ensureStripeConfigured` short-circuits with `503` (`HTTP_STATUS.SERVICE_UNAVAILABLE`) responses and returns a boolean, and update route handlers to return early when Stripe is disabled to avoid `null` dereferences.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b01a6a5d08329a1b03923e9ebf014)