### PR TITLE
Harden inbound rate limiter fallback to avoid fail-open when Redis is down

### DIFF
--- a/server/routes/inbound-request.ts
+++ b/server/routes/inbound-request.ts
@@ -23,6 +23,8 @@ const RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000; // 15 minutes
 const RATE_LIMIT_MAX_EMAIL = 3; // Max 3 submissions per email per window
 const RATE_LIMIT_PREFIX = "rl:inbound:";
 
+const localRateLimitStore = new Map<string, { count: number; resetAt: number }>();
+
 const rateLimitRedisClient = getRateLimitRedisClient();
 
 const RATE_LIMIT_SCRIPT = `
@@ -70,11 +72,25 @@ async function checkRateLimit(
   key: string,
   maxCount: number
 ): Promise<{ allowed: boolean; remaining: number }> {
+  const checkLocalRateLimit = () => {
+    const now = Date.now();
+    const record = localRateLimitStore.get(key);
+
+    if (!record || record.resetAt <= now) {
+      localRateLimitStore.set(key, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
+      return { allowed: true, remaining: maxCount - 1 };
+    }
+
+    record.count += 1;
+    const remaining = Math.max(maxCount - record.count, 0);
+    return { allowed: record.count <= maxCount, remaining };
+  };
+
   if (!rateLimitRedisClient) {
     if (process.env.NODE_ENV === "production") {
-      logger.warn("Redis rate limit client unavailable; allowing inbound request");
+      logger.warn("Redis rate limit client unavailable; using local inbound rate limit fallback");
     }
-    return { allowed: true, remaining: maxCount };
+    return checkLocalRateLimit();
   }
 
   try {
@@ -86,8 +102,8 @@ async function checkRateLimit(
     const remaining = Math.max(maxCount - current, 0);
     return { allowed: current <= maxCount, remaining };
   } catch (error) {
-    logger.warn({ error }, "Redis rate limit check failed; allowing inbound request");
-    return { allowed: true, remaining: maxCount };
+    logger.warn({ error }, "Redis rate limit check failed; using local inbound rate limit fallback");
+    return checkLocalRateLimit();
   }
 }
 


### PR DESCRIPTION
### Motivation
- Prevent a fail-open path in inbound request throttling that previously allowed unlimited submissions when Redis was missing or errored. 
- Ensure inbound requests remain rate-limited even during Redis outages to reduce spam and operational/third-party costs.

### Description
- Add a local in-memory fallback store `localRateLimitStore` and a `checkLocalRateLimit` helper in `server/routes/inbound-request.ts` to enforce the same window/max semantics when Redis is unavailable. 
- Use the local fallback both when the Redis client is not present and when the Redis `eval` call throws an error. 
- Update warning logs to indicate the local fallback is being used instead of logging that requests are being allowed unthrottled. 
- Preserve existing Redis-backed behavior when Redis is available.

### Testing
- Ran the TypeScript check via `npm run check`, which completed but reported failures unrelated to this change (pre-existing TypeScript issues elsewhere in the repository).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab87b82044832984050c0ca2dd5ce0)