### PR TITLE
Sanitize CSV cells in admin leads export to prevent CSV injection

### DIFF
--- a/server/routes/admin-leads.ts
+++ b/server/routes/admin-leads.ts
@@ -19,6 +19,16 @@ import type {
 
 const router = Router();
 
+const CSV_FORMULA_PREFIX = /^[=+\-@]/;
+
+function sanitizeCsvCell(value: unknown): string {
+  const normalized = String(value ?? "").replace(/\r?\n|\r/g, " ");
+  const formulaSafe = CSV_FORMULA_PREFIX.test(normalized)
+    ? `'${normalized}`
+    : normalized;
+  return `"${formulaSafe.replace(/"/g, '""')}"`;
+}
+
 // Admin email allowlist (in production, use Firebase Custom Claims)
 const ADMIN_EMAILS = [
   "ohstnhunt@gmail.com",
@@ -553,10 +563,10 @@ router.get("/export/csv", requireAdmin, async (req: Request, res: Response) => {
           decrypted.contact.roleTitle,
           decrypted.request.budgetBucket,
           decrypted.request.helpWith.join("; "),
-          (decrypted.request.details || "").replace(/"/g, '""'),
+          decrypted.request.details || "",
           decrypted.context.sourcePageUrl,
           decrypted.owner.email || "",
-        ].map((val) => `"${val}"`);
+        ].map((val) => sanitizeCsvCell(val));
       })
     );
 


### PR DESCRIPTION
### Motivation
- The admin CSV export was writing user-controlled lead fields (names, company, details, source URL) into CSV cells verbatim, allowing spreadsheet formulas (e.g., `=HYPERLINK(...)`) to execute on open. 
- Preventing CSV/spreadsheet formula injection is required to protect admin confidentiality and integrity when exports are opened in Excel/Sheets. 
- Provide a minimal, localized server-side mitigation that preserves existing export behavior.

### Description
- Added `CSV_FORMULA_PREFIX` and a `sanitizeCsvCell(value: unknown)` helper to `server/routes/admin-leads.ts` to normalize line breaks, escape double quotes, and prefix values that start with `=`, `+`, `-`, or `@` with a single quote. 
- Replaced the previous ad-hoc quoting with `sanitizeCsvCell` for all exported columns in the `/api/admin/leads/export/csv` route so every cell is safely quoted and neutralized. 
- Kept CSV headers and overall CSV composition unchanged to preserve downstream compatibility while centralizing sanitization/quoting logic. 
- The change is localized to `server/routes/admin-leads.ts` and is minimal in scope.

### Testing
- Ran the TypeScript project check with `npm run check`; the run completed but failed due to pre-existing TypeScript errors elsewhere in the repo that are unrelated to this change. 
- Performed code review/inspection to validate that exported values are now passed through `sanitizeCsvCell`, which neutralizes formula-leading characters before CSV output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab896f748083298bbfddca6649a817)