### PR TITLE
Add structured robot-team run setup fields and model_checkpoint modality

### DIFF
--- a/client/src/lib/robotEvalJobRequest.ts
+++ b/client/src/lib/robotEvalJobRequest.ts
@@ -266,6 +266,7 @@ export function buildPolicyPackageFromRobotTeamSubmission(
     high_level_skill_trace: {},
     teleop_demo: {},
     sim_controller_plugin: {},
+    model_checkpoint: {},
   };
 
   if (submission.selectedModalities.includes("policy_api_endpoint")) {
@@ -329,6 +330,19 @@ export function buildPolicyPackageFromRobotTeamSubmission(
       task_scenario_mapping: fields.taskScenarioMapping,
       rights_privacy_attestation: fields.rightsPrivacyAttestation,
       labels: fields.labels,
+    });
+  }
+
+  if (submission.selectedModalities.includes("model_checkpoint")) {
+    const fields = fieldsFor(submission, "model_checkpoint");
+    policyPackage.model_checkpoint = compactRecord({
+      artifact_uri: fields.artifactUri,
+      digest_checksum: fields.digestChecksum,
+      framework_runtime: fields.frameworkRuntime,
+      model_card_policy_interface_notes: fields.modelCardPolicyInterfaceNotes,
+      observation_schema_ref: fields.observationSchemaRef,
+      action_schema_ref: fields.actionSchemaRef,
+      owner_contact: fields.ownerContact,
     });
   }
 

--- a/client/src/lib/robotTeamTestSubmission.test.ts
+++ b/client/src/lib/robotTeamTestSubmission.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildRobotTeamSubmissionInput,
+  normalizeRobotTeamTestSubmission,
+} from "./robotTeamTestSubmission";
+
+describe("robot-team test submission", () => {
+  it("normalizes run setup fields and model checkpoint modality", () => {
+    const submission = normalizeRobotTeamTestSubmission(
+      buildRobotTeamSubmissionInput({
+        siteWorldId: "siteworld-1",
+        taskId: "task-1",
+        scenarioId: "scenario-1",
+        robotProfileId: "robot-1",
+        policyLabels: [
+          " primary ",
+          "",
+          "baseline",
+          "primary",
+          "ablation",
+          "ignored",
+        ],
+        episodeCount: "custom",
+        customEpisodeCount: "250",
+        validationMode: "comparative_policy_eval",
+        observationSchemaRef: "gs://team/schemas/obs.json",
+        actionSchemaRef: "gs://team/schemas/action.json",
+        controlFrequency: "20 Hz",
+        robotEmbodiment: "mobile manipulator",
+        gripper: "parallel jaw",
+        cameraSetup: "wrist RGB-D + mast stereo",
+        intrinsicsExtrinsicsRef: "gs://team/calibration/cameras.json",
+        sitePackageTarget: "cold-storage package",
+        taskInstruction: "pick tote from shelf",
+        startStateConstraints: "robot starts at aisle entry",
+        successCriteria: "tote placed without safety event",
+        modalities: {
+          model_checkpoint: {
+            selected: true,
+            fields: {
+              artifactUri: "gs://team/checkpoints/policy.pt",
+              digestChecksum: "sha256:checkpoint",
+              frameworkRuntime: "PyTorch 2.4 / CUDA 12.4",
+              modelCardPolicyInterfaceNotes: "gs://team/cards/policy.md",
+              observationSchemaRef: "gs://team/schemas/obs.json",
+              actionSchemaRef: "gs://team/schemas/action.json",
+              ownerContact: "owner@example.com",
+            },
+          },
+        },
+      }),
+    );
+
+    expect(submission?.policyLabels).toEqual([
+      "primary",
+      "baseline",
+      "ablation",
+    ]);
+    expect(submission?.episodeCount).toBe("custom");
+    expect(submission?.customEpisodeCount).toBe("250");
+    expect(submission?.validationMode).toBe("comparative_policy_eval");
+    expect(submission?.observationSchemaRef).toBe("gs://team/schemas/obs.json");
+    expect(submission?.actionSchemaRef).toBe("gs://team/schemas/action.json");
+    expect(submission?.controlFrequency).toBe("20 Hz");
+    expect(submission?.robotEmbodiment).toBe("mobile manipulator");
+    expect(submission?.gripper).toBe("parallel jaw");
+    expect(submission?.cameraSetup).toBe("wrist RGB-D + mast stereo");
+    expect(submission?.intrinsicsExtrinsicsRef).toBe(
+      "gs://team/calibration/cameras.json",
+    );
+    expect(submission?.sitePackageTarget).toBe("cold-storage package");
+    expect(submission?.taskInstruction).toBe("pick tote from shelf");
+    expect(submission?.startStateConstraints).toBe(
+      "robot starts at aisle entry",
+    );
+    expect(submission?.successCriteria).toBe(
+      "tote placed without safety event",
+    );
+    expect(submission?.selectedModalities).toEqual(["model_checkpoint"]);
+    expect(submission?.modalities.model_checkpoint.reviewStatus).toBe(
+      "ready_for_review",
+    );
+    expect(submission?.requestedOutputs).toEqual([
+      "observation_frames",
+      "action_trace",
+      "success_failure",
+      "export_bundle",
+    ]);
+  });
+});

--- a/client/src/lib/robotTeamTestSubmission.ts
+++ b/client/src/lib/robotTeamTestSubmission.ts
@@ -7,7 +7,33 @@ export type RobotTeamTestSubmissionModalityId =
   | "recorded_action_trace"
   | "high_level_skill_trace"
   | "teleop_demo"
-  | "sim_controller_plugin";
+  | "sim_controller_plugin"
+  | "model_checkpoint";
+
+export type RobotTeamTestSubmissionEpisodeCount = "100" | "500" | "custom";
+
+export type RobotTeamTestSubmissionValidationMode =
+  | "virtual_preflight"
+  | "comparative_policy_eval"
+  | "real_rollout_validated";
+
+export type RobotTeamTestSubmissionRunSetup = {
+  policyLabels: string[];
+  episodeCount: RobotTeamTestSubmissionEpisodeCount;
+  customEpisodeCount?: string;
+  validationMode: RobotTeamTestSubmissionValidationMode;
+  observationSchemaRef: string;
+  actionSchemaRef: string;
+  controlFrequency: string;
+  robotEmbodiment: string;
+  gripper: string;
+  cameraSetup: string;
+  intrinsicsExtrinsicsRef: string;
+  sitePackageTarget: string;
+  taskInstruction: string;
+  startStateConstraints: string;
+  successCriteria: string;
+};
 
 export type RobotTeamTestSubmissionReviewStatus =
   | "not_selected"
@@ -50,8 +76,26 @@ export type RobotTeamTestSubmission = {
   taskId?: string | null;
   scenarioId?: string | null;
   robotProfileId?: string | null;
+  policyLabels: string[];
+  episodeCount: RobotTeamTestSubmissionEpisodeCount;
+  customEpisodeCount?: string;
+  validationMode: RobotTeamTestSubmissionValidationMode;
+  observationSchemaRef: string;
+  actionSchemaRef: string;
+  controlFrequency: string;
+  robotEmbodiment: string;
+  gripper: string;
+  cameraSetup: string;
+  intrinsicsExtrinsicsRef: string;
+  sitePackageTarget: string;
+  taskInstruction: string;
+  startStateConstraints: string;
+  successCriteria: string;
   selectedModalities: RobotTeamTestSubmissionModalityId[];
-  modalities: Record<RobotTeamTestSubmissionModalityId, RobotTeamTestSubmissionModality>;
+  modalities: Record<
+    RobotTeamTestSubmissionModalityId,
+    RobotTeamTestSubmissionModality
+  >;
   missingEvidenceStatuses: string[];
   requestedOutputs: string[];
   pipelineDatasetSchemaRefs: string[];
@@ -63,365 +107,492 @@ export type RobotTeamTestSubmission = {
   };
 };
 
