### PR TITLE
Reposition Policy Evaluation as primary product; add Validated Evaluation Pack; move Policy Improvement to follow-on

### DIFF
--- a/client/src/data/simplePricing.ts
+++ b/client/src/data/simplePricing.ts
@@ -1,5 +1,5 @@
 export type SimplePricingOption = {
-  id: "capture" | "world-models" | "simulation" | "site-operator";
+  id: "capture" | "world-models" | "simulation" | "validated-evaluation" | "site-operator";
   step: string;
   name: string;
   internalName: string;
@@ -31,13 +31,13 @@ export const simplePricingOptions: SimplePricingOption[] = [
   },
   {
     id: "world-models",
-    step: "Policy lift",
+    step: "Follow-on improvement",
     name: "Policy Improvement Run",
     internalName: "Sim-only Policy Improvement",
     price: "$35,000",
     unit: "per sim-only run",
     payer: "Robot team / OEM / integrator",
-    summary: "Improve a customer-supplied policy, adapter, task head, distilled skill, or complete policy inside simulation.",
+    summary: "Follow-on work after evaluation: improve a customer-supplied policy, adapter, task head, distilled skill, or complete policy inside simulation.",
     includes: [
       "Baseline evaluation and dominant failure-mode diagnosis",
       "Twin and cousin scenarios plus curriculum",
@@ -47,19 +47,36 @@ export const simplePricingOptions: SimplePricingOption[] = [
   },
   {
     id: "simulation",
-    step: "Evaluation run",
-    name: "Task Evaluation Run",
-    internalName: "Real-Site Task Evaluation",
+    step: "Primary evaluation",
+    name: "Policy Evaluation Run",
+    internalName: "Real-Site Policy Evaluation",
     price: "$6,500",
-    unit: "per run",
+    unit: "per 100-episode run",
     payer: "Robot team / OEM / integrator",
     summary:
-      "Evaluate one robot policy/profile on one real site against one scoped Task Pack.",
+      "Rank 1-3 policies/checkpoints on one captured real-site task pack before field time.",
     includes: [
-      "Unit: 1 site, 1 robot policy/profile, 1 Task Pack",
-      "Up to 500 scenarios",
-      "Pass/fail results, cycle-time results, intervention and failure notes",
-      "Scenario/results manifest and availability confirmed per request before evaluation starts",
+      "100 or 500 WAM-eval episodes",
+      "Unit: 1 site package, 1 task pack, 1 robot embodiment, 1-3 policies/checkpoints",
+      "Predicted success, policy ranking, failure taxonomy, and per-scenario metrics",
+      "OOD/uncertainty flags, generated rollout clips, and recommended real-world validation targets",
+    ],
+  },
+  {
+    id: "validated-evaluation",
+    step: "Validated evaluation",
+    name: "Validated Evaluation Pack",
+    internalName: "Paired Real Robot Validation",
+    price: "Scoped",
+    unit: "after evaluation",
+    payer: "Robot team / OEM / integrator",
+    summary:
+      "Add paired real robot rollouts and quantitative validity reporting for the validated envelope only.",
+    includes: [
+      "Paired real robot rollouts",
+      "Pearson/Spearman/SRCC or rank-fidelity",
+      "MAE, confidence bounds, validity envelope, and failure-mode agreement",
+      "Reports validity only for the validated robot/task/site envelope",
     ],
   },
   {
@@ -83,6 +100,7 @@ export const simplePricingOptions: SimplePricingOption[] = [
 export function getPricingContactInterest(id: SimplePricingOption["id"]): string {
   if (id === "capture") return "capturer-signup";
   if (id === "site-operator") return "site-review";
-  if (id === "simulation") return "hosted-evaluation";
+  if (id === "simulation") return "policy-evaluation-run";
+  if (id === "validated-evaluation") return "validated-evaluation-pack";
   return "world-model";
 }

--- a/client/src/lib/contactRequestPrefill.ts
+++ b/client/src/lib/contactRequestPrefill.ts
@@ -60,8 +60,8 @@ export const CONTACT_REQUEST_PATH_OPTIONS: Array<{
 }> = [
   {
     value: "hosted-review",
-    label: "Task Evaluation Run",
-    description: "Share a policy API, container, action trace, or assisted review path for one site/task.",
+    label: "Policy Evaluation Run",
+    description: "Request 100 or 500 WAM-eval episodes for 1 site package, 1 task pack, 1 robot embodiment, and 1-3 policies/checkpoints.",
     cta: "Request evaluation",
     buyerType: "robot_team",
     commercialRequestPath: "hosted_evaluation",
@@ -461,7 +461,7 @@ function inferredTaskStatement(input: ContactRequestUrlInput, requestPath: Conta
   }
   if (workflow) return workflow;
   if (requestPath === "hosted-review" && primaryNeed) {
-    return `Request a Task Evaluation Run for ${primaryNeed}.`;
+    return `Request a Policy Evaluation Run for ${primaryNeed}.`;
   }
   if (requestPath === "new-capture" && primaryNeed) {
     return `Request an exact-site capture path for an eval-card dataset around ${primaryNeed}.`;
@@ -469,8 +469,8 @@ function inferredTaskStatement(input: ContactRequestUrlInput, requestPath: Conta
   if ((requestPath === "data-package" || requestPath === "world-model") && primaryNeed) {
     return `Request a Policy Improvement Run for ${primaryNeed}.`;
   }
-  if (primaryNeed) return `Request a Task Evaluation Run for ${primaryNeed}.`;
-  if (siteClass) return `Request a Task Evaluation Run for ${siteClass}.`;
+  if (primaryNeed) return `Request a Policy Evaluation Run for ${primaryNeed}.`;
+  if (siteClass) return `Request a Policy Evaluation Run for ${siteClass}.`;
   return "";
 }
 

--- a/client/src/pages/Contact.tsx
+++ b/client/src/pages/Contact.tsx
@@ -18,7 +18,7 @@ const robotNextSteps = [
   "We review the site/task fit.",
   "We recommend scope and scenario count.",
   "You approve pricing and access terms.",
-  "We run the evaluation or prepare the site/task package.",
+  "We run the Policy Evaluation Run or scope a Validated Evaluation Pack when paired robot rollouts are needed.",
 ];
 
 const dataPackageNextSteps = [
@@ -50,7 +50,7 @@ function PersonaSwitch({ activePersona }: { activePersona: ContactPersona }) {
       persona: "robot_team" as const,
       href: "/contact/robot-team#contact-intake",
       title: "Robot teams",
-      body: "Request an evaluation or policy improvement run.",
+      body: "Request a Policy Evaluation Run or follow-on pack.",
       Icon: Bot,
     },
     {
@@ -173,10 +173,10 @@ function ExplainerCard({
     <aside className="border border-black/10 bg-white p-5">
       <ClipboardCheck className="h-5 w-5 text-slate-950" />
       <p className="mt-4 text-sm font-semibold text-slate-950">
-        A Task Evaluation Run means:
+        A Policy Evaluation Run means:
       </p>
       <p className="mt-2 text-sm leading-6 text-slate-600">
-        1 site x 1 robot policy/profile x 1 task pack x scenario count.
+        100 or 500 WAM-eval episodes x 1 site package x 1 task pack x 1 robot embodiment x 1-3 policies/checkpoints, with predicted success, policy ranking, failure taxonomy, per-scenario metrics, OOD/uncertainty flags, generated rollout clips, and recommended real-world validation targets.
       </p>
     </aside>
   );
@@ -233,17 +233,17 @@ export default function Contact() {
     ? "Submit a Site for Robot Evaluation."
     : isDataPackage
       ? "Request a Policy Improvement Run."
-    : "Request a Task Evaluation Run.";
+    : "Request a Policy Evaluation Run.";
   const subhead = isSiteOperator
     ? "Share a facility that robot teams can evaluate against. Participation is free, and you control access boundaries."
     : isDataPackage
       ? "Scope a sim-only run around a customer-supplied policy. Source access is optional; improved artifacts require a trainable interface or approved wrapper path."
-    : "Test one robot policy or profile against a real-site task pack before field time.";
+    : "Rank 1-3 policies/checkpoints on a real-site task pack before field time with 100 or 500 WAM-eval episodes.";
   const intro = isSiteOperator
     ? "Tell us what the site is, where it is, and what access/privacy limits apply. We will review whether it fits the Blueprint site library."
     : isDataPackage
       ? "Tell us the site type, robot embodiment, action interface, target task, policy access method, and success or cycle-time threshold. We will reply with the recommended sim-only scope and evidence boundary."
-    : "Tell us the site type, task, and threshold that matters. We will reply with the recommended scope, scenario count, and next proof step.";
+    : "Tell us the site type, task, robot embodiment, policies/checkpoints, and threshold that matters. We will reply with the recommended 100- or 500-episode scope and next validation step.";
 
   return (
     <>
@@ -253,14 +253,14 @@ export default function Contact() {
             ? "Submit a Site for Robot Evaluation | Blueprint"
             : isDataPackage
               ? "Request a Policy Improvement Run | Blueprint"
-            : "Request a Task Evaluation Run | Blueprint"
+            : "Request a Policy Evaluation Run | Blueprint"
         }
         description={
           isSiteOperator
             ? "Submit a facility to Blueprint for free robot-evaluation review with access, privacy, and commercialization boundaries."
             : isDataPackage
               ? "Request a Blueprint Policy Improvement Run for sim-only baseline evaluation, failure diagnosis, policy improvement, sealed testing, and an evidence report."
-            : "Request a Blueprint Task Evaluation Run for one robot policy, real-site task pack, and scenario scope."
+            : "Request a Blueprint Policy Evaluation Run for 100 or 500 WAM-eval episodes across one site package, one task pack, one robot embodiment, and 1-3 policies/checkpoints."
         }
         canonical={isSiteOperator ? "/contact/site-operator" : "/contact/robot-team"}
       />
@@ -312,7 +312,7 @@ export default function Contact() {
                   ? "Free site submission"
                   : isDataPackage
                     ? "Policy Improvement Run"
-                    : "Task Evaluation Run"}
+                    : "Policy Evaluation Run"}
               </div>
               <h2 className="mt-2 text-2xl font-semibold tracking-[-0.03em] text-slate-950">
                 {isSiteOperator

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -100,7 +100,7 @@ const workflowSteps = [
 
 const pricingPlans = [
   {
-    name: "100 WAM-eval episodes",
+    name: "Policy Evaluation Run — 100 WAM-eval episodes",
     price: "From $6,500 / run",
     summary:
       "Policy Evaluation Run for 1 site package, 1 task pack, 1 robot embodiment, and 1-3 policies/checkpoints when you need fast pre-field ranking.",
@@ -108,12 +108,20 @@ const pricingPlans = [
     cta: "Request 100-episode run",
   },
   {
-    name: "500 WAM-eval episodes",
+    name: "Policy Evaluation Run — 500 WAM-eval episodes",
     price: "From $18,000 / run",
     summary:
       "Expanded Policy Evaluation Run with deeper failure discovery, per-scenario metrics, OOD/uncertainty flags, rollout clips, and validation target recommendations.",
     href: pricingHref,
     cta: "Request 500-episode run",
+  },
+  {
+    name: "Validated Evaluation Pack",
+    price: "Scoped after evaluation",
+    summary:
+      "Adds paired real robot rollouts and reports Pearson/Spearman/SRCC or rank-fidelity, MAE, confidence bounds, validity envelope, and failure-mode agreement only for the validated envelope.",
+    href: "/contact/robot-team?persona=robot-team&buyerType=robot_team&interest=validated-evaluation-pack&path=policy-evaluation-run&requestedOutputs=Validated%20Evaluation%20Pack&source=home-pricing-validated-evaluation",
+    cta: "Request validated pack",
   },
 ];
 
@@ -331,7 +339,7 @@ export default function Home() {
                 <ArrowRight className="h-4 w-4" aria-hidden="true" />
               </a>
             </div>
-            <div className="mt-8 grid gap-4 lg:grid-cols-2">
+            <div className="mt-8 grid gap-4 lg:grid-cols-3">
               {pricingPlans.map((plan) => (
                 <article
                   key={plan.name}
@@ -379,6 +387,42 @@ export default function Home() {
                 </a>
               </div>
             </div>
+          </div>
+        </section>
+
+
+        <section
+          id="after-evaluation"
+          className="border-y border-black/10 bg-white px-4 py-16 sm:px-6 lg:px-10"
+          data-home-section="after-evaluation"
+        >
+          <div className="mx-auto grid max-w-[88rem] gap-8 lg:grid-cols-[0.42fr_0.58fr]">
+            <SectionHeading
+              eyebrow="After evaluation"
+              title="Move to improvement only after the ranking identifies what to fix."
+              body="Policy Improvement Runs are follow-on work: use the Policy Evaluation Run to find the dominant failure modes, scenario clusters, and validation targets first, then scope sim-only curriculum, candidate improvement, sealed testing, and evidence reporting for a customer-supplied policy."
+            />
+            <article className="border border-black/10 bg-[#f8f4ec] p-6">
+              <p className="text-xs font-semibold uppercase tracking-normal text-[#8b6f42]">
+                Follow-on product
+              </p>
+              <h3 className="mt-4 text-3xl font-semibold text-[#111110]">
+                Policy Improvement Run
+              </h3>
+              <p className="mt-4 text-sm leading-7 text-[#5f5a53]">
+                Baseline evaluation, failure diagnosis, twin/cousin scenarios,
+                curriculum generation, sim-only post-training, sealed testing,
+                and an evidence report stay scoped to the evaluated site/task/robot
+                envelope and are not a deployment guarantee.
+              </p>
+              <a
+                href="/contact/robot-team?persona=robot-team&buyerType=robot_team&interest=policy-improvement-run&path=policy-improvement-run&requestedOutputs=Policy%20Improvement%20Run&source=home-after-evaluation-policy-improvement"
+                className="mt-6 inline-flex min-h-11 items-center justify-center gap-2 border border-black/15 bg-white px-4 text-sm font-semibold text-[#111110] transition hover:bg-[#f0e7d8]"
+              >
+                Scope follow-on improvement
+                <ArrowRight className="h-4 w-4" aria-hidden="true" />
+              </a>
+            </article>
           </div>
         </section>
 

--- a/client/src/pages/Pricing.tsx
+++ b/client/src/pages/Pricing.tsx
@@ -4,7 +4,6 @@ import {
   ArrowRight,
   Building2,
   ClipboardCheck,
-  Database,
   Layers3,
   ShieldCheck,
 } from "lucide-react";
@@ -22,8 +21,11 @@ type PricingPlan = {
   cta: string;
 };
 
-const taskEvaluationHref =
-  "/contact/robot-team?persona=robot-team&buyerType=robot_team&interest=hosted-evaluation&path=hosted-review&requestedOutputs=Task%20Evaluation%20Run&source=pricing-task-evaluation";
+const policyEvaluationHref =
+  "/contact/robot-team?persona=robot-team&buyerType=robot_team&interest=policy-evaluation-run&path=hosted-review&requestedOutputs=Policy%20Evaluation%20Run&episodeCount=500&source=pricing-policy-evaluation";
+
+const validatedEvaluationHref =
+  "/contact/robot-team?persona=robot-team&buyerType=robot_team&interest=validated-evaluation-pack&path=hosted-review&requestedOutputs=Validated%20Evaluation%20Pack&source=pricing-validated-evaluation";
 
 const policyImprovementHref =
   "/contact/robot-team?persona=robot-team&buyerType=robot_team&interest=policy-improvement-run&path=policy-improvement-run&requestedOutputs=Policy%20Improvement%20Run&source=pricing-policy-improvement";
@@ -33,49 +35,42 @@ const siteOperatorHref = "/contact/site-operator?source=pricing-site-operator-fr
 const plans: PricingPlan[] = [
   {
     icon: ClipboardCheck,
-    name: "Task Evaluation Run",
+    name: "Policy Evaluation Run",
     range: "From $6,500 / run",
     description:
-      "Test one robot policy/profile against one real-site Task Pack.",
+      "Rank 1-3 policies/checkpoints before field time with 100 or 500 WAM-eval episodes.",
     unit:
-      "One Task Evaluation Run = 1 site × 1 robot policy/profile × 1 Task Pack × up to 500 scenarios.",
+      "One Policy Evaluation Run = 100 or 500 WAM-eval episodes × 1 site package × 1 task pack × 1 robot embodiment × 1-3 policies/checkpoints.",
     includes: [
-      "Scenario manifest",
-      "Start-state and variation set",
-      "Target threshold set",
-      "Pass/fail results",
-      "Cycle-time results",
-      "Intervention and failure notes",
-      "Selected rollout evidence",
-      "Exportable scenario/results manifest",
-      "Short findings summary",
+      "Predicted success",
+      "Policy ranking",
+      "Failure taxonomy",
+      "Per-scenario metrics",
+      "OOD/uncertainty flags",
+      "Generated rollout clips",
+      "Recommended real-world validation targets",
     ],
-    href: taskEvaluationHref,
-    cta: "Request Task Evaluation Run",
+    href: policyEvaluationHref,
+    cta: "Request Policy Evaluation Run",
   },
   {
-    icon: Database,
-    name: "Policy Improvement Run",
-    range: "From $35,000 / run",
+    icon: ShieldCheck,
+    name: "Validated Evaluation Pack",
+    range: "Scoped after evaluation",
     description:
-      "Improve a customer-supplied robot policy inside a sim-only workflow.",
+      "Pair WAM-eval results with real robot rollouts for the same validated robot/task/site envelope.",
+    unit:
+      "Includes paired real robot rollouts; quantitative validity claims apply only inside the validated envelope.",
     includes: [
-      "Baseline evaluation and dominant failure-mode diagnosis",
-      "Twin and cousin scenario generation",
-      "Curriculum construction for the target task",
-      "Post-training of an adapter, task head, distilled skill, or complete policy",
-      "Sealed scenario test for candidate versions",
-      "Improved artifact and evidence report",
+      "Paired real robot rollout evidence",
+      "Pearson/Spearman/SRCC or rank-fidelity",
+      "MAE and confidence bounds",
+      "Validity envelope",
+      "Failure-mode agreement",
+      "Validated-envelope-only reporting",
     ],
-    useCases: [
-      "sim-only policy lift",
-      "customer-supplied policy improvement",
-      "adapter or task-head post-training",
-      "failure recovery",
-      "pilot-threshold preparation",
-    ],
-    href: policyImprovementHref,
-    cta: "Request Policy Improvement",
+    href: validatedEvaluationHref,
+    cta: "Request Validated Pack",
   },
 ];
 
@@ -112,7 +107,7 @@ export default function Pricing() {
     <>
       <SEO
         title="Pricing | Blueprint"
-        description="Simple Blueprint pricing for robot teams: Task Evaluation Runs from $6,500 per run and Policy Improvement Runs from $35,000 per sim-only run. Site operators submit sites free."
+        description="Simple Blueprint pricing for robot teams: Policy Evaluation Runs with 100 or 500 WAM-eval episodes and Validated Evaluation Packs with paired real robot rollouts. Site operators submit sites free."
         canonical="/pricing"
         image={`https://tryblueprint.io${humanoidReadinessAssets.hostedDashboard}`}
       />
@@ -133,23 +128,21 @@ export default function Pricing() {
               Simple pricing for real-site robot evaluation.
             </h1>
             <p className="mt-6 max-w-2xl text-lg leading-8 text-white/78">
-              Blueprint sells two robot-team products: Task Evaluation Runs and
-              Policy Improvement Runs. Site operators can submit sites for
-              free.
+              Blueprint sells Policy Evaluation Runs first, then Validated Evaluation Packs when paired real robot rollouts are needed. Policy Improvement Runs are follow-on work after evaluation.
             </p>
             <div className="mt-8 flex flex-col gap-3 sm:flex-row">
               <a
-                href={taskEvaluationHref}
+                href={policyEvaluationHref}
                 className="inline-flex min-h-12 items-center justify-center gap-2 bg-[#d8bd8d] px-5 text-sm font-semibold text-[#111110] transition hover:bg-[#e8cfa1]"
               >
-                Request Task Evaluation Run
+                Request Policy Evaluation Run
                 <ArrowRight className="h-4 w-4" aria-hidden="true" />
               </a>
               <a
-                href={policyImprovementHref}
+                href={validatedEvaluationHref}
                 className="inline-flex min-h-12 items-center justify-center border border-white/30 px-5 text-sm font-semibold text-white transition hover:bg-white/10"
               >
-                Request Policy Improvement
+                Request Validated Pack
               </a>
             </div>
           </div>
@@ -237,17 +230,13 @@ export default function Pricing() {
             <div className="grid gap-6 lg:grid-cols-[0.36fr_0.64fr]">
               <div>
                 <p className="text-xs font-semibold uppercase tracking-normal text-[#d8bd8d]">
-                  Full-stack robot teams
+                  After evaluation
                 </p>
                 <h2 className="mt-3 text-4xl font-semibold leading-tight">
-                  Source access is optional.
+                  Policy Improvement Run is follow-on work.
                 </h2>
                 <p className="mt-4 text-sm leading-7 text-white/72">
-                  Policy Improvement Runs work with customer-supplied policies
-                  through API, container, private runner, adapter, sim plugin,
-                  or action-trace workflows. Producing an improved artifact
-                  requires either a trainable interface or a customer-approved
-                  wrapper/adapter path.
+                  Move into improvement only after a Policy Evaluation Run identifies the failure modes, scenario clusters, and validation targets worth fixing. Customer-supplied policies can connect through API, container, private runner, adapter, sim plugin, or action-trace workflows; improved artifacts require a trainable interface or approved wrapper path.
                 </p>
               </div>
               <div className="grid gap-4 md:grid-cols-3">
@@ -274,8 +263,7 @@ export default function Pricing() {
               </h2>
               <p className="mt-4 text-sm leading-6 text-[#5f5a53]">
                 Scenario = one test attempt. Task Pack = the full set of
-                scenarios for that job. Task Evaluation Run = one policy tested
-                against one Task Pack.
+                scenarios for that job. Policy Evaluation Run = 1-3 policies/checkpoints tested against one Task Pack with 100 or 500 WAM-eval episodes.
               </p>
             </div>
             <div className="grid gap-4">
@@ -302,9 +290,7 @@ export default function Pricing() {
               <article className="border border-black/10 bg-white p-5">
                 <h3 className="text-xl font-semibold">Multi-task pricing</h3>
                 <p className="mt-3 text-sm leading-6 text-[#5f5a53]">
-                  Need the same policy tested across multiple Task Packs? Ask
-                  for a bundle. A common bundle is 3 Task Evaluation Runs on the
-                  same site and policy from $18,000.
+                  Need the same policy set tested across multiple Task Packs? Ask for a bundle. Validated Evaluation Packs add paired real robot rollouts and report fidelity only for the validated envelope.
                 </p>
               </article>
             </div>


### PR DESCRIPTION
### Motivation
- Align public product copy and pricing to present `Policy Evaluation Run` as the primary pre-field offering and ensure outputs/limits are explicit (100 or 500 WAM-eval episodes, 1 site package, 1 task pack, 1 robot embodiment, 1–3 policies/checkpoints). 
- Add a clearly scoped `Validated Evaluation Pack` for paired real-robot rollouts and validity/fidelity reporting so quantitative claims stay inside a validated envelope. 
- Reduce confusion by moving `Policy Improvement Run` into a follow-on/after-evaluation section rather than first-screen or primary pricing placement.

### Description
- Updated UI and copy in `client/src/pages/Home.tsx` to center `Policy Evaluation Run` pricing cards, add a `Validated Evaluation Pack` card, and add an “After evaluation” follow-on section describing `Policy Improvement Run` scope. 
- Reworked `client/src/pages/Pricing.tsx` to replace the original primary cards with `Policy Evaluation Run` and `Validated Evaluation Pack`, adjust CTA hrefs, and change explanatory copy to state that `Policy Improvement Run` is follow-on work. 
- Updated intake/contact/business helpers: `client/src/data/simplePricing.ts` now models `Policy Evaluation Run` and a `validated-evaluation` option, and `client/src/lib/contactRequestPrefill.ts` updated prefill labels, inferred statements, and mapping so generated contact URLs and forms use the new terminology. 
- Adjusted `client/src/pages/Contact.tsx` copy and UX to present `Policy Evaluation Run` as the primary robot-team request and keep `Policy Improvement Run` in the data-package path; ensured hrefs and CTAs consistently route to the new `policy-evaluation-run` and `validated-evaluation-pack` interests.

### Testing
- Ran TypeScript checks with `npm run check`; initial TS object-literal error was observed during edits, the duplicate property was fixed and `npm run check` completed successfully. 
- Ran repository checks (`git diff --check`) and formatting attempts where available; no outstanding diff-check errors remain. 
- Attempted to refresh graphify pilot with `bash scripts/graphify/run-webapp-architecture-pilot.sh --no-viz` as required by repo guidance but the run was blocked because the environment lacks the `graphifyy` Python package (action noted for follow-up).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35eaefe334832990809f3e2dbe7a4e)