### PR TITLE
Use generic login auth error to mitigate account enumeration

### DIFF
--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -100,12 +100,8 @@ export default function Login() {
 
     try {
       await signIn(formData.email, formData.password);
-    } catch (error) {
-      setAuthError(
-        error instanceof Error
-          ? error.message
-          : "Authentication failed. Please try again.",
-      );
+    } catch {
+      setAuthError("Invalid email or password.");
     } finally {
       setIsLoading(false);
     }


### PR DESCRIPTION
### Motivation
- Prevent user enumeration by avoiding display of provider-specific authentication errors on the login page and replace them with a single generic message.

### Description
- Replace the sign-in error handling in `client/src/pages/Login.tsx` so the catch for email/password sign-in always sets a generic message (`"Invalid email or password."`) instead of propagating provider-specific error text.

### Testing
- Ran `npm run check` (TypeScript typecheck) which failed due to pre-existing unrelated server-side TypeScript errors and did not surface any new errors introduced by this client-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab8ca8da588329ab58baf4a860bb70)