-export const ROBOT_TEAM_TEST_SUBMISSION_MODALITY_DEFINITIONS: RobotTeamTestSubmissionModalityDefinition[] = [
-  {
-    id: "policy_api_endpoint",
-    label: "Policy API endpoint",
-    shortLabel: "API endpoint",
-    summary: "Let Blueprint send an observation to your service and receive the next action back. Keep source code and model weights private.",
-    missingEvidenceStatus: "needs_policy_api_endpoint_ref",
-    requestedOutputs: ["observation_frames", "action_trace", "success_failure", "export_bundle"],
-    fields: [
-      {
-        key: "endpointUrl",
-        label: "Endpoint URL",
-        helper: "HTTPS endpoint or internal gateway URL.",
-        required: true,
-        placeholder: "https://policy.example.com/v1/action",
-      },
-      {
-        key: "authHandling",
-        label: "Auth handling / redacted secret ref",
-        helper: "Name the auth method and where the secret reference lives.",
-        required: true,
-        placeholder: "Bearer token in team secret manager: robot-policy-prod",
-      },
-      {
-        key: "observationSchemaRef",
-        label: "Observation schema URI or JSON ref",
-        helper: "Artifact reference for what the policy sees: cameras, robot state, task instruction, or other inputs.",
-        required: true,
-        placeholder: "gs://team-bucket/schemas/observation.v1.json",
-      },
-      {
-        key: "actionSchemaRef",
-        label: "Action schema URI or JSON ref",
-        helper: "Artifact reference for what the policy sends back: base motion, arm motion, gripper command, skill, or stop signal.",
-        required: true,
-        placeholder: "gs://team-bucket/schemas/action.v1.json",
-      },
-      {
-        key: "runtimeConstraints",
-        label: "Rate-limit / runtime constraints",
-        helper: "Timeout, rate limit, batch, and cold-start constraints.",
-        required: true,
-        placeholder: "200 ms p95, 10 rps, no external network from container.",
-      },
-      {
-        key: "callbackLogUri",
-        label: "Callback / log URI",
-        helper: "Where Blueprint can send or retrieve run logs.",
-        required: true,
-        placeholder: "gs://team-bucket/blueprint/logs/",
-      },
-      {
-        key: "ownerContact",
-        label: "Owner contact",
-        helper: "Technical owner for schema or runtime questions.",
-        required: true,
-        placeholder: "robot-eval-owner@example.com",
-      },
-    ],
-  },
-  {
-    id: "docker_container",
-    label: "Docker container",
-    shortLabel: "Container",
-    summary: "Package the policy as a runnable service when the simulator needs low-latency access on the same machine or private network.",
-    missingEvidenceStatus: "needs_docker_container_ref",
-    requestedOutputs: ["observation_frames", "action_trace", "rollout_video", "export_bundle"],
-    fields: [
-      {
-        key: "imageRef",
-        label: "Image / artifact URI",
-        helper: "Registry ref or artifact pointer for the runnable policy service.",
-        required: true,
-        placeholder: "registry.example.com/team/policy:2026-06-03",
-      },
-      {
-        key: "digestChecksum",
-        label: "Digest / checksum",
-        helper: "Immutable digest or checksum.",
-        required: true,
-        placeholder: "sha256:...",
-      },
-      {
-        key: "entrypoint",
-        label: "Entrypoint",
-        helper: "Command Blueprint should call inside the container.",
-        required: true,
-        placeholder: "python -m policy_server --port 8080",
-      },
-      {
-        key: "environmentContract",
-        label: "Environment contract",
-        helper: "Required env vars, files, mount points, and secret refs.",
-        required: true,
-        placeholder: "OBS_SCHEMA=/schemas/obs.json, ACTION_SCHEMA=/schemas/action.json",
-      },
-      {
-        key: "hardwareNeeds",
-        label: "Hardware / GPU needs",
-        helper: "CPU, memory, GPU, accelerator, and driver expectations.",
-        required: true,
-        placeholder: "1x L4, CUDA 12.4, 16 GB RAM.",
-      },
-      {
-        key: "ioSchemaRef",
-        label: "Expected input / output schema",
-        helper: "Artifact reference for full IO contract.",
-        required: true,
-        placeholder: "gs://team-bucket/schemas/container-io.v1.json",
-      },
-      {
-        key: "runtimeNotes",
-        label: "Runtime notes",
-        helper: "Startup, shutdown, determinism, and unsupported modes.",
-        required: true,
-        placeholder: "Warm-up one request before measuring cycle time.",
-      },
-    ],
-  },
-  {
-    id: "recorded_action_trace",
-    label: "Recorded action traces",
-    shortLabel: "Action traces",
-    summary: "Share precomputed actions for a task when you cannot connect a live policy yet.",
-    missingEvidenceStatus: "needs_recorded_action_trace_ref",
-    requestedOutputs: ["observation_frames", "action_trace", "success_failure", "export_bundle"],
-    fields: [
-      {
-        key: "traceManifestUri",
-        label: "Trace manifest URI",
-        helper: "Manifest containing trace files and run metadata.",
-        required: true,
-        placeholder: "gs://team-bucket/traces/manifest.json",
-      },
-      {
-        key: "format",
-        label: "Format",
-        helper: "Trace format, codec, and serialization.",
-        required: true,
-        placeholder: "JSONL actions, one row per timestamp.",
-      },
-      {
-        key: "taskScenarioMapping",
-        label: "Task / scenario mapping",
-        helper: "How traces map to Blueprint task_id and scenario_id.",
-        required: true,
-        placeholder: "trace task_key maps to task_id sw-chi-01-task-1.",
-      },
-      {
-        key: "timestampAlignment",
-        label: "Timestamp alignment",
-        helper: "Clock source and alignment method.",
-        required: true,
-        placeholder: "Unix ms aligned to observation frame timestamps.",
-      },
-      {
-        key: "observationActionAlignment",
-        label: "Observation / action alignment",
-        helper: "How observations and actions are paired.",
-        required: true,
-        placeholder: "action[t] consumes observation[t-1].",
-      },
-      {
-        key: "successFailureLabels",
-        label: "Success / failure labels",
-        helper: "Label source and label vocabulary.",
-        required: true,
-        placeholder: "success, partial, failure with failure_mode_id.",
-      },
-      {
-        key: "checksum",
-        label: "Checksum",
-        helper: "Manifest checksum or trace package digest.",
-        required: true,
-        placeholder: "sha256:...",
-      },
-    ],
-  },
-  {
-    id: "high_level_skill_trace",
-    label: "High-level skill traces",
-    shortLabel: "Skill traces",
-    summary: "Share steps like navigate, pick, place, or recover when the policy works above low-level joint control.",
-    missingEvidenceStatus: "needs_high_level_skill_trace_ref",
-    requestedOutputs: ["task_summary", "scenario", "success_failure", "export_bundle"],
-    fields: [
-      {
-        key: "skillTaxonomyVersion",
-        label: "Skill taxonomy / version",
-        helper: "Taxonomy name and version used by the trace.",
-        required: true,
-        placeholder: "team.manipulation_skills.v3",
-      },
-      {
-        key: "orderedSkillSequence",
-        label: "Ordered skill sequence",
-        helper: "Artifact URI or inline ordered skill summary.",
-        required: true,
-        placeholder: "approach_shelf -> locate_tote -> grasp_tote -> retreat",
-      },
-      {
-        key: "preconditionsPostconditions",
-        label: "Preconditions / postconditions",
-        helper: "State assertions before and after each skill.",
-        required: true,
-        placeholder: "Pre: tote visible. Post: tote secured in gripper.",
-      },
-      {
-        key: "failureLabels",
-        label: "Failure labels",
-        helper: "Failure taxonomy or label mapping.",
-        required: true,
-        placeholder: "failure_perception_occlusion, failure_intervention_required.",
-      },
-      {
-        key: "sourceType",
-        label: "Source type",
-        helper: "Planner, human-labeled demo, robot log, or policy output.",
-        required: true,
-        placeholder: "planner_export",
-      },
-      {
-        key: "confidenceCoverageNote",
-        label: "Confidence / coverage note",
-        helper: "Coverage gaps, confidence, and reviewed scope.",
-        required: true,
-        placeholder: "Covers nominal tote pick only; low coverage on occluded shelf.",
-      },
-    ],
-  },
-  {
-    id: "teleop_demo",
-    label: "Teleop demos",
-    shortLabel: "Teleop",
-    summary: "Share human-driven demonstrations so Blueprint can compare the site task, controls, labels, and failure points.",
-    missingEvidenceStatus: "needs_teleop_demo_ref",
-    requestedOutputs: ["observation_frames", "action_trace", "rollout_video", "export_bundle"],
-    fields: [
-      {
-        key: "demoArtifactUri",
-        label: "Demo media or trajectory URI",
-        helper: "Artifact reference for media, trajectory, or manifest.",
-        required: true,
-        placeholder: "gs://team-bucket/teleop/demo-001/manifest.json",
-      },
-      {
-        key: "operatorDevice",
-        label: "Operator / device",
-        helper: "Operator role and input device.",
-        required: true,
-        placeholder: "Certified operator, dual-stick controller.",
-      },
-      {
-        key: "controlMapping",
-        label: "Control mapping",
-        helper: "Control dimensions and device mapping.",
-        required: true,
-        placeholder: "left stick base xy, right stick yaw, trigger gripper.",
-      },
-      {
-        key: "timeSync",
-        label: "Time sync",
-        helper: "Clock sync with observation and action records.",
-        required: true,
-        placeholder: "NTP synced, trajectory timestamps in Unix ms.",
-      },
-      {
-        key: "taskScenarioMapping",
-        label: "Task / scenario mapping",
-        helper: "How demos map to Blueprint task and scenario IDs.",
-        required: true,
-        placeholder: "demo_id D001 maps to scenario sw-chi-01-scenario-1.",
-      },
-      {
-        key: "rightsPrivacyAttestation",
-        label: "Rights / privacy attestation",
-        helper: "Artifact reference or statement for demo use boundaries.",
-        required: true,
-        placeholder: "privacy reviewed; operator face excluded; attestation URI attached.",
-      },
-      {
-        key: "labels",
-        label: "Labels",
-        helper: "Success, failure, intervention, and safety labels.",
-        required: true,
-        placeholder: "success=true, interventions=0, safety_events=0.",
-      },
-    ],
-  },
-  {
-    id: "sim_controller_plugin",
-    label: "Sim controller plugin",
-    shortLabel: "Sim plugin",
-    summary: "Share the adapter that lets a simulator speak your robot controller format without claiming the sim has already run.",
-    missingEvidenceStatus: "needs_sim_controller_plugin_ref",
-    requestedOutputs: ["observation_frames", "action_trace", "rollout_video", "export_bundle"],
-    fields: [
-      {
-        key: "simulatorFramework",
-        label: "Simulator / framework",
-        helper: "Simulator family and integration surface.",
-        required: true,
-        placeholder: "Isaac Sim 4.x controller extension.",
-      },
-      {
-        key: "pluginUri",
-        label: "Plugin URI / ref",
-        helper: "Artifact reference for plugin package or source snapshot.",
-        required: true,
-        placeholder: "gs://team-bucket/plugins/isaac-controller-v2.zip",
-      },
-      {
-        key: "supportedControlModes",
-        label: "Supported control modes",
-        helper: "Position, velocity, torque, high-level skill, or custom mode.",
-        required: true,
-        placeholder: "base velocity, ee delta pose, binary gripper.",
-      },
-      {
-        key: "observationActionSpaces",
-        label: "Observation / action spaces",
-        helper: "Observation and action schema references or summaries.",
-        required: true,
-        placeholder: "obs schema v1, action schema ee_delta_pose_gripper.",
-      },
-      {
-        key: "replayExportPath",
-        label: "Replay / export path",
-        helper: "Where replay outputs and logs are written.",
-        required: true,
-        placeholder: "gs://team-bucket/sim/replays/",
-      },
-      {
-        key: "compatibilityNotes",
-        label: "Version / compatibility notes",
-        helper: "Version pinning, unsupported modes, and adapter notes.",
-        required: true,
-        placeholder: "Isaac Sim 4.2, Python 3.10, no contact-rich manipulation yet.",
-      },
-    ],
-  },
-];
+export const ROBOT_TEAM_TEST_SUBMISSION_MODALITY_DEFINITIONS: RobotTeamTestSubmissionModalityDefinition[] =
+  [
+    {
+      id: "policy_api_endpoint",
+      label: "Policy API endpoint",
+      shortLabel: "API endpoint",
+      summary:
+        "Let Blueprint send an observation to your service and receive the next action back. Keep source code and model weights private.",
+      missingEvidenceStatus: "needs_policy_api_endpoint_ref",
+      requestedOutputs: [
+        "observation_frames",
+        "action_trace",
+        "success_failure",
+        "export_bundle",
+      ],
+      fields: [
+        {
+          key: "endpointUrl",
+          label: "Endpoint URL",
+          helper: "HTTPS endpoint or internal gateway URL.",
+          required: true,
+          placeholder: "https://policy.example.com/v1/action",
+        },
+        {
+          key: "authHandling",
+          label: "Auth handling / redacted secret ref",
+          helper: "Name the auth method and where the secret reference lives.",
+          required: true,
+          placeholder: "Bearer token in team secret manager: robot-policy-prod",
+        },
+        {
+          key: "observationSchemaRef",
+          label: "Observation schema URI or JSON ref",
+          helper:
+            "Artifact reference for what the policy sees: cameras, robot state, task instruction, or other inputs.",
+          required: true,
+          placeholder: "gs://team-bucket/schemas/observation.v1.json",
+        },
+        {
+          key: "actionSchemaRef",
+          label: "Action schema URI or JSON ref",
+          helper:
+            "Artifact reference for what the policy sends back: base motion, arm motion, gripper command, skill, or stop signal.",
+          required: true,
+          placeholder: "gs://team-bucket/schemas/action.v1.json",
+        },
+        {
+          key: "runtimeConstraints",
+          label: "Rate-limit / runtime constraints",
+          helper: "Timeout, rate limit, batch, and cold-start constraints.",
+          required: true,
+          placeholder:
+            "200 ms p95, 10 rps, no external network from container.",
+        },
+        {
+          key: "callbackLogUri",
+          label: "Callback / log URI",
+          helper: "Where Blueprint can send or retrieve run logs.",
+          required: true,
+          placeholder: "gs://team-bucket/blueprint/logs/",
+        },
+        {
+          key: "ownerContact",
+          label: "Owner contact",
+          helper: "Technical owner for schema or runtime questions.",
+          required: true,
+          placeholder: "robot-eval-owner@example.com",
+        },
+      ],
+    },
+    {
+      id: "docker_container",
+      label: "Docker container",
+      shortLabel: "Container",
+      summary:
+        "Package the policy as a runnable service when the simulator needs low-latency access on the same machine or private network.",
+      missingEvidenceStatus: "needs_docker_container_ref",
+      requestedOutputs: [
+        "observation_frames",
+        "action_trace",
+        "rollout_video",
+        "export_bundle",
+      ],
+      fields: [
+        {
+          key: "imageRef",
+          label: "Image / artifact URI",
+          helper:
+            "Registry ref or artifact pointer for the runnable policy service.",
+          required: true,
+          placeholder: "registry.example.com/team/policy:2026-06-03",
+        },
+        {
+          key: "digestChecksum",
+          label: "Digest / checksum",
+          helper: "Immutable digest or checksum.",
+          required: true,
+          placeholder: "sha256:...",
+        },
+        {
+          key: "entrypoint",
+          label: "Entrypoint",
+          helper: "Command Blueprint should call inside the container.",
+          required: true,
+          placeholder: "python -m policy_server --port 8080",
+        },
+        {
+          key: "environmentContract",
+          label: "Environment contract",
+          helper: "Required env vars, files, mount points, and secret refs.",
+          required: true,
+          placeholder:
+            "OBS_SCHEMA=/schemas/obs.json, ACTION_SCHEMA=/schemas/action.json",
+        },
+        {
+          key: "hardwareNeeds",
+          label: "Hardware / GPU needs",
+          helper: "CPU, memory, GPU, accelerator, and driver expectations.",
+          required: true,
+          placeholder: "1x L4, CUDA 12.4, 16 GB RAM.",
+        },
+        {
+          key: "ioSchemaRef",
+          label: "Expected input / output schema",
+          helper: "Artifact reference for full IO contract.",
+          required: true,
+          placeholder: "gs://team-bucket/schemas/container-io.v1.json",
+        },
+        {
+          key: "runtimeNotes",
+          label: "Runtime notes",
+          helper: "Startup, shutdown, determinism, and unsupported modes.",
+          required: true,
+          placeholder: "Warm-up one request before measuring cycle time.",
+        },
+      ],
+    },
+    {
+      id: "recorded_action_trace",
+      label: "Recorded action traces",
+      shortLabel: "Action traces",
+      summary:
+        "Share precomputed actions for a task when you cannot connect a live policy yet.",
+      missingEvidenceStatus: "needs_recorded_action_trace_ref",
+      requestedOutputs: [
+        "observation_frames",
+        "action_trace",
+        "success_failure",
+        "export_bundle",
+      ],
+      fields: [
+        {
+          key: "traceManifestUri",
+          label: "Trace manifest URI",
+          helper: "Manifest containing trace files and run metadata.",
+          required: true,
+          placeholder: "gs://team-bucket/traces/manifest.json",
+        },
+        {
+          key: "format",
+          label: "Format",
+          helper: "Trace format, codec, and serialization.",
+          required: true,
+          placeholder: "JSONL actions, one row per timestamp.",
+        },
+        {
+          key: "taskScenarioMapping",
+          label: "Task / scenario mapping",
+          helper: "How traces map to Blueprint task_id and scenario_id.",
+          required: true,
+          placeholder: "trace task_key maps to task_id sw-chi-01-task-1.",
+        },
+        {
+          key: "timestampAlignment",
+          label: "Timestamp alignment",
+          helper: "Clock source and alignment method.",
+          required: true,
+          placeholder: "Unix ms aligned to observation frame timestamps.",
+        },
+        {
+          key: "observationActionAlignment",
+          label: "Observation / action alignment",
+          helper: "How observations and actions are paired.",
+          required: true,
+          placeholder: "action[t] consumes observation[t-1].",
+        },
+        {
+          key: "successFailureLabels",
+          label: "Success / failure labels",
+          helper: "Label source and label vocabulary.",
+          required: true,
+          placeholder: "success, partial, failure with failure_mode_id.",
+        },
+        {
+          key: "checksum",
+          label: "Checksum",
+          helper: "Manifest checksum or trace package digest.",
+          required: true,
+          placeholder: "sha256:...",
+        },
+      ],
+    },
+    {
+      id: "high_level_skill_trace",
+      label: "High-level skill traces",
+      shortLabel: "Skill traces",
+      summary:
+        "Share steps like navigate, pick, place, or recover when the policy works above low-level joint control.",
+      missingEvidenceStatus: "needs_high_level_skill_trace_ref",
+      requestedOutputs: [
+        "task_summary",
+        "scenario",
+        "success_failure",
+        "export_bundle",
+      ],
+      fields: [
+        {
+          key: "skillTaxonomyVersion",
+          label: "Skill taxonomy / version",
+          helper: "Taxonomy name and version used by the trace.",
+          required: true,
+          placeholder: "team.manipulation_skills.v3",
+        },
+        {
+          key: "orderedSkillSequence",
+          label: "Ordered skill sequence",
+          helper: "Artifact URI or inline ordered skill summary.",
+          required: true,
+          placeholder: "approach_shelf -> locate_tote -> grasp_tote -> retreat",
+        },
+        {
+          key: "preconditionsPostconditions",
+          label: "Preconditions / postconditions",
+          helper: "State assertions before and after each skill.",
+          required: true,
+          placeholder: "Pre: tote visible. Post: tote secured in gripper.",
+        },
+        {
+          key: "failureLabels",
+          label: "Failure labels",
+          helper: "Failure taxonomy or label mapping.",
+          required: true,
+          placeholder:
+            "failure_perception_occlusion, failure_intervention_required.",
+        },
+        {
+          key: "sourceType",
+          label: "Source type",
+          helper: "Planner, human-labeled demo, robot log, or policy output.",
+          required: true,
+          placeholder: "planner_export",
+        },
+        {
+          key: "confidenceCoverageNote",
+          label: "Confidence / coverage note",
+          helper: "Coverage gaps, confidence, and reviewed scope.",
+          required: true,
+          placeholder:
+            "Covers nominal tote pick only; low coverage on occluded shelf.",
+        },
+      ],
+    },
+    {
+      id: "teleop_demo",
+      label: "Teleop demos",
+      shortLabel: "Teleop",
+      summary:
+        "Share human-driven demonstrations so Blueprint can compare the site task, controls, labels, and failure points.",
+      missingEvidenceStatus: "needs_teleop_demo_ref",
+      requestedOutputs: [
+        "observation_frames",
+        "action_trace",
+        "rollout_video",
+        "export_bundle",
+      ],
+      fields: [
+        {
+          key: "demoArtifactUri",
+          label: "Demo media or trajectory URI",
+          helper: "Artifact reference for media, trajectory, or manifest.",
+          required: true,
+          placeholder: "gs://team-bucket/teleop/demo-001/manifest.json",
+        },
+        {
+          key: "operatorDevice",
+          label: "Operator / device",
+          helper: "Operator role and input device.",
+          required: true,
+          placeholder: "Certified operator, dual-stick controller.",
+        },
+        {
+          key: "controlMapping",
+          label: "Control mapping",
+          helper: "Control dimensions and device mapping.",
+          required: true,
+          placeholder: "left stick base xy, right stick yaw, trigger gripper.",
+        },
+        {
+          key: "timeSync",
+          label: "Time sync",
+          helper: "Clock sync with observation and action records.",
+          required: true,
+          placeholder: "NTP synced, trajectory timestamps in Unix ms.",
+        },
+        {
+          key: "taskScenarioMapping",
+          label: "Task / scenario mapping",
+          helper: "How demos map to Blueprint task and scenario IDs.",
+          required: true,
+          placeholder: "demo_id D001 maps to scenario sw-chi-01-scenario-1.",
+        },
+        {
+          key: "rightsPrivacyAttestation",
+          label: "Rights / privacy attestation",
+          helper: "Artifact reference or statement for demo use boundaries.",
+          required: true,
+          placeholder:
+            "privacy reviewed; operator face excluded; attestation URI attached.",
+        },
+        {
+          key: "labels",
+          label: "Labels",
+          helper: "Success, failure, intervention, and safety labels.",
+          required: true,
+          placeholder: "success=true, interventions=0, safety_events=0.",
+        },
+      ],
+    },
+    {
+      id: "model_checkpoint",
+      label: "Model checkpoint",
+      shortLabel: "Checkpoint",
+      summary:
+        "Share an immutable model artifact reference and interface notes when Blueprint should prepare a policy handoff without exposing source code.",
+      missingEvidenceStatus: "needs_model_checkpoint_ref",
+      requestedOutputs: [
+        "observation_frames",
+        "action_trace",
+        "success_failure",
+        "export_bundle",
+      ],
+      fields: [
+        {
+          key: "artifactUri",
+          label: "Artifact URI",
+          helper:
+            "Storage URI or registry reference for the checkpoint artifact.",
+          required: true,
+          placeholder: "gs://team-bucket/checkpoints/policy-2026-06-20.pt",
+        },
+        {
+          key: "digestChecksum",
+          label: "Immutable digest / checksum",
+          helper:
+            "Content-addressed digest or checksum for the exact artifact.",
+          required: true,
+          placeholder: "sha256:...",
+        },
+        {
+          key: "frameworkRuntime",
+          label: "Framework / runtime",
+          helper:
+            "Training framework, inference runtime, language, accelerator, and version pins.",
+          required: true,
+          placeholder: "PyTorch 2.4, Python 3.11, CUDA 12.4, safetensors.",
+        },
+        {
+          key: "modelCardPolicyInterfaceNotes",
+          label: "Model card / policy interface notes",
+          helper:
+            "Model card URI or notes on expected inputs, outputs, limits, and unsupported modes.",
+          required: true,
+          placeholder:
+            "Model card at gs://team-bucket/cards/policy.md; expects RGB-D + proprioception.",
+        },
+        {
+          key: "observationSchemaRef",
+          label: "Observation schema ref",
+          helper:
+            "Artifact reference for observation tensors, robot state, and task instruction inputs.",
+          required: true,
+          placeholder: "gs://team-bucket/schemas/observation.v1.json",
+        },
+        {
+          key: "actionSchemaRef",
+          label: "Action schema ref",
+          helper:
+            "Artifact reference for output action space and command units.",
+          required: true,
+          placeholder: "gs://team-bucket/schemas/action.v1.json",
+        },
+        {
+          key: "ownerContact",
+          label: "Owner contact",
+          helper:
+            "Technical owner for checkpoint, runtime, schema, or model-card questions.",
+          required: true,
+          placeholder: "robot-eval-owner@example.com",
+        },
+      ],
+    },
+    {
+      id: "sim_controller_plugin",
+      label: "Sim controller plugin",
+      shortLabel: "Sim plugin",
+      summary:
+        "Share the adapter that lets a simulator speak your robot controller format without claiming the sim has already run.",
+      missingEvidenceStatus: "needs_sim_controller_plugin_ref",
+      requestedOutputs: [
+        "observation_frames",
+        "action_trace",
+        "rollout_video",
+        "export_bundle",
+      ],
+      fields: [
+        {
+          key: "simulatorFramework",
+          label: "Simulator / framework",
+          helper: "Simulator family and integration surface.",
+          required: true,
+          placeholder: "Isaac Sim 4.x controller extension.",
+        },
+        {
+          key: "pluginUri",
+          label: "Plugin URI / ref",
+          helper: "Artifact reference for plugin package or source snapshot.",
+          required: true,
+          placeholder: "gs://team-bucket/plugins/isaac-controller-v2.zip",
+        },
+        {
+          key: "supportedControlModes",
+          label: "Supported control modes",
+          helper:
+            "Position, velocity, torque, high-level skill, or custom mode.",
+          required: true,
+          placeholder: "base velocity, ee delta pose, binary gripper.",
+        },
+        {
+          key: "observationActionSpaces",
+          label: "Observation / action spaces",
+          helper: "Observation and action schema references or summaries.",
+          required: true,
+          placeholder: "obs schema v1, action schema ee_delta_pose_gripper.",
+        },
+        {
+          key: "replayExportPath",
+          label: "Replay / export path",
+          helper: "Where replay outputs and logs are written.",
+          required: true,
+          placeholder: "gs://team-bucket/sim/replays/",
+        },
+        {
+          key: "compatibilityNotes",
+          label: "Version / compatibility notes",
+          helper: "Version pinning, unsupported modes, and adapter notes.",
+          required: true,
+          placeholder:
+            "Isaac Sim 4.2, Python 3.10, no contact-rich manipulation yet.",
+        },
+      ],
+    },
+  ];
 
 const fieldDefinitionsByModality = Object.fromEntries(
   ROBOT_TEAM_TEST_SUBMISSION_MODALITY_DEFINITIONS.map((definition) => [
     definition.id,
     definition,
   ]),
-) as Record<RobotTeamTestSubmissionModalityId, RobotTeamTestSubmissionModalityDefinition>;
+) as Record<
+  RobotTeamTestSubmissionModalityId,
+  RobotTeamTestSubmissionModalityDefinition
+>;
 
 export const ROBOT_TEAM_TEST_SUBMISSION_MODALITY_IDS =
