### PR TITLE
Align policy evaluation request prefill labels

### DIFF
--- a/client/src/components/site/ContactForm.tsx
+++ b/client/src/components/site/ContactForm.tsx
@@ -145,6 +145,8 @@ function buildRouteDetails(prefill: ReturnType<typeof parseContactRequestPrefill
   return [
     prefill.scenario ? `Scenario: ${prefill.scenario}` : "",
     prefill.requestedOutputs ? `Requested outputs: ${prefill.requestedOutputs}` : "",
+    prefill.episodeCount ? `Episode count: ${prefill.episodeCount}` : "",
+    prefill.validationMode ? `Validation mode: ${prefill.validationMode}` : "",
     prefill.message ? `Message: ${prefill.message}` : "",
   ].filter(Boolean).join("\n");
 }
@@ -248,6 +250,8 @@ export function ContactForm() {
   const [targetRobotTeam, setTargetRobotTeam] = useState("");
   const [policyAccessMethod, setPolicyAccessMethod] = useState("");
   const [scenarioCount, setScenarioCount] = useState("");
+  const [episodeCount, setEpisodeCount] = useState("");
+  const [validationMode, setValidationMode] = useState("");
   const [deadline, setDeadline] = useState("");
   const [notes, setNotes] = useState("");
   const [accessBoundary, setAccessBoundary] = useState("");
@@ -308,6 +312,14 @@ export function ContactForm() {
     if (!policyAccessMethod && fit?.evalCardInput?.preferredReviewPath) {
       setPolicyAccessMethod(fit.evalCardInput.preferredReviewPath);
     }
+    if (!episodeCount && requestPrefill.episodeCount) {
+      setEpisodeCount(requestPrefill.episodeCount);
+      setShowOptionalDetails(true);
+    }
+    if (!validationMode && requestPrefill.validationMode) {
+      setValidationMode(requestPrefill.validationMode);
+      setShowOptionalDetails(true);
+    }
     if (!notes && routeDetails) {
       setNotes(routeDetails);
       setShowOptionalDetails(true);
@@ -323,6 +335,7 @@ export function ContactForm() {
     company,
     currentUser,
     email,
+    episodeCount,
     firstName,
     lastName,
     notes,
@@ -336,6 +349,7 @@ export function ContactForm() {
     targetSiteType,
     taskStatement,
     userData,
+    validationMode,
   ]);
 
   useEffect(() => {
@@ -408,6 +422,8 @@ export function ContactForm() {
     const optionalDetails = [
       policyAccessMethod.trim() ? `Policy access method: ${policyAccessMethod.trim()}` : "",
       scenarioCount.trim() ? `Scenario count: ${scenarioCount.trim()}` : "",
+      episodeCount.trim() ? `Episode count: ${episodeCount.trim()}` : "",
+      validationMode.trim() ? `Validation mode: ${validationMode.trim()}` : "",
       deadline.trim() ? `Deadline: ${deadline.trim()}` : "",
       notes.trim() ? `Notes: ${notes.trim()}` : "",
     ].filter(Boolean).join("\n");
@@ -423,9 +439,11 @@ export function ContactForm() {
         requiredMetrics: taskStatement.trim(),
       },
       scenarioCardInput: {
-        normalScenario: scenarioCount.trim()
-          ? `${scenarioCount.trim()} requested scenarios`
-          : "",
+        normalScenario: [
+          scenarioCount.trim() ? `${scenarioCount.trim()} requested scenarios` : "",
+          episodeCount.trim() ? `${episodeCount.trim()} requested episodes` : "",
+          validationMode.trim() ? `${validationMode.trim()} validation mode` : "",
+        ].filter(Boolean).join("; "),
       },
       evalCardInput: {
         robotOrPolicyTested: targetRobotTeam.trim(),
@@ -736,6 +754,37 @@ export function ContactForm() {
                   value={scenarioCount}
                   onChange={(event) => setScenarioCount(event.target.value)}
                 />
+              </div>
+              <div>
+                <label htmlFor="contact-episode-count" className={labelClassName}>
+                  Episode count
+                </label>
+                <select
+                  id="contact-episode-count"
+                  className={inputClassName}
+                  value={episodeCount}
+                  onChange={(event) => setEpisodeCount(event.target.value)}
+                >
+                  <option value="">Not selected</option>
+                  <option value="100">100</option>
+                  <option value="500">500</option>
+                </select>
+              </div>
+              <div>
+                <label htmlFor="contact-validation-mode" className={labelClassName}>
+                  Validation mode
+                </label>
+                <select
+                  id="contact-validation-mode"
+                  className={inputClassName}
+                  value={validationMode}
+                  onChange={(event) => setValidationMode(event.target.value)}
+                >
+                  <option value="">Not selected</option>
+                  <option value="virtual_preflight">Virtual preflight</option>
+                  <option value="comparative_policy_eval">Comparative policy eval</option>
+                  <option value="real_rollout_validated">Real rollout validated</option>
+                </select>
               </div>
               <div>
                 <label htmlFor="contact-deadline" className={labelClassName}>

--- a/client/src/lib/contactRequestPrefill.ts
+++ b/client/src/lib/contactRequestPrefill.ts
@@ -32,6 +32,8 @@ export type ContactRequestPrefill = {
   targetRobotTeam: string;
   scenario: string;
   requestedOutputs: string;
+  episodeCount: string;
+  validationMode: string;
   message: string;
   proofPathPreference: ProofPathPreference | "";
   realSiteRobotEvalFit: RealSiteRobotEvalFitInput | null;
@@ -110,6 +112,8 @@ const DEFAULT_PREFILL: ContactRequestPrefill = {
   targetRobotTeam: "",
   scenario: "",
   requestedOutputs: "",
+  episodeCount: "",
+  validationMode: "",
   message: "",
   proofPathPreference: "",
   realSiteRobotEvalFit: null,
@@ -158,6 +162,7 @@ export function normalizeContactRequestPath(
   if (
     normalized === "hosted-review" ||
     normalized === "hosted-evaluation" ||
+    normalized === "policy-evaluation-run" ||
     normalized === "hosted-session" ||
     normalized === "evaluation-package"
   ) {
@@ -212,13 +217,14 @@ export function requestPathToBuyerType(value: ContactRequestPath): BuyerType {
 }
 
 export function interestForRequestPath(value: ContactRequestPath): string {
-  if (value === "hosted-review") return "hosted-evaluation";
+  if (value === "hosted-review") return "policy-evaluation-run";
   if (value === "new-capture") return "capture-access";
   if (value === "site-question") return "site-review";
   return "policy-improvement-run";
 }
 
 export function publicPathForRequestPath(value: ContactRequestPath): string {
+  if (value === "hosted-review") return "policy-evaluation-run";
   return value === "data-package" ? "policy-improvement-run" : value;
 }
 
@@ -440,6 +446,8 @@ export function parseContactRequestPrefill(
     targetRobotTeam: getParam(params, ["targetRobotTeam", "robot", "robotTeam"]),
     scenario: getParam(params, ["scenario"]),
     requestedOutputs: getParam(params, ["requestedOutputs", "outputs"]),
+    episodeCount: getParam(params, ["episodeCount", "episodes"]),
+    validationMode: getParam(params, ["validationMode", "validation"]),
     message,
     proofPathPreference: parseProofPathPreference(
       getParam(params, ["proofPathPreference"]),
@@ -504,7 +512,11 @@ export function buildContactRequestUrl(input: ContactRequestUrlInput = {}): stri
   if (taskStatement) params.set("taskStatement", taskStatement);
   if (input.targetRobotTeam) params.set("targetRobotTeam", clean(input.targetRobotTeam));
   if (input.scenario) params.set("scenario", clean(input.scenario));
-  if (input.requestedOutputs) params.set("requestedOutputs", clean(input.requestedOutputs));
+  const requestedOutputs = clean(input.requestedOutputs) ||
+    (requestPath === "hosted-review" ? "Policy Evaluation Run" : "");
+  if (requestedOutputs) params.set("requestedOutputs", requestedOutputs);
+  if (input.episodeCount) params.set("episodeCount", clean(input.episodeCount));
+  if (input.validationMode) params.set("validationMode", clean(input.validationMode));
   if (input.message) params.set("message", clean(input.message));
   appendRobotFitParams(params, realSiteRobotEvalFit);
   params.set(

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -120,7 +120,7 @@ const pricingPlans = [
     price: "Scoped after evaluation",
     summary:
       "Adds paired real robot rollouts and reports Pearson/Spearman/SRCC or rank-fidelity, MAE, confidence bounds, validity envelope, and failure-mode agreement only for the validated envelope.",
-    href: "/contact/robot-team?persona=robot-team&buyerType=robot_team&interest=validated-evaluation-pack&path=policy-evaluation-run&requestedOutputs=Validated%20Evaluation%20Pack&source=home-pricing-validated-evaluation",
+    href: "/contact/robot-team?persona=robot-team&buyerType=robot_team&interest=policy-evaluation-run&path=policy-evaluation-run&requestedOutputs=Policy%20Evaluation%20Run&episodeCount=500&validationMode=real_rollout_validated&source=home-pricing-validated-evaluation",
     cta: "Request validated pack",
   },
 ];

--- a/client/src/pages/Pricing.tsx
+++ b/client/src/pages/Pricing.tsx
@@ -22,10 +22,10 @@ type PricingPlan = {
 };
 
 const policyEvaluationHref =
-  "/contact/robot-team?persona=robot-team&buyerType=robot_team&interest=policy-evaluation-run&path=hosted-review&requestedOutputs=Policy%20Evaluation%20Run&episodeCount=500&source=pricing-policy-evaluation";
+  "/contact/robot-team?persona=robot-team&buyerType=robot_team&interest=policy-evaluation-run&path=policy-evaluation-run&requestedOutputs=Policy%20Evaluation%20Run&episodeCount=500&source=pricing-policy-evaluation";
 
 const validatedEvaluationHref =
-  "/contact/robot-team?persona=robot-team&buyerType=robot_team&interest=validated-evaluation-pack&path=hosted-review&requestedOutputs=Validated%20Evaluation%20Pack&source=pricing-validated-evaluation";
+  "/contact/robot-team?persona=robot-team&buyerType=robot_team&interest=policy-evaluation-run&path=policy-evaluation-run&requestedOutputs=Policy%20Evaluation%20Run&episodeCount=500&validationMode=real_rollout_validated&source=pricing-validated-evaluation";
 
 const policyImprovementHref =
   "/contact/robot-team?persona=robot-team&buyerType=robot_team&interest=policy-improvement-run&path=policy-improvement-run&requestedOutputs=Policy%20Improvement%20Run&source=pricing-policy-improvement";

--- a/client/src/pages/RobotTeamEval.tsx
+++ b/client/src/pages/RobotTeamEval.tsx
@@ -243,16 +243,17 @@ function buildRequestReviewHref(params: {
   const query = new URLSearchParams({
     persona: "robot-team",
     buyerType: "robot_team",
-    interest: "hosted-evaluation",
-    path: "hosted-evaluation",
+    interest: "policy-evaluation-run",
+    path: "policy-evaluation-run",
     source: "robot-team-eval",
+    episodeCount: params.submission?.episodeCount || "100",
+    validationMode: params.submission?.validationMode || "virtual_preflight",
     siteName: params.siteName,
     siteLocation: params.siteAddress,
     targetRobotTeam: params.robotName,
     taskStatement: `Robot-team structured test submission for ${params.taskText}`,
     requestedOutputs:
-      params.submission?.requestedOutputs.join(", ") ||
-      fallbackOutputs.join(", "),
+      "Policy Evaluation Run",
     message: `Selected modalities: ${selectedModes}\nMissing evidence statuses: ${missing}\nRun setup:\n${setup}\nStructured refs:\n${structuredRefs}`,
   });
   return `/contact?${query.toString()}`;

--- a/client/tests/lib/contactRequestPrefill.test.ts
+++ b/client/tests/lib/contactRequestPrefill.test.ts
@@ -8,7 +8,7 @@ import {
 describe("contactRequestPrefill", () => {
   it("parses agent-friendly location, workflow, source, buyer type, and path aliases", () => {
     const prefill = parseContactRequestPrefill(
-      "source=site-worlds&buyerType=robot_team&path=hosted-review&location=123%20Unknown%20St&workflow=warehouse%20tote&message=Need%20a%20review&siteType=warehouse&requiredMetrics=97%25%20success&robotOrPolicy=Unitree%20G1%20policy&validationExpectations=sim%20trace",
+      "source=site-worlds&buyerType=robot_team&path=hosted-review&location=123%20Unknown%20St&workflow=warehouse%20tote&message=Need%20a%20review&episodeCount=500&validationMode=comparative_policy_eval&requestedOutputs=Policy%20Evaluation%20Run&siteType=warehouse&requiredMetrics=97%25%20success&robotOrPolicy=Unitree%20G1%20policy&validationExpectations=sim%20trace",
     );
 
     expect(prefill).toMatchObject({
@@ -20,6 +20,9 @@ describe("contactRequestPrefill", () => {
       workflow: "warehouse tote",
       taskStatement: "warehouse tote",
       message: "Need a review",
+      requestedOutputs: "Policy Evaluation Run",
+      episodeCount: "500",
+      validationMode: "comparative_policy_eval",
       primaryNeed: "123 Unknown St",
       realSiteRobotEvalFit: {
         siteCardInput: {
@@ -65,6 +68,8 @@ describe("contactRequestPrefill", () => {
           resultsValidationExpectations: "Simulator traces and action logs.",
         },
       },
+      episodeCount: "100",
+      validationMode: "virtual_preflight",
       message: "Scope hosted review without granting access.",
     });
     const url = new URL(href, "https://tryblueprint.local");
@@ -72,7 +77,8 @@ describe("contactRequestPrefill", () => {
     expect(url.pathname).toBe("/contact/robot-team");
     expect(url.searchParams.get("source")).toBe("site-worlds");
     expect(url.searchParams.get("buyerType")).toBe("robot_team");
-    expect(url.searchParams.get("path")).toBe("hosted-review");
+    expect(url.searchParams.get("interest")).toBe("policy-evaluation-run");
+    expect(url.searchParams.get("path")).toBe("policy-evaluation-run");
     expect(url.searchParams.get("location")).toBe("123 Unknown St");
     expect(url.searchParams.get("siteLocation")).toBe("123 Unknown St");
     expect(url.searchParams.get("workflow")).toBe("warehouse tote");
@@ -88,9 +94,41 @@ describe("contactRequestPrefill", () => {
     expect(url.searchParams.get("robotOrPolicy")).toBe("robot-team agent");
     expect(url.searchParams.get("preferredReviewPath")).toBe("Hosted review first.");
     expect(url.searchParams.get("validationExpectations")).toBe("Simulator traces and action logs.");
+    expect(url.searchParams.get("requestedOutputs")).toBe("Policy Evaluation Run");
+    expect(url.searchParams.get("episodeCount")).toBe("100");
+    expect(url.searchParams.get("validationMode")).toBe("virtual_preflight");
     expect(url.searchParams.get("proofPathPreference")).toBe("exact_site_required");
     expect(url.searchParams.has("entitlementId")).toBe(false);
     expect(url.searchParams.has("access")).toBe(false);
+  });
+
+  it("maps rebuilt Policy Evaluation Run query labels to hosted evaluation state", () => {
+    const prefill = parseContactRequestPrefill(
+      "persona=robot-team&buyerType=robot_team&interest=policy-evaluation-run&path=policy-evaluation-run&requestedOutputs=Policy%20Evaluation%20Run&episodeCount=500&validationMode=real_rollout_validated",
+      "/contact/robot-team",
+    );
+
+    expect(prefill).toMatchObject({
+      buyerType: "robot_team",
+      requestPath: "hosted-review",
+      commercialRequestPath: "hosted_evaluation",
+      requestedOutputs: "Policy Evaluation Run",
+      episodeCount: "500",
+      validationMode: "real_rollout_validated",
+    });
+
+    const genericContactPrefill = parseContactRequestPrefill(
+      "persona=robot-team&buyerType=robot_team&interest=policy-evaluation-run&path=policy-evaluation-run&requestedOutputs=Policy%20Evaluation%20Run&episodeCount=100&validationMode=virtual_preflight",
+      "/contact",
+    );
+
+    expect(genericContactPrefill).toMatchObject({
+      requestPath: "hosted-review",
+      commercialRequestPath: "hosted_evaluation",
+      requestedOutputs: "Policy Evaluation Run",
+      episodeCount: "100",
+      validationMode: "virtual_preflight",
+    });
   });
 
   it("maps legacy world-model params to the Policy Improvement Run lane", () => {


### PR DESCRIPTION
### Motivation
- Rebuild the Policy Evaluation Run query/prefill labels so public CTAs and internal links use `interest=policy-evaluation-run` / `path=policy-evaluation-run` and carry the new prefill keys for run size and validation mode.
- Preserve these values visibly on the contact form and ensure they are included in submitted intake payloads for correct downstream handling of hosted evaluation requests.

### Description
- Updated public CTA links to use the rebuilt labels and include `requestedOutputs=Policy Evaluation Run` and optional `episodeCount`/`validationMode` where appropriate in `client/src/pages/Home.tsx` and `client/src/pages/Pricing.tsx`.
- Updated `client/src/pages/RobotTeamEval.tsx` to build review links with `interest=policy-evaluation-run`, `path=policy-evaluation-run`, and to pass `episodeCount` and `validationMode` from the run setup into the generated `/contact` URL.
- Extended `client/src/lib/contactRequestPrefill.ts` to parse and emit `episodeCount` and `validationMode`, map the rebuilt `policy-evaluation-run` labels into the hosted-evaluation request path, and default `requestedOutputs` for hosted requests to `Policy Evaluation Run`.
- Added visible fields and form state for `episodeCount` and `validationMode` in `client/src/components/site/ContactForm.tsx`, prefill them from query params, surface them in the optional details block, and include them in the constructed `realSiteRobotEvalFit` / submitted `InboundRequestPayload`.
- Updated tests in `client/tests/lib/contactRequestPrefill.test.ts` to cover parsing/building of the rebuilt Policy Evaluation Run query labels and the new prefill keys.

### Testing
- Ran the updated unit tests with `npm run test -- --run client/tests/lib/contactRequestPrefill.test.ts`, and all tests passed.
- Ran the TypeScript typecheck with `npm run check`, which completed successfully.
- Attempted to refresh graphify architecture outputs with `bash scripts/graphify/run-webapp-architecture-pilot.sh --no-viz`, but this step is blocked locally due to a missing Python package (`graphifyy`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35ed98c0e48329a4b00a60e9c14bd6)