### PR TITLE
Remove User-Agent based rate-limit bypass

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -18,34 +18,6 @@ const isProduction = process.env.NODE_ENV === "production";
 
 const createRateLimitStore = (prefix: string) => createRateLimitRedisStore(prefix);
 
-// Known crawler/bot User-Agents that should bypass rate limiting
-const CRAWLER_USER_AGENTS = [
-  "Googlebot",
-  "Bingbot",
-  "Slurp", // Yahoo
-  "DuckDuckBot",
-  "Baiduspider",
-  "YandexBot",
-  "facebookexternalhit",
-  "Twitterbot",
-  "LinkedInBot",
-  "GPTBot", // OpenAI
-  "ChatGPT-User", // OpenAI
-  "Claude-Web", // Anthropic
-  "Anthropic", // Anthropic
-  "PerplexityBot",
-  "Google-Extended", // Google AI
-  "CCBot", // Common Crawl
-  "Applebot",
-];
-
-const isCrawler = (userAgent: string | undefined): boolean => {
-  if (!userAgent) return false;
-  return CRAWLER_USER_AGENTS.some((bot) =>
-    userAgent.toLowerCase().includes(bot.toLowerCase())
-  );
-};
-
 const createRateLimiter = ({
   windowMs,
   limit,
@@ -65,8 +37,7 @@ const createRateLimiter = ({
     store: createRateLimitStore(prefix),
     skip: (req) =>
       req.method === "OPTIONS" ||
-      skipPaths.some((path) => req.path.startsWith(path)) ||
-      isCrawler(req.headers["user-agent"]),
+      skipPaths.some((path) => req.path.startsWith(path)),
     handler: (_req, res) => {
       res.status(429).json({ error: "Too many requests. Please try again later." });
     },


### PR DESCRIPTION
### Motivation
- Prevent clients from spoofing crawler User-Agent strings (e.g., `Googlebot`, `GPTBot`) to bypass global and sensitive route rate limiters. 
- Close a DoS/abuse vector where attacker-controlled `User-Agent` headers disabled rate limiting for cost- or abuse-sensitive endpoints.

### Description
- Removed the crawler User-Agent allowlist and the `isCrawler` helper that checked `req.headers["user-agent"]`.
- Stopped skipping rate limiting based on the `User-Agent` header in the shared `createRateLimiter` helper, leaving only `OPTIONS` requests and explicit `skipPaths` exempt. 
- Preserved existing limiter configuration and application (global, AI, auth, upload limiters) while removing the spoofable bypass condition.

### Testing
- Ran the TypeScript check with `npm run check` against the modified code, which completed but reported pre-existing TypeScript errors unrelated to this change.  
- No unit/e2e tests were modified; the change is minimal and limited to the rate limiter skip logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab888242648329b16240ff2d1cdc81)