-  ROBOT_TEAM_TEST_SUBMISSION_MODALITY_DEFINITIONS.map((definition) => definition.id);
+  ROBOT_TEAM_TEST_SUBMISSION_MODALITY_DEFINITIONS.map(
+    (definition) => definition.id,
+  );
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === "object" && !Array.isArray(value));
 }
 
 function normalizeString(value: unknown, maxLength = 2000) {
-  const text = String(value ?? "").replace(/\s+/g, " ").trim();
+  const text = String(value ?? "")
+    .replace(/\s+/g, " ")
+    .trim();
   return text.length > maxLength ? text.slice(0, maxLength) : text;
 }
 
@@ -461,7 +632,8 @@ function normalizeRawModality(
     raw.fields ?? raw,
   );
   const hasAnyFieldValue = Object.values(fields).some(Boolean);
-  const selected = raw.selected === true || raw.enabled === true || hasAnyFieldValue;
+  const selected =
+    raw.selected === true || raw.enabled === true || hasAnyFieldValue;
   const reviewStatus: RobotTeamTestSubmissionReviewStatus = !selected
     ? "not_selected"
     : missingFields.length > 0
@@ -476,7 +648,9 @@ function normalizeRawModality(
     artifactReferenceUris,
     missingFields: selected ? missingFields : [],
     missingEvidenceStatus:
-      selected && missingFields.length > 0 ? definition.missingEvidenceStatus : null,
+      selected && missingFields.length > 0
+        ? definition.missingEvidenceStatus
+        : null,
     reviewStatus,
   };
 }
@@ -494,6 +668,28 @@ function rawModalityValue(
     return rawModalities[id];
   }
   return undefined;
