### PR TITLE
Remove unused GeminiMultimodal import from Dashboard

### DIFF
--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -6,7 +6,6 @@
 
 import { useState, useEffect, useRef, useMemo } from "react";
 import GeminiChat from "@/components/GeminiChat";
-import GeminiMultimodal from "@/components/GeminiMultimodal";
 import { motion, AnimatePresence } from "framer-motion";
 import DarkModeToggle from "@/components/DarkModeToggle";
 import { LiveAPIProvider } from "@/contexts/LiveAPIContext";


### PR DESCRIPTION
### Motivation
- Remove a stale import for a missing component to avoid unresolved module errors and keep `Dashboard` imports accurate.

### Description
- Deleted the `GeminiMultimodal` import from `client/src/pages/Dashboard.tsx` since the component is not present in `client/src/components`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b0477e1ec832995e620bac0f6d5f3)