### PR TITLE
Migrate CodeEntryModal and UpgradeModal to dialog primitives

### DIFF
--- a/client/src/components/CodeEntryModal.tsx
+++ b/client/src/components/CodeEntryModal.tsx
@@ -1,8 +1,13 @@
 "use client";
 
 import { useState } from "react";
-import { Modal } from "@/components/ui/Modal";
 import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 
@@ -27,29 +32,41 @@ export function CodeEntryModal({
   };
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose} title="Enter Verification Code">
-      <form onSubmit={handleSubmit} className="space-y-4">
-        <div className="space-y-2">
-          <Label htmlFor="verification-code">Verification Code</Label>
-          <Input
-            id="verification-code"
-            placeholder="Enter 6-character code"
-            value={code}
-            onChange={(e) => setCode(e.target.value)}
-            maxLength={6}
-            pattern="[A-Za-z0-9]{6}"
-            required
-            className="text-center text-2xl tracking-widest"
-          />
-          <p className="text-sm text-gray-500">
-            Enter the 6-character alphanumeric verification code sent to your
-            business contact.
-          </p>
-        </div>
-        <Button type="submit" className="w-full">
-          Verify Code
-        </Button>
-      </form>
-    </Modal>
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) {
+          onClose();
+        }
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Enter Verification Code</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="verification-code">Verification Code</Label>
+            <Input
+              id="verification-code"
+              placeholder="Enter 6-character code"
+              value={code}
+              onChange={(e) => setCode(e.target.value)}
+              maxLength={6}
+              pattern="[A-Za-z0-9]{6}"
+              required
+              className="text-center text-2xl tracking-widest"
+            />
+            <p className="text-sm text-gray-500">
+              Enter the 6-character alphanumeric verification code sent to your
+              business contact.
+            </p>
+          </div>
+          <Button type="submit" className="w-full">
+            Verify Code
+          </Button>
+        </form>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/client/src/components/UpgradeModal.tsx
+++ b/client/src/components/UpgradeModal.tsx
@@ -4,7 +4,12 @@ import { motion } from "framer-motion"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
 import { Label } from "@/components/ui/label"
-import { Modal } from "@/components/ui/Modal"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
 
 interface UpgradeModalProps {
   isOpen: boolean
@@ -25,45 +30,57 @@ export function UpgradeModal({ isOpen, onClose, usageDetails }: UpgradeModalProp
   }
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose} title="Enter Payment Information">
-      <div className="space-y-6">
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div className="space-y-2">
-            <Label htmlFor="card-name">Cardholder Name</Label>
-            <Input id="card-name" placeholder="John Smith" required />
-          </div>
-          
-          <div className="space-y-2">
-            <Label htmlFor="card-number">Card Number</Label>
-            <Input id="card-number" placeholder="4242 4242 4242 4242" required />
-          </div>
-          
-          <div className="grid grid-cols-2 gap-4">
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) {
+          onClose()
+        }
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Enter Payment Information</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-6">
+          <form onSubmit={handleSubmit} className="space-y-4">
             <div className="space-y-2">
-              <Label htmlFor="expiry">Expiry Date</Label>
-              <Input id="expiry" placeholder="MM/YY" required />
+              <Label htmlFor="card-name">Cardholder Name</Label>
+              <Input id="card-name" placeholder="John Smith" required />
             </div>
+
             <div className="space-y-2">
-              <Label htmlFor="cvc">CVC</Label>
-              <Input id="cvc" placeholder="123" required />
+              <Label htmlFor="card-number">Card Number</Label>
+              <Input id="card-number" placeholder="4242 4242 4242 4242" required />
             </div>
-          </div>
 
-          <motion.div
-            whileHover={{ scale: 1.02 }}
-            whileTap={{ scale: 0.98 }}
-          >
-            <Button type="submit" className="w-full">
-              Save Billing Information
-            </Button>
-          </motion.div>
-        </form>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="expiry">Expiry Date</Label>
+                <Input id="expiry" placeholder="MM/YY" required />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="cvc">CVC</Label>
+                <Input id="cvc" placeholder="123" required />
+              </div>
+            </div>
 
-        <p className="text-xs text-gray-500 text-center">
-          Your card will be charged monthly based on actual usage.
-          Cancel anytime.
-        </p>
-      </div>
-    </Modal>
+            <motion.div
+              whileHover={{ scale: 1.02 }}
+              whileTap={{ scale: 0.98 }}
+            >
+              <Button type="submit" className="w-full">
+                Save Billing Information
+              </Button>
+            </motion.div>
+          </form>
+
+          <p className="text-xs text-gray-500 text-center">
+            Your card will be charged monthly based on actual usage.
+            Cancel anytime.
+          </p>
+        </div>
+      </DialogContent>
+    </Dialog>
   )
 }


### PR DESCRIPTION
### Motivation
- Remove legacy `@/components/ui/Modal` usage and adopt the existing dialog primitives for consistency with `client/src/components/ui/` components.
- Ensure modals use the same accessible dialog implementation and lifecycle (open/close) used elsewhere in the UI library.

### Description
- Replaced `Modal` imports in `client/src/components/CodeEntryModal.tsx` and `client/src/components/UpgradeModal.tsx` with dialog primitives imported from `@/components/ui/dialog` (`Dialog`, `DialogContent`, `DialogHeader`, `DialogTitle`).
- Rewrote component JSX to use `Dialog`/`DialogContent` and added `DialogHeader`/`DialogTitle` while preserving form fields and button layout.
- Wired `onOpenChange` to call the original `onClose` callback when the dialog is closed to preserve previous behavior.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b04764c1c8329b8da67e69a825bc4)