### PR TITLE
Fix static prerender fallback path traversal

### DIFF
--- a/server/vite.ts
+++ b/server/vite.ts
@@ -64,13 +64,18 @@ export function serveStatic(app: Express) {
     const hasExtension = path.extname(req.path) !== "";
     if (!hasExtension) {
       const cleanedPath = req.path.replace(/\/+$/, "") || "/";
-      const htmlPath =
+      const candidateHtmlPath =
         cleanedPath === "/"
           ? indexPath
           : path.resolve(distPath, cleanedPath.slice(1), "index.html");
 
-      if (fs.existsSync(htmlPath)) {
-        res.sendFile(htmlPath);
+      const relativeToDist = path.relative(distPath, candidateHtmlPath);
+      const isWithinDist =
+        relativeToDist === "index.html" ||
+        (!relativeToDist.startsWith("..") && !path.isAbsolute(relativeToDist));
+
+      if (isWithinDist && fs.existsSync(candidateHtmlPath)) {
+        res.sendFile(candidateHtmlPath);
         return;
       }
     }


### PR DESCRIPTION
### Motivation
- The prerender fallback in `server/vite.ts` built a filesystem path from `req.path` and could theoretically serve `index.html` files outside `dist/public` when given traversal-style inputs, so the handler needs to enforce containment before serving discovered files.

### Description
- Replace the direct `htmlPath` resolution with a `candidateHtmlPath` computed from the request and keep the prior fallback to `dist/public/index.html`.
- Compute `relativeToDist` using `path.relative(distPath, candidateHtmlPath)` and verify containment with an `isWithinDist` check that rejects `..` or absolute resolved targets.
- Only call `res.sendFile` for the candidate path when `isWithinDist` is true and the file exists, otherwise fall back to the main `index.html`.

### Testing
- Ran the TypeScript check via `npm run check`, which completed but reported pre-existing TypeScript errors unrelated to this change, so the type-check run failed overall.  No other automated tests were modified or executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab952ff6b8832983979993bf76e492)