### PR TITLE
Prevent account enumeration on forgot-password page

### DIFF
--- a/client/src/pages/ForgotPassword.tsx
+++ b/client/src/pages/ForgotPassword.tsx
@@ -9,23 +9,16 @@ export default function ForgotPassword() {
   const [email, setEmail] = useState("");
   const [isSubmitted, setIsSubmitted] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setIsLoading(true);
-    setErrorMessage(null);
     try {
       await sendPasswordResetEmail(auth, email);
-      setIsSubmitted(true);
-    } catch (error) {
-      const message =
-        error instanceof Error && error.message
-          ? error.message
-          : "We couldn't send a reset email. Please try again.";
-      setErrorMessage(message);
-      setIsSubmitted(false);
+    } catch {
+      // Use the same response for all outcomes to avoid account enumeration.
     } finally {
+      setIsSubmitted(true);
       setIsLoading(false);
     }
   };
@@ -73,7 +66,6 @@ export default function ForgotPassword() {
                 type="button"
                 onClick={() => {
                   setIsSubmitted(false);
-                  setErrorMessage(null);
                 }}
                 className="text-sm font-medium text-indigo-600 hover:text-indigo-500"
               >
@@ -83,14 +75,6 @@ export default function ForgotPassword() {
           ) : (
             /* Form State */
             <form onSubmit={handleSubmit} className="space-y-4">
-              {errorMessage ? (
-                <div
-                  role="alert"
-                  className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700"
-                >
-                  {errorMessage}
-                </div>
-              ) : null}
               <div>
                 <label
                   htmlFor="email"


### PR DESCRIPTION
### Motivation
- The forgot-password flow previously surfaced raw Firebase errors and diverged the UI on success vs failure, allowing unauthenticated account enumeration.
- The change ensures the page presents a uniform response regardless of `sendPasswordResetEmail` outcome to avoid leaking whether an email is registered.

### Description
- Removed the `errorMessage` state and the UI block that rendered provider error text so raw auth errors are not shown to users.
- Updated the submit handler to swallow provider errors and always transition to the submitted/success state while preserving the loading indicator and success confirmation.
- Preserved the existing UX otherwise, including the email input, loading state, success card, and "Try a different email" flow.

### Testing
- Ran `npm run check` (TypeScript project check) which failed due to pre-existing unrelated TypeScript issues in `server/*`, not introduced by this change.
- Executed an automated Playwright script against the running app to exercise `/forgot-password` and captured a screenshot showing the success state, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab87617b0083299936685b640d6182)