### PR TITLE
Restore IP-based rate limiting for inbound requests

### DIFF
--- a/server/routes/inbound-request.ts
+++ b/server/routes/inbound-request.ts
@@ -1,4 +1,5 @@
 import { Request, Response, Router } from "express";
+import crypto from "crypto";
 import admin, { dbAdmin as db } from "../../client/src/lib/firebaseAdmin";
 import { HTTP_STATUS } from "../constants/http-status";
 import { sendEmail } from "../utils/email";
@@ -20,6 +21,7 @@ import type {
 const router = Router();
 
 const RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000; // 15 minutes
+const RATE_LIMIT_MAX_IP = 10; // Max 10 submissions per IP per window
 const RATE_LIMIT_MAX_EMAIL = 3; // Max 3 submissions per email per window
 const RATE_LIMIT_PREFIX = "rl:inbound:";
 
@@ -62,6 +64,13 @@ const DISPOSABLE_EMAIL_DOMAINS = [
   "10minutemail.com",
   "yopmail.com",
 ];
+
+/**
+ * Hash IP address for privacy in logs/rate-limit keys
+ */
+function hashIp(ip: string): string {
+  return crypto.createHash("sha256").update(ip).digest("hex").slice(0, 16);
+}
 
 /**
  * Check rate limit for a given key
@@ -276,6 +285,8 @@ function generateConfirmationEmailHtml(firstName: string): string {
  */
 router.post("/", async (req: Request, res: Response) => {
   const startTime = Date.now();
+  const clientIp = req.ip || req.socket.remoteAddress || "unknown";
+  const ipHash = hashIp(clientIp);
 
   try {
     const payload = req.body as InboundRequestPayload;
@@ -347,6 +358,20 @@ router.post("/", async (req: Request, res: Response) => {
     }
 
     // 5. Check rate limits
+    const ipRateLimit = await checkRateLimit(
+      `${RATE_LIMIT_PREFIX}ip:${ipHash}`,
+      RATE_LIMIT_MAX_IP
+    );
+    if (!ipRateLimit.allowed) {
+      logger.warn({ ipHash }, "IP rate limit exceeded");
+      return res.status(429).json({
+        ok: false,
+        requestId: payload.requestId,
+        status: "new",
+        message: "Too many requests. Please try again later.",
+      } satisfies SubmitInboundRequestResponse);
+    }
+
     const emailDomain = emailLower.split("@")[1];
     const emailRateLimit = await checkRateLimit(
       `${RATE_LIMIT_PREFIX}email:${emailDomain}`,


### PR DESCRIPTION
### Motivation
- A recent change removed per-IP throttling from the public inbound request endpoint, leaving only an email-domain limiter and enabling abuse via domain rotation. 
- The goal is to reinstate a source-based throttle to prevent a single IP from overwhelming backend automations while preserving existing domain-based limits and privacy.

### Description
- Reintroduced `RATE_LIMIT_MAX_IP` and an IP-based rate-limit check in `server/routes/inbound-request.ts` so requests are throttled by both source and email domain. 
- Added a `hashIp` helper and `import crypto` and use a truncated SHA-256 hash for Redis rate-limit keys and logging to avoid storing raw IP values. 
- The handler now checks `rl:inbound:ip:<hashed-ip>` with `max 10` per `15 minutes` before the existing `rl:inbound:email:<domain>` check (`max 3` per `15 minutes`), preserving existing response semantics. 
- Only a minimal, in-file change was made to restore the lost IP-based protection and avoid reintroducing other logic.

### Testing
- Ran static type checks with `npm run check` (TypeScript `tsc`), which failed due to pre-existing unrelated TypeScript errors elsewhere in the repo and not caused by this change. 
- Verified by inspecting the modified route that both `ip` and `email` rate-limit keys are now evaluated and appropriate `429` responses are returned when limits are exceeded. 
- No new unit or integration tests were added for this small remediation to avoid altering broader test surface in this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab8766bc98832996ce7a5c70cd43ee)