+}
+
+function normalizeEpisodeCount(
+  value: unknown,
+): RobotTeamTestSubmissionEpisodeCount {
+  return value === "500" || value === "custom" ? value : "100";
+}
+
+function normalizeValidationMode(
+  value: unknown,
+): RobotTeamTestSubmissionValidationMode {
+  return value === "comparative_policy_eval" ||
+    value === "real_rollout_validated"
+    ? value
+    : "virtual_preflight";
+}
+
+function normalizePolicyLabels(value: unknown) {
+  const source = Array.isArray(value)
+    ? value
+    : String(value ?? "").split(/[\n,]/);
+  return uniqueStrings(source).slice(0, 3);
 }
 
 function uniqueStrings(values: Iterable<unknown>) {
@@ -520,18 +716,28 @@ export function normalizeRobotTeamTestSubmission(
   const modalities = Object.fromEntries(
     ROBOT_TEAM_TEST_SUBMISSION_MODALITY_DEFINITIONS.map((definition) => [
       definition.id,
-      normalizeRawModality(definition, rawModalityValue(rawModalities, definition.id)),
+      normalizeRawModality(
+        definition,
+        rawModalityValue(rawModalities, definition.id),
+      ),
     ]),
-  ) as Record<RobotTeamTestSubmissionModalityId, RobotTeamTestSubmissionModality>;
+  ) as Record<
+    RobotTeamTestSubmissionModalityId,
+    RobotTeamTestSubmissionModality
+  >;
   const selectedModalities = ROBOT_TEAM_TEST_SUBMISSION_MODALITY_IDS.filter(
     (id) => modalities[id].selected,
   );
-  const selectedDefinitions = selectedModalities.map((id) => fieldDefinitionsByModality[id]);
+  const selectedDefinitions = selectedModalities.map(
+    (id) => fieldDefinitionsByModality[id],
+  );
   const missingEvidenceStatuses = uniqueStrings([
     ...selectedModalities
       .map((id) => modalities[id].missingEvidenceStatus)
       .filter(Boolean),
-    ...(selectedModalities.length === 0 ? ["needs_robot_team_test_modality"] : []),
+    ...(selectedModalities.length === 0
+      ? ["needs_robot_team_test_modality"]
+      : []),
   ]);
 
   return {
@@ -541,10 +747,30 @@ export function normalizeRobotTeamTestSubmission(
     taskId: normalizeString(value.taskId, 160) || null,
     scenarioId: normalizeString(value.scenarioId, 160) || null,
     robotProfileId: normalizeString(value.robotProfileId, 160) || null,
+    policyLabels: normalizePolicyLabels(value.policyLabels),
+    episodeCount: normalizeEpisodeCount(value.episodeCount),
+    customEpisodeCount:
+      normalizeEpisodeCount(value.episodeCount) === "custom"
+        ? normalizeString(value.customEpisodeCount, 80) || undefined
+        : undefined,
+    validationMode: normalizeValidationMode(value.validationMode),
+    observationSchemaRef: normalizeString(value.observationSchemaRef),
+    actionSchemaRef: normalizeString(value.actionSchemaRef),
+    controlFrequency: normalizeString(value.controlFrequency),
+    robotEmbodiment: normalizeString(value.robotEmbodiment),
+    gripper: normalizeString(value.gripper),
+    cameraSetup: normalizeString(value.cameraSetup),
+    intrinsicsExtrinsicsRef: normalizeString(value.intrinsicsExtrinsicsRef),
+    sitePackageTarget: normalizeString(value.sitePackageTarget),
+    taskInstruction: normalizeString(value.taskInstruction),
+    startStateConstraints: normalizeString(value.startStateConstraints),
+    successCriteria: normalizeString(value.successCriteria),
     selectedModalities,
     modalities,
     missingEvidenceStatuses,
-    requestedOutputs: uniqueStrings(selectedDefinitions.flatMap((definition) => definition.requestedOutputs)),
+    requestedOutputs: uniqueStrings(
+      selectedDefinitions.flatMap((definition) => definition.requestedOutputs),
+    ),
     pipelineDatasetSchemaRefs: [
       "real_site_robot_eval_dataset_manifest.v0.1",
       "robot_team_test_submission_modalities.v0.1",
@@ -579,6 +805,21 @@ export function buildRobotTeamSubmissionInput(params: {
   taskId?: string | null;
   scenarioId?: string | null;
   robotProfileId?: string | null;
+  policyLabels?: unknown;
+  episodeCount?: unknown;
+  customEpisodeCount?: unknown;
+  validationMode?: unknown;
+  observationSchemaRef?: unknown;
+  actionSchemaRef?: unknown;
+  controlFrequency?: unknown;
+  robotEmbodiment?: unknown;
+  gripper?: unknown;
+  cameraSetup?: unknown;
+  intrinsicsExtrinsicsRef?: unknown;
+  sitePackageTarget?: unknown;
+  taskInstruction?: unknown;
+  startStateConstraints?: unknown;
+  successCriteria?: unknown;
   modalities: Partial<
     Record<
       RobotTeamTestSubmissionModalityId,
@@ -595,6 +836,22 @@ export function buildRobotTeamSubmissionInput(params: {
     taskId: params.taskId ?? null,
     scenarioId: params.scenarioId ?? null,
     robotProfileId: params.robotProfileId ?? null,
+    policyLabels: normalizePolicyLabels(params.policyLabels),
+    episodeCount: normalizeEpisodeCount(params.episodeCount),
+    customEpisodeCount:
+      normalizeString(params.customEpisodeCount, 80) || undefined,
+    validationMode: normalizeValidationMode(params.validationMode),
+    observationSchemaRef: normalizeString(params.observationSchemaRef),
+    actionSchemaRef: normalizeString(params.actionSchemaRef),
+    controlFrequency: normalizeString(params.controlFrequency),
+    robotEmbodiment: normalizeString(params.robotEmbodiment),
+    gripper: normalizeString(params.gripper),
+    cameraSetup: normalizeString(params.cameraSetup),
+    intrinsicsExtrinsicsRef: normalizeString(params.intrinsicsExtrinsicsRef),
+    sitePackageTarget: normalizeString(params.sitePackageTarget),
+    taskInstruction: normalizeString(params.taskInstruction),
+    startStateConstraints: normalizeString(params.startStateConstraints),
+    successCriteria: normalizeString(params.successCriteria),
     modalities: Object.fromEntries(
       ROBOT_TEAM_TEST_SUBMISSION_MODALITY_IDS.map((id) => [
         id,

--- a/client/src/pages/RobotTeamEval.tsx
+++ b/client/src/pages/RobotTeamEval.tsx
@@ -18,6 +18,7 @@ import {
   MonitorPlay,
   PackageCheck,
   Route,
+  Cpu,
   TerminalSquare,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
@@ -42,8 +43,32 @@ import {
 } from "@/lib/robotTeamTestSubmission";
 import type { CreateHostedSessionRequest } from "@/types/hostedSession";
 
-type FieldState = Record<RobotTeamTestSubmissionModalityId, Record<string, string>>;
+type FieldState = Record<
+  RobotTeamTestSubmissionModalityId,
+  Record<string, string>
+>;
 type EnabledState = Record<RobotTeamTestSubmissionModalityId, boolean>;
+
+type RunSetupState = {
+  policyLabels: string;
+  episodeCount: "100" | "500" | "custom";
+  customEpisodeCount: string;
+  validationMode:
+    | "virtual_preflight"
+    | "comparative_policy_eval"
+    | "real_rollout_validated";
+  observationSchemaRef: string;
+  actionSchemaRef: string;
+  controlFrequency: string;
+  robotEmbodiment: string;
+  gripper: string;
+  cameraSetup: string;
+  intrinsicsExtrinsicsRef: string;
+  sitePackageTarget: string;
+  taskInstruction: string;
+  startStateConstraints: string;
+  successCriteria: string;
+};
 
 const iconByModality: Record<RobotTeamTestSubmissionModalityId, LucideIcon> = {
   policy_api_endpoint: Link2,
@@ -52,6 +77,7 @@ const iconByModality: Record<RobotTeamTestSubmissionModalityId, LucideIcon> = {
   high_level_skill_trace: Route,
   teleop_demo: Gamepad2,
   sim_controller_plugin: Code2,
+  model_checkpoint: Cpu,
 };
 
 const fallbackOutputs = [
@@ -84,6 +110,33 @@ function initialFieldState(): FieldState {
   ) as FieldState;
 }
 
+function initialRunSetupState(): RunSetupState {
+  return {
+    policyLabels: "primary-policy",
+    episodeCount: "100",
+    customEpisodeCount: "",
+    validationMode: "virtual_preflight",
+    observationSchemaRef: "",
+    actionSchemaRef: "",
+    controlFrequency: "",
+    robotEmbodiment: "",
+    gripper: "",
+    cameraSetup: "",
+    intrinsicsExtrinsicsRef: "",
+    sitePackageTarget: "",
+    taskInstruction: "",
+    startStateConstraints: "",
+    successCriteria: "",
+  };
+}
+
+function runSetupInput(setup: RunSetupState) {
+  return {
+    ...setup,
+    policyLabels: setup.policyLabels.split(/[\n,]/),
+  };
+}
+
 function initialEnabledState(): EnabledState {
   return Object.fromEntries(
     ROBOT_TEAM_TEST_SUBMISSION_MODALITY_DEFINITIONS.map((definition) => [
@@ -95,13 +148,16 @@ function initialEnabledState(): EnabledState {
 
 function publicDemoSiteWorldIds() {
   const ids = new Set<string>();
-  if (import.meta.env.MODE !== "production" || import.meta.env.VITE_ENABLE_DEMO_SITE_WORLDS === "1") {
+  if (
+    import.meta.env.MODE !== "production" ||
+    import.meta.env.VITE_ENABLE_DEMO_SITE_WORLDS === "1"
+  ) {
     ids.add("siteworld-f5fd54898cfb");
   }
   const envSiteWorldId = String(
-    import.meta.env.VITE_HOSTED_DEMO_SITE_WORLD_ID
-      || import.meta.env.BLUEPRINT_HOSTED_DEMO_SITE_WORLD_ID
-      || "",
+    import.meta.env.VITE_HOSTED_DEMO_SITE_WORLD_ID ||
+      import.meta.env.BLUEPRINT_HOSTED_DEMO_SITE_WORLD_ID ||
+      "",
   ).trim();
   if (envSiteWorldId) {
     ids.add(envSiteWorldId);
@@ -120,7 +176,9 @@ async function getFirebaseIdToken(): Promise<string> {
 
   try {
     const firebase = await import("@/lib/firebase");
-    return firebase.auth?.currentUser ? await firebase.auth.currentUser.getIdToken() : "";
+    return firebase.auth?.currentUser
+      ? await firebase.auth.currentUser.getIdToken()
+      : "";
   } catch {
     return "";
   }
@@ -134,7 +192,9 @@ function createSubmissionId() {
 }
 
 function selectedSiteDefaultId() {
-  const publicDemo = siteWorldCards.find((site) => site.id === "siteworld-f5fd54898cfb");
+  const publicDemo = siteWorldCards.find(
+    (site) => site.id === "siteworld-f5fd54898cfb",
+  );
   return publicDemo?.id || siteWorldCards[0]?.id || "";
 }
 
@@ -145,8 +205,30 @@ function buildRequestReviewHref(params: {
   robotName: string;
   submission: RobotTeamTestSubmission | null;
 }) {
-  const selectedModes = params.submission?.selectedModalities.join(", ") || "structured robot-team test";
-  const missing = params.submission?.missingEvidenceStatuses.join(", ") || "none recorded yet";
+  const selectedModes =
+    params.submission?.selectedModalities.join(", ") ||
+    "structured robot-team test";
+  const missing =
+    params.submission?.missingEvidenceStatuses.join(", ") ||
+    "none recorded yet";
+  const setup = params.submission
+    ? [
+        `policyLabels=${params.submission.policyLabels.join(", ") || "none entered"}`,
+        `episodeCount=${params.submission.episodeCount}${params.submission.customEpisodeCount ? ` (${params.submission.customEpisodeCount})` : ""}`,
+        `validationMode=${params.submission.validationMode}`,
+        `observationSchemaRef=${params.submission.observationSchemaRef || "none entered"}`,
+        `actionSchemaRef=${params.submission.actionSchemaRef || "none entered"}`,
+        `controlFrequency=${params.submission.controlFrequency || "none entered"}`,
+        `robotEmbodiment=${params.submission.robotEmbodiment || "none entered"}`,
+        `gripper=${params.submission.gripper || "none entered"}`,
+        `cameraSetup=${params.submission.cameraSetup || "none entered"}`,
+        `intrinsicsExtrinsicsRef=${params.submission.intrinsicsExtrinsicsRef || "none entered"}`,
+        `sitePackageTarget=${params.submission.sitePackageTarget || "none entered"}`,
+        `taskInstruction=${params.submission.taskInstruction || "none entered"}`,
+        `startStateConstraints=${params.submission.startStateConstraints || "none entered"}`,
+        `successCriteria=${params.submission.successCriteria || "none entered"}`,
+      ].join("\n")
+    : "no run setup entered";
   const structuredRefs = params.submission
     ? params.submission.selectedModalities
         .map((modalityId) => {
@@ -168,8 +250,10 @@ function buildRequestReviewHref(params: {
     siteLocation: params.siteAddress,
     targetRobotTeam: params.robotName,
     taskStatement: `Robot-team structured test submission for ${params.taskText}`,
-    requestedOutputs: params.submission?.requestedOutputs.join(", ") || fallbackOutputs.join(", "),
-    message: `Selected modalities: ${selectedModes}\nMissing evidence statuses: ${missing}\nStructured refs:\n${structuredRefs}`,
+    requestedOutputs:
+      params.submission?.requestedOutputs.join(", ") ||
+      fallbackOutputs.join(", "),
+    message: `Selected modalities: ${selectedModes}\nMissing evidence statuses: ${missing}\nRun setup:\n${setup}\nStructured refs:\n${structuredRefs}`,
   });
   return `/contact?${query.toString()}`;
 }
@@ -187,27 +271,44 @@ export default function RobotTeamEval() {
   const [evalScenarioFamilyId, setEvalScenarioFamilyId] = useState(
     initialEvalSite.scenarioFamilies[0].id,
   );
-  const [enabled, setEnabled] = useState<EnabledState>(() => initialEnabledState());
-  const [fieldValues, setFieldValues] = useState<FieldState>(() => initialFieldState());
-  const [status, setStatus] = useState<"idle" | "submitting" | "created" | "blocked">("idle");
+  const [enabled, setEnabled] = useState<EnabledState>(() =>
+    initialEnabledState(),
+  );
+  const [fieldValues, setFieldValues] = useState<FieldState>(() =>
+    initialFieldState(),
+  );
+  const [runSetup, setRunSetup] = useState<RunSetupState>(() =>
+    initialRunSetupState(),
+  );
+  const [status, setStatus] = useState<
+    "idle" | "submitting" | "created" | "blocked"
+  >("idle");
   const [statusMessage, setStatusMessage] = useState("");
-  const [lastSubmission, setLastSubmission] = useState<RobotTeamTestSubmission | null>(null);
+  const [lastSubmission, setLastSubmission] =
+    useState<RobotTeamTestSubmission | null>(null);
 
   const selectedSite = useMemo(
-    () => siteWorldCards.find((site) => site.id === selectedSiteId) || siteWorldCards[0],
+    () =>
+      siteWorldCards.find((site) => site.id === selectedSiteId) ||
+      siteWorldCards[0],
     [selectedSiteId],
   );
-  const selectedRobot = selectedSite?.robotProfiles[0] || selectedSite?.sampleRobotProfile || null;
+  const selectedRobot =
+    selectedSite?.robotProfiles[0] || selectedSite?.sampleRobotProfile || null;
   const selectedTask = selectedSite?.taskCatalog[0] || null;
   const selectedScenario = selectedSite?.scenarioCatalog[0] || null;
   const selectedStartState = selectedSite?.startStateCatalog[0] || null;
-  const selectedEvalSite = useMemo(() => getRobotEvalMoatSite(evalSiteId), [evalSiteId]);
+  const selectedEvalSite = useMemo(
+    () => getRobotEvalMoatSite(evalSiteId),
+    [evalSiteId],
+  );
   const selectedEvalTask = useMemo(
     () => getRobotEvalMoatTask(selectedEvalSite, evalTaskId),
     [evalTaskId, selectedEvalSite],
   );
   const selectedEvalScenarioFamily = useMemo(
-    () => getRobotEvalMoatScenarioFamily(selectedEvalSite, evalScenarioFamilyId),
+    () =>
+      getRobotEvalMoatScenarioFamily(selectedEvalSite, evalScenarioFamilyId),
     [evalScenarioFamilyId, selectedEvalSite],
   );
 
@@ -221,6 +322,7 @@ export default function RobotTeamEval() {
         taskId: selectedTask.id,
         scenarioId: selectedScenario.id,
         robotProfileId: selectedRobot.id || "",
+        ...runSetupInput(runSetup),
         modalities: Object.fromEntries(
           ROBOT_TEAM_TEST_SUBMISSION_MODALITY_DEFINITIONS.map((definition) => [
             definition.id,
@@ -232,12 +334,23 @@ export default function RobotTeamEval() {
         ),
       }),
     );
-  }, [enabled, fieldValues, selectedRobot, selectedScenario, selectedSite, selectedTask]);
+  }, [
+    enabled,
+    fieldValues,
+    runSetup,
+    selectedRobot,
+    selectedScenario,
+    selectedSite,
+    selectedTask,
+  ]);
 
   const requestReviewHref = buildRequestReviewHref({
     siteName: selectedSite?.siteName || "Blueprint site package",
     siteAddress: selectedSite?.siteAddress || "",
-    taskText: selectedEvalTask?.label || selectedTask?.taskText || "selected robot task",
+    taskText:
+      selectedEvalTask?.label ||
+      selectedTask?.taskText ||
+      "selected robot task",
     robotName: selectedRobot?.displayName || "robot profile",
     submission: lastSubmission || currentSubmission,
   });
@@ -247,9 +360,18 @@ export default function RobotTeamEval() {
     setEvalSiteId(nextSite.id);
     setEvalTaskId(nextSite.tasks[0].id);
     setEvalScenarioFamilyId(nextSite.scenarioFamilies[0].id);
-    if (siteWorldCards.some((site) => site.id === nextSite.catalogSiteWorldId)) {
+    if (
+      siteWorldCards.some((site) => site.id === nextSite.catalogSiteWorldId)
+    ) {
       setSelectedSiteId(nextSite.catalogSiteWorldId);
     }
+  };
+
+  const updateRunSetup = <Key extends keyof RunSetupState>(
+    key: Key,
+    value: RunSetupState[Key],
+  ) => {
+    setRunSetup((current) => ({ ...current, [key]: value }));
   };
 
   const updateField = (
@@ -271,9 +393,17 @@ export default function RobotTeamEval() {
     setStatus("submitting");
     setStatusMessage("");
 
-    if (!selectedSite || !selectedRobot || !selectedTask || !selectedScenario || !selectedStartState) {
+    if (
+      !selectedSite ||
+      !selectedRobot ||
+      !selectedTask ||
+      !selectedScenario ||
+      !selectedStartState
+    ) {
       setStatus("blocked");
-      setStatusMessage("Select a site package with task, scenario, start-state, and robot-profile records.");
+      setStatusMessage(
+        "Select a site package with task, scenario, start-state, and robot-profile records.",
+      );
       return;
     }
 
@@ -284,6 +414,7 @@ export default function RobotTeamEval() {
         taskId: selectedTask.id,
         scenarioId: selectedScenario.id,
         robotProfileId: selectedRobot.id || "",
+        ...runSetupInput(runSetup),
         modalities: Object.fromEntries(
           ROBOT_TEAM_TEST_SUBMISSION_MODALITY_DEFINITIONS.map((definition) => [
             definition.id,
@@ -326,7 +457,9 @@ export default function RobotTeamEval() {
         trajectory: null,
         presentation_model: null,
         debug_mode: false,
-        unsafe_allow_blocked_site_world: isPublicDemoSiteWorldId(selectedSite.id),
+        unsafe_allow_blocked_site_world: isPublicDemoSiteWorldId(
+          selectedSite.id,
+        ),
       },
       policy: {
         runMode: "robot_team_structured_test_submission",
@@ -344,7 +477,9 @@ export default function RobotTeamEval() {
       const token = await getFirebaseIdToken();
       const usePublicDemoRoutes = isPublicDemoSiteWorldId(selectedSite.id);
       if (!token && !usePublicDemoRoutes) {
-        throw new Error("Direct session creation needs robot-team access for this protected site package.");
+        throw new Error(
+          "Direct session creation needs robot-team access for this protected site package.",
+        );
       }
       const response = await fetch("/api/site-worlds/sessions", {
         method: "POST",
@@ -365,15 +500,22 @@ export default function RobotTeamEval() {
         throw new Error(
           Array.isArray(payload.blockers) && payload.blockers.length > 0
             ? payload.blockers.join(", ")
-            : payload.error || "Hosted-session creation is request-gated for this package.",
+            : payload.error ||
+                "Hosted-session creation is request-gated for this package.",
         );
       }
       setStatus("created");
-      setStatusMessage("Hosted session created with the structured robot-team test submission attached.");
+      setStatusMessage(
+        "Hosted session created with the structured robot-team test submission attached.",
+      );
       setLocation(payload.workspaceUrl);
     } catch (error) {
       setStatus("blocked");
-      setStatusMessage(error instanceof Error ? error.message : "Direct session creation is request-gated.");
+      setStatusMessage(
+        error instanceof Error
+          ? error.message
+          : "Direct session creation is request-gated.",
+      );
     }
   };
 
@@ -442,9 +584,9 @@ export default function RobotTeamEval() {
                 Site package + robot profile + policy access = eval report.
               </h2>
               <p className="mt-4 max-w-xl text-sm leading-6 text-slate-600">
-                Robot teams keep source code and model weights private. Blueprint
-                only needs the least-sensitive interface that still lets the task
-                be scored.
+                Robot teams keep source code and model weights private.
+                Blueprint only needs the least-sensitive interface that still
+                lets the task be scored.
               </p>
               <p className="mt-5 border-l-2 border-amber-500 pl-3 text-xs leading-5 text-slate-500">
                 Submitted interfaces are inputs. Stronger claims need run logs,
@@ -455,11 +597,16 @@ export default function RobotTeamEval() {
             <div className="flex flex-col justify-center">
               <div className="grid grid-cols-2 gap-2">
                 {visualWorkflowSteps.map((step, index) => (
-                  <div key={step} className="border border-slate-200 bg-slate-50 p-3">
+                  <div
+                    key={step}
+                    className="border border-slate-200 bg-slate-50 p-3"
+                  >
                     <p className="text-xs font-semibold uppercase text-slate-400">
                       {String(index + 1).padStart(2, "0")}
                     </p>
-                    <p className="mt-1 text-sm font-semibold text-slate-950">{step}</p>
+                    <p className="mt-1 text-sm font-semibold text-slate-950">
+                      {step}
+                    </p>
                   </div>
                 ))}
               </div>
@@ -496,9 +643,9 @@ export default function RobotTeamEval() {
                 </h2>
                 <p className="mt-3 max-w-4xl text-sm leading-6 text-slate-600">
                   The product loop stays artifact-first: representative site
-                  package, canonical task ID, scenario family, submitted policy or
-                  trace references, advisory report, and a scoped pilot, tune, or
-                  hold decision.
+                  package, canonical task ID, scenario family, submitted policy
+                  or trace references, advisory report, and a scoped pilot,
+                  tune, or hold decision.
                 </p>
               </div>
               <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs font-semibold uppercase text-amber-900">
@@ -548,12 +695,15 @@ export default function RobotTeamEval() {
                 <select
                   aria-label="Scenario family"
                   value={selectedEvalScenarioFamily.id}
-                  onChange={(event) => setEvalScenarioFamilyId(event.target.value)}
+                  onChange={(event) =>
+                    setEvalScenarioFamilyId(event.target.value)
+                  }
                   className="w-full rounded-md border border-slate-300 bg-white px-3 py-3 text-sm text-slate-950 outline-none transition focus:border-slate-950"
                 >
                   {selectedEvalSite.scenarioFamilies.map((scenarioFamily) => (
                     <option key={scenarioFamily.id} value={scenarioFamily.id}>
-                      {scenarioFamily.label} - {scenarioFamily.generatedScenarioCount} variants
+                      {scenarioFamily.label} -{" "}
+                      {scenarioFamily.generatedScenarioCount} variants
                     </option>
                   ))}
                 </select>
@@ -570,14 +720,16 @@ export default function RobotTeamEval() {
                   {selectedEvalScenarioFamily.sampleScenario}
                 </p>
                 <div className="mt-3 flex flex-wrap gap-2">
-                  {selectedEvalScenarioFamily.variationIds.map((variationId) => (
-                    <span
-                      key={variationId}
-                      className="rounded-md border border-slate-200 bg-white px-2.5 py-1 text-xs font-semibold text-slate-600"
-                    >
-                      {variationId.replaceAll("_", " ")}
-                    </span>
-                  ))}
+                  {selectedEvalScenarioFamily.variationIds.map(
+                    (variationId) => (
+                      <span
+                        key={variationId}
+                        className="rounded-md border border-slate-200 bg-white px-2.5 py-1 text-xs font-semibold text-slate-600"
+                      >
+                        {variationId.replaceAll("_", " ")}
+                      </span>
+                    ),
+                  )}
                 </div>
               </div>
               <div className="rounded-md border border-slate-200 bg-slate-50 p-4">
@@ -612,14 +764,15 @@ export default function RobotTeamEval() {
                   <p className="text-[11px] font-semibold uppercase text-slate-400">
                     Step {index + 1}
                   </p>
-                  <h3 className="mt-1 text-sm font-semibold text-slate-950">{step.label}</h3>
+                  <h3 className="mt-1 text-sm font-semibold text-slate-950">
+                    {step.label}
+                  </h3>
                   <p className="mt-2 break-words text-xs font-semibold text-slate-500">
                     {step.artifact}
                   </p>
                 </article>
               ))}
             </div>
-
           </div>
 
           <aside className="h-fit rounded-lg border border-black/10 bg-white p-5 shadow-sm lg:sticky lg:top-24">
@@ -628,9 +781,12 @@ export default function RobotTeamEval() {
                 <Gauge className="h-5 w-5" />
               </div>
               <div>
-                <p className="text-sm font-semibold text-slate-950">Advisory eval report</p>
+                <p className="text-sm font-semibold text-slate-950">
+                  Advisory eval report
+                </p>
                 <p className="mt-1 text-xs leading-5 text-slate-500">
-                  Representative policy_eval_report.json output for the selected workflow.
+                  Representative policy_eval_report.json output for the selected
+                  workflow.
                 </p>
               </div>
             </div>
@@ -646,7 +802,9 @@ export default function RobotTeamEval() {
                   }`}
                 >
                   <div className="flex items-start justify-between gap-3">
-                    <p className="text-sm font-semibold text-slate-950">{metric.label}</p>
+                    <p className="text-sm font-semibold text-slate-950">
+                      {metric.label}
+                    </p>
                     <span className="shrink-0 text-xs font-semibold uppercase text-slate-500">
                       {metric.status}
                     </span>
@@ -654,7 +812,9 @@ export default function RobotTeamEval() {
                   <p className="mt-1 text-lg font-semibold text-slate-950">
                     {metric.value}
                   </p>
-                  <p className="mt-1 text-xs leading-5 text-slate-500">{metric.detail}</p>
+                  <p className="mt-1 text-xs leading-5 text-slate-500">
+                    {metric.detail}
+                  </p>
                 </div>
               ))}
             </div>
@@ -662,13 +822,22 @@ export default function RobotTeamEval() {
             <div className="mt-5">
               <div className="flex items-center gap-2">
                 <GitBranch className="h-4 w-4 text-slate-500" />
-                <p className="text-sm font-semibold text-slate-950">Decision options</p>
+                <p className="text-sm font-semibold text-slate-950">
+                  Decision options
+                </p>
               </div>
               <div className="mt-3 grid gap-2">
                 {robotEvalDecisionOptions.map((option) => (
-                  <div key={option.id} className="rounded-md border border-slate-200 bg-slate-50 p-3">
-                    <p className="text-sm font-semibold text-slate-950">{option.label}</p>
-                    <p className="mt-1 text-xs leading-5 text-slate-500">{option.criteria}</p>
+                  <div
+                    key={option.id}
+                    className="rounded-md border border-slate-200 bg-slate-50 p-3"
+                  >
+                    <p className="text-sm font-semibold text-slate-950">
+                      {option.label}
+                    </p>
+                    <p className="mt-1 text-xs leading-5 text-slate-500">
+                      {option.criteria}
+                    </p>
                   </div>
                 ))}
               </div>
@@ -692,15 +861,18 @@ export default function RobotTeamEval() {
                     Choose the real-site package and task context
                   </h2>
                   <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-600">
-                    The submission is attached to a siteWorldId, taskId, scenarioId,
-                    startStateId, robotProfileId, and requested output list.
+                    The submission is attached to a siteWorldId, taskId,
+                    scenarioId, startStateId, robotProfileId, and requested
+                    output list.
                   </p>
                 </div>
                 <PackageCheck className="hidden h-10 w-10 text-slate-400 md:block" />
               </div>
               <div className="mt-5 grid gap-4 lg:grid-cols-[minmax(0,0.7fr)_minmax(0,0.3fr)]">
                 <label className="block">
-                  <span className="mb-2 block text-sm font-semibold text-slate-800">Package</span>
+                  <span className="mb-2 block text-sm font-semibold text-slate-800">
+                    Package
+                  </span>
                   <select
                     value={selectedSite?.id || selectedSiteId}
                     onChange={(event) => setSelectedSiteId(event.target.value)}
@@ -714,97 +886,297 @@ export default function RobotTeamEval() {
                   </select>
                 </label>
                 <div className="rounded-md border border-slate-200 bg-slate-50 p-4">
-                  <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">Selected robot</p>
-                  <p className="mt-2 text-sm font-semibold text-slate-950">{selectedRobot?.displayName || "Robot profile required"}</p>
-                  <p className="mt-1 text-xs leading-5 text-slate-500">{selectedRobot?.actionSpaceSummary || "Action space pending."}</p>
+                  <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
+                    Selected robot
+                  </p>
+                  <p className="mt-2 text-sm font-semibold text-slate-950">
+                    {selectedRobot?.displayName || "Robot profile required"}
+                  </p>
+                  <p className="mt-1 text-xs leading-5 text-slate-500">
+                    {selectedRobot?.actionSpaceSummary ||
+                      "Action space pending."}
+                  </p>
                 </div>
               </div>
             </section>
 
-            <section className="grid gap-4 xl:grid-cols-2">
-              {ROBOT_TEAM_TEST_SUBMISSION_MODALITY_DEFINITIONS.map((definition, index) => {
-                const Icon = iconByModality[definition.id];
-                const normalized = currentSubmission?.modalities[definition.id];
-                const selected = enabled[definition.id];
-                return (
-                  <article
-                    key={definition.id}
-                    className={`rounded-lg border bg-white p-5 shadow-sm transition ${
-                      selected ? "border-slate-950" : "border-black/10"
-                    }`}
+            <section className="rounded-lg border border-black/10 bg-white p-5 shadow-sm">
+              <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+                <div>
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+                    Run setup
+                  </p>
+                  <h2 className="mt-2 text-2xl font-semibold tracking-[-0.03em]">
+                    Describe the policy, robot, sensors, and success contract
+                  </h2>
+                  <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-600">
+                    These top-level fields travel with every modality so the
+                    handoff keeps policy labels, episode counts, schema refs,
+                    robot embodiment, camera setup, and task criteria separate
+                    from artifact-specific refs.
+                  </p>
+                </div>
+              </div>
+              <div className="mt-5 grid gap-4 lg:grid-cols-3">
+                <label className="block">
+                  <span className="mb-2 block text-sm font-semibold text-slate-800">
+                    Policy labels
+                  </span>
+                  <textarea
+                    aria-label="Policy labels"
+                    value={runSetup.policyLabels}
+                    onChange={(event) =>
+                      updateRunSetup("policyLabels", event.target.value)
+                    }
+                    rows={2}
+                    placeholder="primary-policy, baseline-policy, ablation-policy"
+                    className="w-full resize-y rounded-md border border-slate-300 bg-white px-3 py-2.5 text-sm leading-6 text-slate-950 outline-none transition placeholder:text-slate-400 focus:border-slate-950"
+                  />
+                  <span className="mt-1.5 block text-xs leading-5 text-slate-500">
+                    Enter 1-3 non-empty labels separated by commas or new lines.
+                  </span>
+                </label>
+                <label className="block">
+                  <span className="mb-2 block text-sm font-semibold text-slate-800">
+                    Episode count
+                  </span>
+                  <select
+                    aria-label="Episode count"
+                    value={runSetup.episodeCount}
+                    onChange={(event) =>
+                      updateRunSetup(
+                        "episodeCount",
+                        event.target.value as RunSetupState["episodeCount"],
+                      )
+                    }
+                    className="w-full rounded-md border border-slate-300 bg-white px-3 py-3 text-sm text-slate-950 outline-none transition focus:border-slate-950"
                   >
-                    <div className="flex items-start justify-between gap-4">
-                      <div className="flex min-w-0 items-start gap-3">
-                        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md border border-slate-200 bg-slate-50">
-                          <Icon className="h-5 w-5 text-slate-700" />
-                        </div>
-                        <div className="min-w-0">
-                          <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">
-                            Modality {index + 1}
-                          </p>
-                          <h3 className="mt-1 text-lg font-semibold tracking-[-0.02em] text-slate-950">
-                            {definition.label}
-                          </h3>
-                          <p className="mt-2 text-sm leading-6 text-slate-600">{definition.summary}</p>
-                        </div>
-                      </div>
-                      <button
-                        type="button"
-                        onClick={() =>
-                          setEnabled((current) => ({
-                            ...current,
-                            [definition.id]: !current[definition.id],
-                          }))
-                        }
-                        className={`inline-flex min-h-10 shrink-0 items-center rounded-md border px-3 text-xs font-semibold uppercase tracking-[0.12em] ${
-                          selected
-                            ? "border-emerald-600 bg-emerald-50 text-emerald-800"
-                            : "border-slate-200 bg-white text-slate-500"
-                        }`}
-                      >
-                        {selected ? "Selected" : "Add"}
-                      </button>
-                    </div>
+                    <option value="100">100 episodes</option>
+                    <option value="500">500 episodes</option>
+                    <option value="custom">Custom</option>
+                  </select>
+                </label>
+                <label className="block">
+                  <span className="mb-2 block text-sm font-semibold text-slate-800">
+                    Custom episode count
+                  </span>
+                  <input
+                    aria-label="Custom episode count"
+                    value={runSetup.customEpisodeCount}
+                    onChange={(event) =>
+                      updateRunSetup("customEpisodeCount", event.target.value)
+                    }
+                    disabled={runSetup.episodeCount !== "custom"}
+                    placeholder="250"
+                    className="w-full rounded-md border border-slate-300 bg-white px-3 py-3 text-sm text-slate-950 outline-none transition placeholder:text-slate-400 focus:border-slate-950 disabled:bg-slate-100 disabled:text-slate-400"
+                  />
+                </label>
+                <label className="block">
+                  <span className="mb-2 block text-sm font-semibold text-slate-800">
+                    Validation mode
+                  </span>
+                  <select
+                    aria-label="Validation mode"
+                    value={runSetup.validationMode}
+                    onChange={(event) =>
+                      updateRunSetup(
+                        "validationMode",
+                        event.target.value as RunSetupState["validationMode"],
+                      )
+                    }
+                    className="w-full rounded-md border border-slate-300 bg-white px-3 py-3 text-sm text-slate-950 outline-none transition focus:border-slate-950"
+                  >
+                    <option value="virtual_preflight">Virtual preflight</option>
+                    <option value="comparative_policy_eval">
+                      Comparative policy eval
+                    </option>
+                    <option value="real_rollout_validated">
+                      Real rollout validated
+                    </option>
+                  </select>
+                </label>
+                {(
+                  [
+                    [
+                      "observationSchemaRef",
+                      "Observation schema ref",
+                      "gs://team-bucket/schemas/observation.v1.json",
+                    ],
+                    [
+                      "actionSchemaRef",
+                      "Action schema ref",
+                      "gs://team-bucket/schemas/action.v1.json",
+                    ],
+                    [
+                      "controlFrequency",
+                      "Control frequency",
+                      "20 Hz control loop",
+                    ],
+                    [
+                      "robotEmbodiment",
+                      "Robot embodiment",
+                      "Mobile manipulator with 7-DoF arm",
+                    ],
+                    ["gripper", "Gripper", "parallel jaw gripper"],
+                    [
+                      "cameraSetup",
+                      "Camera setup",
+                      "wrist RGB-D + mast stereo",
+                    ],
+                    [
+                      "intrinsicsExtrinsicsRef",
+                      "Intrinsics / extrinsics ref",
+                      "gs://team-bucket/calibration/cameras.json",
+                    ],
+                    [
+                      "sitePackageTarget",
+                      "Site package target",
+                      "Cold-storage pick aisle package",
+                    ],
+                    [
+                      "taskInstruction",
+                      "Task instruction",
+                      "Pick tote from shelf and place onto cart",
+                    ],
+                    [
+                      "startStateConstraints",
+                      "Start-state constraints",
+                      "Robot starts at aisle entry; tote visible",
+                    ],
+                    [
+                      "successCriteria",
+                      "Success criteria",
+                      "Tote placed on cart without safety event",
+                    ],
+                  ] as const
+                ).map(([key, label, placeholder]) => (
+                  <label key={key} className="block">
+                    <span className="mb-2 block text-sm font-semibold text-slate-800">
+                      {label}
+                    </span>
+                    <textarea
+                      aria-label={label}
+                      value={runSetup[key]}
+                      onChange={(event) =>
+                        updateRunSetup(key, event.target.value)
+                      }
+                      rows={2}
+                      placeholder={placeholder}
+                      className="w-full resize-y rounded-md border border-slate-300 bg-white px-3 py-2.5 text-sm leading-6 text-slate-950 outline-none transition placeholder:text-slate-400 focus:border-slate-950"
+                    />
+                  </label>
+                ))}
+              </div>
+            </section>
 
-                    {selected ? (
-                      <div className="mt-5 grid gap-3">
-                        {definition.fields.map((field) => (
-                          <label key={field.key} className="block">
-                            <span className="mb-1.5 flex items-center justify-between gap-3 text-sm font-semibold text-slate-800">
-                              <span>{field.label}</span>
-                              {field.required ? <span className="text-xs text-slate-400">Required</span> : null}
-                            </span>
-                            <textarea
-                              aria-label={`${definition.label} ${field.label}`}
-                              value={fieldValues[definition.id][field.key] || ""}
-                              onChange={(event) => updateField(definition.id, field.key, event.target.value)}
-                              rows={field.key.toLowerCase().includes("sequence") ? 3 : 2}
-                              placeholder={field.placeholder}
-                              className="w-full resize-y rounded-md border border-slate-300 bg-white px-3 py-2.5 text-sm leading-6 text-slate-950 outline-none transition placeholder:text-slate-400 focus:border-slate-950"
-                            />
-                            <span className="mt-1.5 block text-xs leading-5 text-slate-500">{field.helper}</span>
-                          </label>
-                        ))}
+            <section className="grid gap-4 xl:grid-cols-2">
+              {ROBOT_TEAM_TEST_SUBMISSION_MODALITY_DEFINITIONS.map(
+                (definition, index) => {
+                  const Icon = iconByModality[definition.id];
+                  const normalized =
+                    currentSubmission?.modalities[definition.id];
+                  const selected = enabled[definition.id];
+                  return (
+                    <article
+                      key={definition.id}
+                      className={`rounded-lg border bg-white p-5 shadow-sm transition ${
+                        selected ? "border-slate-950" : "border-black/10"
+                      }`}
+                    >
+                      <div className="flex items-start justify-between gap-4">
+                        <div className="flex min-w-0 items-start gap-3">
+                          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md border border-slate-200 bg-slate-50">
+                            <Icon className="h-5 w-5 text-slate-700" />
+                          </div>
+                          <div className="min-w-0">
+                            <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">
+                              Modality {index + 1}
+                            </p>
+                            <h3 className="mt-1 text-lg font-semibold tracking-[-0.02em] text-slate-950">
+                              {definition.label}
+                            </h3>
+                            <p className="mt-2 text-sm leading-6 text-slate-600">
+                              {definition.summary}
+                            </p>
+                          </div>
+                        </div>
+                        <button
+                          type="button"
+                          onClick={() =>
+                            setEnabled((current) => ({
+                              ...current,
+                              [definition.id]: !current[definition.id],
+                            }))
+                          }
+                          className={`inline-flex min-h-10 shrink-0 items-center rounded-md border px-3 text-xs font-semibold uppercase tracking-[0.12em] ${
+                            selected
+                              ? "border-emerald-600 bg-emerald-50 text-emerald-800"
+                              : "border-slate-200 bg-white text-slate-500"
+                          }`}
+                        >
+                          {selected ? "Selected" : "Add"}
+                        </button>
                       </div>
-                    ) : (
-                      <p className="mt-5 rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-xs font-semibold text-slate-500">
-                        Add this mode to show the required references.
-                      </p>
-                    )}
 
-                    <div className="mt-4 flex flex-wrap items-center gap-2 text-xs font-semibold">
-                      <span className="rounded-md border border-slate-200 bg-slate-50 px-2.5 py-1 text-slate-600">
-                        {normalized?.reviewStatus.replaceAll("_", " ") || "not selected"}
-                      </span>
-                      {normalized?.missingEvidenceStatus ? (
-                        <span className="rounded-md border border-amber-300 bg-amber-50 px-2.5 py-1 text-amber-800">
-                          {normalized.missingEvidenceStatus}
+                      {selected ? (
+                        <div className="mt-5 grid gap-3">
+                          {definition.fields.map((field) => (
+                            <label key={field.key} className="block">
+                              <span className="mb-1.5 flex items-center justify-between gap-3 text-sm font-semibold text-slate-800">
+                                <span>{field.label}</span>
+                                {field.required ? (
+                                  <span className="text-xs text-slate-400">
+                                    Required
+                                  </span>
+                                ) : null}
+                              </span>
+                              <textarea
+                                aria-label={`${definition.label} ${field.label}`}
+                                value={
+                                  fieldValues[definition.id][field.key] || ""
+                                }
+                                onChange={(event) =>
+                                  updateField(
+                                    definition.id,
+                                    field.key,
+                                    event.target.value,
+                                  )
+                                }
+                                rows={
+                                  field.key.toLowerCase().includes("sequence")
+                                    ? 3
+                                    : 2
+                                }
+                                placeholder={field.placeholder}
+                                className="w-full resize-y rounded-md border border-slate-300 bg-white px-3 py-2.5 text-sm leading-6 text-slate-950 outline-none transition placeholder:text-slate-400 focus:border-slate-950"
+                              />
+                              <span className="mt-1.5 block text-xs leading-5 text-slate-500">
+                                {field.helper}
+                              </span>
+                            </label>
+                          ))}
+                        </div>
+                      ) : (
+                        <p className="mt-5 rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-xs font-semibold text-slate-500">
+                          Add this mode to show the required references.
+                        </p>
+                      )}
+
+                      <div className="mt-4 flex flex-wrap items-center gap-2 text-xs font-semibold">
+                        <span className="rounded-md border border-slate-200 bg-slate-50 px-2.5 py-1 text-slate-600">
+                          {normalized?.reviewStatus.replaceAll("_", " ") ||
+                            "not selected"}
                         </span>
-                      ) : null}
-                    </div>
-                  </article>
-                );
-              })}
+                        {normalized?.missingEvidenceStatus ? (
+                          <span className="rounded-md border border-amber-300 bg-amber-50 px-2.5 py-1 text-amber-800">
+                            {normalized.missingEvidenceStatus}
+                          </span>
+                        ) : null}
+                      </div>
+                    </article>
+                  );
+                },
+              )}
             </section>
           </div>
 
@@ -814,18 +1186,26 @@ export default function RobotTeamEval() {
                 <TerminalSquare className="h-5 w-5" />
               </div>
               <div>
-                <p className="text-sm font-semibold text-slate-950">Submission summary</p>
+                <p className="text-sm font-semibold text-slate-950">
+                  Submission summary
+                </p>
                 <p className="text-xs text-slate-500">Policy payload preview</p>
               </div>
             </div>
 
             <div className="mt-5 space-y-3 text-sm">
               <div className="rounded-md border border-slate-200 bg-slate-50 p-3">
-                <p className="text-xs font-semibold uppercase tracking-[0.15em] text-slate-500">Site</p>
-                <p className="mt-1 break-words font-semibold text-slate-950">{selectedSite?.siteName}</p>
+                <p className="text-xs font-semibold uppercase tracking-[0.15em] text-slate-500">
+                  Site
+                </p>
+                <p className="mt-1 break-words font-semibold text-slate-950">
+                  {selectedSite?.siteName}
+                </p>
               </div>
               <div className="rounded-md border border-slate-200 bg-slate-50 p-3">
-                <p className="text-xs font-semibold uppercase tracking-[0.15em] text-slate-500">Task</p>
+                <p className="text-xs font-semibold uppercase tracking-[0.15em] text-slate-500">
+                  Task
+                </p>
                 <p className="mt-1 break-words font-semibold text-slate-950">
                   {selectedEvalTask.label}
                 </p>
@@ -834,16 +1214,21 @@ export default function RobotTeamEval() {
                 </p>
               </div>
               <div className="rounded-md border border-slate-200 bg-slate-50 p-3">
-                <p className="text-xs font-semibold uppercase tracking-[0.15em] text-slate-500">Scenario family</p>
+                <p className="text-xs font-semibold uppercase tracking-[0.15em] text-slate-500">
+                  Scenario family
+                </p>
                 <p className="mt-1 break-words font-semibold text-slate-950">
                   {selectedEvalScenarioFamily.label}
                 </p>
                 <p className="mt-1 break-words text-xs font-semibold text-slate-500">
-                  {selectedEvalScenarioFamily.generatedScenarioCount} generated variants
+                  {selectedEvalScenarioFamily.generatedScenarioCount} generated
+                  variants
                 </p>
               </div>
               <div className="rounded-md border border-slate-200 bg-slate-50 p-3">
-                <p className="text-xs font-semibold uppercase tracking-[0.15em] text-slate-500">Selected modalities</p>
+                <p className="text-xs font-semibold uppercase tracking-[0.15em] text-slate-500">
+                  Selected modalities
+                </p>
                 <p className="mt-1 break-words font-semibold text-slate-950">
                   {currentSubmission?.selectedModalities.length
                     ? currentSubmission.selectedModalities.join(", ")
@@ -851,7 +1236,9 @@ export default function RobotTeamEval() {
                 </p>
               </div>
               <div className="rounded-md border border-slate-200 bg-slate-50 p-3">
-                <p className="text-xs font-semibold uppercase tracking-[0.15em] text-slate-500">Missing evidence</p>
+                <p className="text-xs font-semibold uppercase tracking-[0.15em] text-slate-500">
+                  Missing evidence
+                </p>
                 <p className="mt-1 break-words font-semibold text-slate-950">
                   {currentSubmission?.missingEvidenceStatuses.length
                     ? currentSubmission.missingEvidenceStatuses.join(", ")
@@ -868,7 +1255,11 @@ export default function RobotTeamEval() {
                     : "border-amber-300 bg-amber-50 text-amber-900"
                 }`}
               >
-                {status === "created" ? <CheckCircle2 className="mb-2 h-4 w-4" /> : <FileJson2 className="mb-2 h-4 w-4" />}
+                {status === "created" ? (
+                  <CheckCircle2 className="mb-2 h-4 w-4" />
+                ) : (
+                  <FileJson2 className="mb-2 h-4 w-4" />
+                )}
                 {statusMessage}
               </div>
             ) : null}
@@ -897,8 +1288,9 @@ export default function RobotTeamEval() {
               Submit intake request
             </a>
             <p className="mt-4 text-xs leading-5 text-slate-500">
-              Direct creation uses the existing hosted-session endpoint. Protected
-              packages still require robot-team access or entitlement proof.
+              Direct creation uses the existing hosted-session endpoint.
+              Protected packages still require robot-team access or entitlement
+              proof.
             </p>
           </aside>
         </form>

--- a/e2e/robot-team-eval.spec.ts
+++ b/e2e/robot-team-eval.spec.ts
@@ -2,15 +2,21 @@ import { expect, test } from "@playwright/test";
 
 const policyApiFields = {
   "Policy API endpoint Endpoint URL": "https://robot-team.example/policy",
-  "Policy API endpoint Auth handling / redacted secret ref": "Bearer token in redacted secret ref robot-policy-prod",
-  "Policy API endpoint Observation schema URI or JSON ref": "gs://robot-team/schemas/observation.v1.json",
-  "Policy API endpoint Action schema URI or JSON ref": "gs://robot-team/schemas/action.v1.json",
+  "Policy API endpoint Auth handling / redacted secret ref":
+    "Bearer token in redacted secret ref robot-policy-prod",
+  "Policy API endpoint Observation schema URI or JSON ref":
+    "gs://robot-team/schemas/observation.v1.json",
+  "Policy API endpoint Action schema URI or JSON ref":
+    "gs://robot-team/schemas/action.v1.json",
   "Policy API endpoint Rate-limit / runtime constraints": "200 ms p95, 10 rps",
-  "Policy API endpoint Callback / log URI": "gs://robot-team/blueprint/callbacks/",
+  "Policy API endpoint Callback / log URI":
+    "gs://robot-team/blueprint/callbacks/",
   "Policy API endpoint Owner contact": "robot-owner@example.com",
 };
 
-test("robot-team eval interface renders and submits normalized hosted-session policy", async ({ page }) => {
+test("robot-team eval interface renders and submits normalized hosted-session policy", async ({
+  page,
+}) => {
   await page.setViewportSize({ width: 1280, height: 900 });
 
   let observedBody: Record<string, unknown> | null = null;
@@ -28,14 +34,49 @@ test("robot-team eval interface renders and submits normalized hosted-session po
 
   await page.goto("/for-robot-teams");
 
-  await expect(page.getByRole("heading", { name: "Robot-team test interface" })).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "Robot-team test interface" }),
+  ).toBeVisible();
   await expect(page.getByText("Policy API endpoint").first()).toBeVisible();
   await expect(page.getByText("Docker container").first()).toBeVisible();
   await expect(page.getByText("Recorded action traces").first()).toBeVisible();
   await expect(page.getByText("High-level skill traces").first()).toBeVisible();
   await expect(page.getByText("Teleop demos").first()).toBeVisible();
   await expect(page.getByText("Sim controller plugin").first()).toBeVisible();
-  await expect(page.getByText(/does not prove deployment readiness/i)).toBeVisible();
+  await expect(page.getByText("Model checkpoint").first()).toBeVisible();
+  await expect(
+    page.getByText(/does not prove deployment readiness/i),
+  ).toBeVisible();
+
+  await page
+    .getByLabel("Policy labels")
+    .fill("warehouse-policy, baseline-policy, ignored-fourth, ignored-fifth");
+  await page.getByLabel("Episode count").selectOption("custom");
+  await page.getByLabel("Custom episode count").fill("250");
+  await page
+    .getByLabel("Validation mode")
+    .selectOption("comparative_policy_eval");
+  await page
+    .getByLabel("Observation schema ref")
+    .fill("gs://robot-team/schemas/top-observation.v1.json");
+  await page
+    .getByLabel("Action schema ref")
+    .fill("gs://robot-team/schemas/top-action.v1.json");
+  await page.getByLabel("Control frequency").fill("20 Hz");
+  await page.getByLabel("Robot embodiment").fill("mobile manipulator");
+  await page.getByLabel("Gripper").fill("parallel jaw");
+  await page.getByLabel("Camera setup").fill("wrist RGB-D and mast stereo");
+  await page
+    .getByLabel("Intrinsics / extrinsics ref")
+    .fill("gs://robot-team/calibration/cameras.json");
+  await page.getByLabel("Site package target").fill("cold-storage pick aisle");
+  await page.getByLabel("Task instruction").fill("pick tote from shelf");
+  await page
+    .getByLabel("Start-state constraints")
+    .fill("robot starts at aisle entry");
+  await page
+    .getByLabel("Success criteria")
+    .fill("tote placed without safety event");
 
   for (const [label, value] of Object.entries(policyApiFields)) {
     await page.getByLabel(label).fill(value);
@@ -43,34 +84,77 @@ test("robot-team eval interface renders and submits normalized hosted-session po
 
   await page.getByRole("button", { name: /Create hosted session/i }).click();
   await expect(page.getByText(/Runtime path is request-gated/i)).toBeVisible();
-  await expect(page.getByRole("link", { name: /Submit intake request/i })).toHaveAttribute(
-    "href",
-    /source=robot-team-eval/,
-  );
-  const intakeHref = await page.getByRole("link", { name: /Submit intake request/i }).getAttribute("href");
+  await expect(
+    page.getByRole("link", { name: /Submit intake request/i }),
+  ).toHaveAttribute("href", /source=robot-team-eval/);
+  const intakeHref = await page
+    .getByRole("link", { name: /Submit intake request/i })
+    .getAttribute("href");
   expect(decodeURIComponent(intakeHref || "")).toContain(
     "endpointUrl=https://robot-team.example/policy",
+  );
+  expect(decodeURIComponent(intakeHref || "")).toContain(
+    "policyLabels=warehouse-policy, baseline-policy, ignored-fourth",
+  );
+  expect(decodeURIComponent(intakeHref || "")).toContain(
+    "validationMode=comparative_policy_eval",
   );
 
   expect(observedBody?.sessionMode).toBe("runtime_only");
   const policy = observedBody?.policy as Record<string, unknown>;
   const submission = policy.robotTeamTestSubmission as Record<string, unknown>;
-  expect(submission.schemaVersion).toBe("blueprint.robot_team_test_submission.v1");
+  expect(submission.schemaVersion).toBe(
+    "blueprint.robot_team_test_submission.v1",
+  );
   expect(submission.selectedModalities).toEqual(["policy_api_endpoint"]);
+  expect(submission.policyLabels).toEqual([
+    "warehouse-policy",
+    "baseline-policy",
+    "ignored-fourth",
+  ]);
+  expect(submission.episodeCount).toBe("custom");
+  expect(submission.customEpisodeCount).toBe("250");
+  expect(submission.validationMode).toBe("comparative_policy_eval");
+  expect(submission.observationSchemaRef).toBe(
+    "gs://robot-team/schemas/top-observation.v1.json",
+  );
+  expect(submission.actionSchemaRef).toBe(
+    "gs://robot-team/schemas/top-action.v1.json",
+  );
+  expect(submission.controlFrequency).toBe("20 Hz");
+  expect(submission.robotEmbodiment).toBe("mobile manipulator");
+  expect(submission.gripper).toBe("parallel jaw");
+  expect(submission.cameraSetup).toBe("wrist RGB-D and mast stereo");
+  expect(submission.intrinsicsExtrinsicsRef).toBe(
+    "gs://robot-team/calibration/cameras.json",
+  );
+  expect(submission.sitePackageTarget).toBe("cold-storage pick aisle");
+  expect(submission.taskInstruction).toBe("pick tote from shelf");
+  expect(submission.startStateConstraints).toBe("robot starts at aisle entry");
+  expect(submission.successCriteria).toBe("tote placed without safety event");
   expect(submission.pipelineDatasetSchemaRefs).toContain(
     "robot_team_test_submission_modalities.v0.1",
   );
 });
 
-test("robot-team eval canonical submission route is usable on mobile", async ({ page }) => {
+test("robot-team eval canonical submission route is usable on mobile", async ({
+  page,
+}) => {
   await page.setViewportSize({ width: 390, height: 844 });
   await page.goto("/robot-team/eval");
 
-  await expect(page.getByRole("heading", { name: "Robot-team test interface" })).toBeVisible();
-  await expect(page.getByRole("button", { name: /Create hosted session/i })).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "Robot-team test interface" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: /Create hosted session/i }),
+  ).toBeVisible();
 
   const hasHorizontalOverflow = await page.evaluate(() => {
-    return document.documentElement.scrollWidth > document.documentElement.clientWidth + 1;
+    return (
+      document.documentElement.scrollWidth >
+      document.documentElement.clientWidth + 1
+    );
   });
   expect(hasHorizontalOverflow).toBe(false);
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,50 +1,51 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vitest/config'
-import react from '@vitejs/plugin-react'
-import path from 'path'
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+import path from "path";
 
 const __dirname = import.meta.dirname;
 
 export default defineConfig({
   plugins: [react()],
-    test: {
+  test: {
     globals: true,
-    environment: 'happy-dom',
-    setupFiles: './client/tests/setup.ts',
+    environment: "happy-dom",
+    setupFiles: "./client/tests/setup.ts",
     css: true,
     testTimeout: 60000,
     hookTimeout: 120000,
     include: [
-      'client/tests/**/*.{test,spec}.{ts,tsx,js,jsx}',
-      'server/tests/**/*.{test,spec}.{ts,tsx,js,jsx}',
-      'scripts/**/*.{test,spec}.{ts,tsx,js,jsx}',
-      'ops/paperclip/plugins/blueprint-automation/src/**/*.{test,spec}.{ts,tsx,js,jsx}',
+      "client/tests/**/*.{test,spec}.{ts,tsx,js,jsx}",
+      "client/src/lib/**/*.{test,spec}.{ts,tsx,js,jsx}",
+      "server/tests/**/*.{test,spec}.{ts,tsx,js,jsx}",
+      "scripts/**/*.{test,spec}.{ts,tsx,js,jsx}",
+      "ops/paperclip/plugins/blueprint-automation/src/**/*.{test,spec}.{ts,tsx,js,jsx}",
     ],
     exclude: [
-      'e2e/**',
-      'node_modules/**',
-      'dist/**',
-      'paperclip-desktop/**',
-      '.claude/**',
-      '.worktrees/**',
-      'coverage/**',
-      'test-results/**',
+      "e2e/**",
+      "node_modules/**",
+      "dist/**",
+      "paperclip-desktop/**",
+      ".claude/**",
+      ".worktrees/**",
+      "coverage/**",
+      "test-results/**",
     ],
     coverage: {
-      provider: 'v8',
-      reporter: ['text', 'json', 'html'],
-      reportsDirectory: './coverage',
+      provider: "v8",
+      reporter: ["text", "json", "html"],
+      reportsDirectory: "./coverage",
       exclude: [
-        'e2e/**',
-        'node_modules/**',
-        'dist/**',
-        'paperclip-desktop/**',
-        '.claude/**',
-        '.worktrees/**',
-        'coverage/**',
-        'test-results/**',
-        'scripts/launch-preflight.mjs',
-        'scripts/launch-smoke.mjs',
+        "e2e/**",
+        "node_modules/**",
+        "dist/**",
+        "paperclip-desktop/**",
+        ".claude/**",
+        ".worktrees/**",
+        "coverage/**",
+        "test-results/**",
+        "scripts/launch-preflight.mjs",
+        "scripts/launch-smoke.mjs",
       ],
       thresholds: {
         lines: 25.5,
@@ -59,4 +60,4 @@ export default defineConfig({
       "@": path.resolve(__dirname, "client", "src"),
     },
   },
-})
+});


### PR DESCRIPTION
### Motivation
- Provide a structured top-level run setup for robot-team submissions so run-wide metadata (policy labels, episode counts, validation mode, schemas, robot/camera descriptors, task/start-state constraints, and success criteria) travels with every submission and is available for handoff and job requests.
- Add a first-class `model_checkpoint` modality so teams can submit immutable model artifacts and interface notes alongside existing modalities without exposing source code or changing existing modality contracts.
- Surface the new run-setup fields in the `/robot-team/eval` UI and include them in the contact/handoff message so reviewers and intake flows see run-wide context up-front.
- Preserve existing modality IDs and requested-output arrays so older integrations remain compatible.

### Description
- Introduced run-setup types and normalization in `client/src/lib/robotTeamTestSubmission.ts`, including `policyLabels`, `episodeCount`/`customEpisodeCount`, `validationMode`, `observationSchemaRef`, `actionSchemaRef`, `controlFrequency`, `robotEmbodiment`, `gripper`, `cameraSetup`, `intrinsicsExtrinsicsRef`, `sitePackageTarget`, `taskInstruction`, `startStateConstraints`, and `successCriteria`, plus helpers to normalize policy labels (dedupe/cap to 3), episode count, and validation mode.
- Added the `model_checkpoint` modality to `ROBOT_TEAM_TEST_SUBMISSION_MODALITY_DEFINITIONS` with fields for `artifactUri`, `digestChecksum`, `frameworkRuntime`, `modelCardPolicyInterfaceNotes`, `observationSchemaRef`, `actionSchemaRef`, and `ownerContact` while keeping existing modalities unchanged.
- Extended `buildRobotTeamSubmissionInput` and `normalizeRobotTeamTestSubmission` to accept and carry the new run-setup fields and to include them in the normalized `RobotTeamTestSubmission` object.
- Updated `client/src/pages/RobotTeamEval.tsx` to render a new Run setup flow, manage run-setup state, include the run-setup in submissions created by `buildRobotTeamSubmissionInput`, and append readable run-setup details to the contact handoff message generated by `buildRequestReviewHref`.
- Mapped `model_checkpoint` into the job/policy package in `client/src/lib/robotEvalJobRequest.ts` so `buildPolicyPackageFromRobotTeamSubmission` will include checkpoint payload when selected.
- Added a unit test `client/src/lib/robotTeamTestSubmission.test.ts` that validates normalization of run-setup fields and the `model_checkpoint` modality, and updated the Playwright e2e spec `e2e/robot-team-eval.spec.ts` to cover UI interactions for the run-setup fields and handoff URL inspection.
- Adjusted `vitest.config.ts` to include `client/src/lib/**/*.{test,spec}` so the new lib test is discovered by the repository test runner.

### Testing
- `npm run check` (`tsc -p tsconfig.full.json --noEmit`) completed successfully.
- Unit tests: `npm run test -- client/src/lib/robotTeamTestSubmission.test.ts` ran the new spec and passed (1 test passed).
- Playwright e2e: `npm run test:e2e -- e2e/robot-team-eval.spec.ts` failed to run in this environment because the Playwright Chromium browser binary is not available; attempted `npx playwright install chromium` but downloads from the Playwright CDN failed (403/400 in this environment), so e2e verification is blocked here.
- Graphify pilot: attempted `bash scripts/graphify/run-webapp-architecture-pilot.sh --no-viz`; installing `graphifyy` succeeded, but the staged AST pilot reported no code files in the staged corpus in this run (no meaningful graphify output produced).

If you want, I can split the UI-only vs. schema-only changes into separate PRs, or follow up to iterate on the e2e install environment to get Playwright browsers installed and re-run the e2e tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35e9551cfc83299b396f2a1abc3ad3)