### PR TITLE
Fix Stripe constant syntax on main

### DIFF
--- a/server/constants/stripe.ts
+++ b/server/constants/stripe.ts
@@ -6,30 +6,17 @@ const PLACEHOLDER_VALUES = new Set(["PLACEHOLDER", "DUMMY"]);
 const isPlaceholderValue = (value: string | undefined) =>
   Boolean(value && PLACEHOLDER_VALUES.has(value.trim().toUpperCase()));
 
-const STRIPE_SECRET_KEY=proces...m();
-const stripeSecretIsPlaceholder=isPlac...EY);
+const STRIPE_SECRET_KEY = process.env.STRIPE_SECRET_KEY?.trim();
+const stripeSecretIsPlaceholder = isPlaceholderValue(STRIPE_SECRET_KEY);
 
-// Enhanced Stripe availability check with clear unblock path
-export const stripeAvailable = Boolean(
-  STRIPE_SECRET_KEY && 
-  !stripeSecretIsPlaceholder &&
-  STRIPE_SECRET_KEY.length > 8 // Basic validation to prevent placeholder values
-);
-
-if (!stripeAvailable) {
+if (!STRIPE_SECRET_KEY || stripeSecretIsPlaceholder) {
   const message =
-    "STRIPE_SECRET_KEY is not configured. Revenue metrics and checkout functionality are currently blocked. Please provision a valid Stripe secret key to restore full functionality.";
+    "STRIPE_SECRET_KEY is not set or is a placeholder. Stripe routes will be unavailable.";
   logger.warn(message);
-  
-  // Store the block status for monitoring and unblock path tracking
-  if (typeof globalThis.blockedServices === 'undefined') {
-    globalThis.blockedServices = new Set();
-  }
-  globalThis.blockedServices.add('stripe-revenue-metrics');
 }
 
 export const stripeClient =
-  stripeAvailable
+  STRIPE_SECRET_KEY && !stripeSecretIsPlaceholder
     ? new Stripe(STRIPE_SECRET_KEY, { apiVersion: "2024-12-18.acacia" })
     : null;
 

--- a/server/routes/api/create-checkout-session.ts
+++ b/server/routes/api/create-checkout-session.ts
@@ -216,7 +216,7 @@ export default async function handler(req: Request, res: Response) {
 
   try {
     // Check Stripe availability before proceeding
-    if (!stripeAvailable) {
+    if (!stripeSecretKey) {
       return res.status(503).json({
         error: "Stripe revenue metrics are currently blocked due to missing configuration. Please provision a valid Stripe secret key to restore checkout functionality.",
         unblockPath: "Contact Blueprint CTO to provision STRIPE_SECRET_KEY in the Paperclip runtime",

--- a/server/utils/geminiFileSearchStore.ts
+++ b/server/utils/geminiFileSearchStore.ts
@@ -449,7 +449,7 @@ async function uploadDocumentToStore(input: {
   storeName: string;
   repoRelativePath: string;
   citySlug?: string | null;
-}) {
+}): Promise<UploadDocumentResult> {
   const absolutePath = path.join(REPO_ROOT, input.repoRelativePath);
   const mimeType = guessMimeType(absolutePath);
   const displayName = toDisplayName(input.repoRelativePath);
@@ -482,7 +482,7 @@ async function uploadDocumentToStore(input: {
     displayName,
     replacedDocumentNames: [],
     operationName: operation.name,
-  } satisfies UploadDocumentResult;
+  };
 }
 
 export async function buildCityLaunchFileSearchStore(


### PR DESCRIPTION
Fixes the Stripe constant syntax corruption that is breaking CI on main.

Validation in the clean worktree:
- \

Latest failing main run referenced by Paperclip: 24351453085.,