### PR TITLE
Remove deprecated ScreenShareButton imports and usage

### DIFF
--- a/client/src/pages/ClaimBlueprint.tsx
+++ b/client/src/pages/ClaimBlueprint.tsx
@@ -2,7 +2,6 @@ import { useState, useEffect, useCallback } from "react";
 import { motion } from "framer-motion";
 import { useAuth } from "@/contexts/AuthContext";
 import { useLocation } from "wouter";
-import ScreenShareButton from "@/components/ScreenShareButton";
 import CustomerExperienceDesigner from "@/components/CustomerExperienceDesigner";
 import Nav from "@/components/Nav";
 import {
@@ -927,10 +926,6 @@ export default function ClaimBlueprint() {
           handleNext();
         }}
       />
-      {/* Add the ScreenShareButton here */}
-      <div className="fixed bottom-4 right-4 z-50">
-        <ScreenShareButton />
-      </div>
     </div>
   );
 }

--- a/client/src/pages/CreateBlueprint.tsx
+++ b/client/src/pages/CreateBlueprint.tsx
@@ -13,7 +13,6 @@ import {
 } from "react";
 import { Loader } from "@googlemaps/js-api-loader";
 import { ScanningSetup } from "@/components/ScanningSetup";
-import ScreenShareButton from "@/components/ScreenShareButton";
 import Nav from "@/components/Nav";
 import Footer from "@/components/Footer";
 import { getGoogleMapsApiKey } from "@/lib/client-env";
@@ -1519,7 +1518,6 @@ export default function CreateBlueprint() {
       </main>
 
       <Footer />
-      <ScreenShareButton />
     </div>
   );
 }

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -88,7 +88,6 @@ import {
   getDocs,
   updateDoc,
 } from "firebase/firestore";
-import ScreenShareButton from "@/components/ScreenShareButton";
 import { GoogleGenerativeAI } from "@google/generative-ai";
 import KitArrivalCountdown, {
   DEFAULT_KIT_TRACKING_URL,


### PR DESCRIPTION
### Motivation
- The screen sharing feature appears to be deprecated and the `ScreenShareButton` component is missing, so references were removed to prevent unresolved imports and dead UI.

### Description
- Removed the `ScreenShareButton` import and the floating JSX from `client/src/pages/ClaimBlueprint.tsx`.
- Removed the `ScreenShareButton` import and JSX from `client/src/pages/CreateBlueprint.tsx`.
- Dropped the unused `ScreenShareButton` import from `client/src/pages/Dashboard.tsx`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b04774e0083298caa70fa48a5f448)