### PR TITLE
Validate waitlist `locationType` before idempotency hashing

### DIFF
--- a/server/routes/waitlist.ts
+++ b/server/routes/waitlist.ts
@@ -107,8 +107,14 @@ export default async function waitlistHandler(req: Request, res: Response) {
   }
 
   const emailValue = typeof email === "string" ? email.trim() : "";
+  const locationTypeValue = typeof locationType === "string" ? locationType.trim() : "";
+
   if (!emailValue || !isValidEmailAddress(emailValue)) {
     return res.status(400).json({ error: "Invalid email format" });
+  }
+
+  if (!locationTypeValue) {
+    return res.status(400).json({ error: "Invalid location type" });
   }
 
   const { key: idempotencyKey, ttlMs: idempotencyTtlMs } = buildIdempotencyKey({
@@ -116,7 +122,7 @@ export default async function waitlistHandler(req: Request, res: Response) {
     email: emailValue,
     payload: {
       email: emailValue,
-      locationType,
+      locationType: locationTypeValue,
     },
   });
 
@@ -127,7 +133,7 @@ export default async function waitlistHandler(req: Request, res: Response) {
 
   const to = process.env.WAITLIST_TO ?? "ops@tryblueprint.io";
   const subject = "New on-site capture waitlist submission";
-  const text = `Email: ${emailValue}\nLocation type: ${locationType}`;
+  const text = `Email: ${emailValue}\nLocation type: ${locationTypeValue}`;
 
   const { sent } = await sendEmail({ to, subject, text });
   const responseStatus = sent ? HTTP_STATUS.OK : HTTP_STATUS.ACCEPTED;


### PR DESCRIPTION
### Motivation
- The idempotency key builder recursively stringifies the provided payload and a malicious deeply nested `locationType` object can trigger unbounded recursion and a stack overflow (DoS).
- The waitlist handler previously forwarded `locationType` directly from `req.body` into the idempotency payload without ensuring it was a simple string, exposing the recursion path to attacker-controlled input.

### Description
- Normalize and validate `locationType` in the waitlist POST handler by computing `locationTypeValue` as a trimmed string and rejecting non-strings or empty values with `400 Invalid location type`.
- Use the validated `locationTypeValue` in the idempotency payload passed to `buildIdempotencyKey` to prevent recursive traversal of attacker-controlled objects.
- Use the validated `locationTypeValue` in the outbound email text so all downstream behavior uses the sanitized string.

### Testing
- Ran the repository type check with `npm run check` (which executes `tsc -p tsconfig.full.json --noEmit`) and observed failures due to pre-existing unrelated TypeScript errors in other files, confirming the change itself does not introduce new type errors in the touched handler.
- Manual code inspection confirms `locationType` is no longer passed unchecked into `buildIdempotencyKey`, removing the immediate recursion attack vector.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab886a0a8c8329a0111f562c7b14c3)