### PR TITLE
Surface blocked automation worker results

### DIFF
--- a/server/tests/ops-automation-scheduler.test.ts
+++ b/server/tests/ops-automation-scheduler.test.ts
@@ -18,6 +18,7 @@ const runGapClosureLoop = vi.hoisted(() => vi.fn());
 const runHumanReplyEmailWatcher = vi.hoisted(() => vi.fn());
 const runOperatingGraphProjectionLoop = vi.hoisted(() => vi.fn());
 const sendSlackMessage = vi.hoisted(() => vi.fn());
+const workerStatusSetMock = vi.hoisted(() => vi.fn());
 const workerFailureAlertState = vi.hoisted(() => new Map<string, string>());
 const maybeAlertOnWorkerStatusTransition = vi.hoisted(() =>
   vi.fn(async (params: {
@@ -72,19 +73,6 @@ const maybeAlertOnWorkerStatusTransition = vi.hoisted(() =>
     }
   }),
 );
-const firebaseAdminMock = vi.hoisted(() => ({
-  default: {
-    firestore: {
-      FieldValue: {
-        serverTimestamp: () => "timestamp",
-      },
-    },
-  },
-  dbAdmin: null,
-  authAdmin: null,
-}));
-
-vi.mock("../../client/src/lib/firebaseAdmin", () => firebaseAdminMock);
 
 vi.mock("../utils/ops-alerts", () => ({
   maybeAlertOnWorkerStatusTransition,
@@ -92,7 +80,14 @@ vi.mock("../utils/ops-alerts", () => ({
 
 vi.mock("../../client/src/lib/firebaseAdmin", () => ({
   authAdmin: null,
-  dbAdmin: null,
+  dbAdmin: {
+    collection: vi.fn((collectionName: string) => ({
+      doc: vi.fn((docId: string) => ({
+        set: (payload: Record<string, unknown>, options: Record<string, unknown>) =>
+          workerStatusSetMock(collectionName, docId, payload, options),
+      })),
+    })),
+  },
   default: {
     firestore: {
       FieldValue: {
@@ -154,6 +149,8 @@ vi.mock("../utils/slack", () => ({
 
 beforeEach(() => {
   vi.useFakeTimers();
+  workerStatusSetMock.mockReset();
+  workerFailureAlertState.clear();
   runWaitlistAutomationLoop.mockResolvedValue({ processedCount: 1, failedCount: 0 });
   runInboundQualificationLoop.mockResolvedValue({ processedCount: 2, failedCount: 0 });
   runSupportTriageLoop.mockResolvedValue({ processedCount: 3, failedCount: 0 });
@@ -262,6 +259,51 @@ describe("ops automation scheduler", () => {
     await vi.advanceTimersByTimeAsync(60_000);
 
     expect(runHumanReplyEmailWatcher).toHaveBeenCalledWith({ limit: 25 });
+
+    stop();
+  });
+
+  it("persists blocked worker metadata when the human reply watcher fails closed", async () => {
+    const reason =
+      "Gmail OAuth refresh token was rejected with invalid_grant. Rotate BLUEPRINT_HUMAN_REPLY_GMAIL_REFRESH_TOKEN.";
+    vi.stubEnv("BLUEPRINT_HUMAN_REPLY_GMAIL_WATCHER_ENABLED", "1");
+    vi.stubEnv("BLUEPRINT_HUMAN_REPLY_GMAIL_WATCHER_STARTUP_DELAY_MS", "0");
+    runHumanReplyEmailWatcher.mockResolvedValueOnce({
+      processedCount: 0,
+      failedCount: 0,
+      blockedCount: 0,
+      reason,
+    });
+
+    const { startOpsAutomationScheduler } = await import("../utils/opsAutomationScheduler");
+    const stop = startOpsAutomationScheduler();
+
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    const blockedStatusCall = workerStatusSetMock.mock.calls.find(
+      ([collectionName, docId, payload]) =>
+        collectionName === "opsAutomationWorkerStatus"
+        && docId === "human_reply_email"
+        && payload?.status === "blocked",
+    );
+    expect(blockedStatusCall).toBeTruthy();
+    expect(blockedStatusCall?.[2]).toEqual(
+      expect.objectContaining({
+        status: "blocked",
+        last_processed_count: 0,
+        last_failed_count: 0,
+        last_blocked_count: 0,
+        last_result_reason: reason,
+        last_error: null,
+      }),
+    );
+    expect(maybeAlertOnWorkerStatusTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workerKey: "human_reply_email",
+        nextStatus: "blocked",
+        failedCount: 0,
+      }),
+    );
 
     stop();
   });

--- a/server/utils/opsAutomationScheduler.ts
+++ b/server/utils/opsAutomationScheduler.ts
@@ -39,8 +39,25 @@ type WorkerDefinition = {
   defaultBatchSize: number;
   maxBatchSize?: number;
   defaultStartupDelayMs: number;
-  run: (params: { limit: number }) => Promise<{ processedCount: number; failedCount: number }>;
+  run: (params: { limit: number }) => Promise<WorkerRunResult>;
 };
+
+type WorkerRunResult = {
+  processedCount: number;
+  failedCount: number;
+  blockedCount?: number;
+  reason?: string | null;
+};
+
+function normalizeWorkerResultReason(reason: unknown) {
+  return typeof reason === "string" && reason.trim() ? reason.trim() : null;
+}
+
+function normalizeWorkerBlockedCount(blockedCount: unknown) {
+  return typeof blockedCount === "number" && Number.isFinite(blockedCount)
+    ? Math.max(0, blockedCount)
+    : 0;
+}
 
 async function persistWorkerStatus(
   workerKey: string,
@@ -423,9 +440,12 @@ export function startOpsAutomationScheduler() {
           });
           logger.info(meta, `Starting ${worker.key} automation run`);
           const result = await worker.run({ limit: batchSize });
+          const blockedCount = normalizeWorkerBlockedCount(result.blockedCount);
+          const resultReason = normalizeWorkerResultReason(result.reason);
+          const completedStatus = resultReason || blockedCount > 0 ? "blocked" : "idle";
           await persistWorkerStatus(worker.key, {
             enabled: true,
-            status: "idle",
+            status: completedStatus,
             interval_ms: intervalMs,
             batch_size: batchSize,
             startup_delay_ms: startupDelayMs,
@@ -436,12 +456,14 @@ export function startOpsAutomationScheduler() {
             last_run_duration_ms: Date.now() - runStartedAt,
             last_processed_count: result.processedCount,
             last_failed_count: result.failedCount,
+            last_blocked_count: blockedCount,
+            last_result_reason: resultReason,
             last_error: null,
           });
           await maybeAlertOnWorkerStatusTransition({
             workerKey: worker.key,
             previousStatus: lastKnownStatus,
-            nextStatus: "idle",
+            nextStatus: completedStatus,
             intervalMs,
             batchSize,
             runNumber,
@@ -449,12 +471,14 @@ export function startOpsAutomationScheduler() {
             failedCount: result.failedCount,
             error: null,
           });
-          lastKnownStatus = "idle";
+          lastKnownStatus = completedStatus;
           logger.info(
             attachRequestMeta({
               ...meta,
               processedCount: result.processedCount,
               failedCount: result.failedCount,
+              blockedCount,
+              resultReason,
             }),
             `Completed ${worker.key} automation run`,
           );
@@ -470,6 +494,8 @@ export function startOpsAutomationScheduler() {
             last_run_completed_at_iso: new Date().toISOString(),
             last_run_completed_at: admin.firestore.FieldValue.serverTimestamp(),
             last_run_duration_ms: Date.now() - runStartedAt,
+            last_blocked_count: null,
+            last_result_reason: null,
             last_error: error instanceof Error ? error.message : String(error),
           });
           await maybeAlertOnWorkerStatusTransition({


### PR DESCRIPTION
## Summary
- Persist automation worker `blocked` status when a worker returns a block reason or blocked count
- Preserve `last_blocked_count` and `last_result_reason` in `opsAutomationWorkerStatus`
- Add regression coverage for the human-reply email watcher fail-closed path

## Production log finding
Production Render logs had repeated `human_reply_email` app errors from Google OAuth `invalid_grant`. The primary fail-closed fix is already live on `main` in `ea90b8e5`; this PR completes the operational follow-up so the same credential-blocked state remains visible as blocked scheduler metadata rather than disappearing into an idle run.

## Verification
- `npm run test -- server/tests/human-reply-gmail.test.ts server/tests/ops-automation-scheduler.test.ts`
- `npm run check`
- `bash scripts/graphify/run-webapp-architecture-pilot.sh --no-viz`
- Render deploy for `ea90b8e5` is live and post-deploy logs showed 0 `human_reply_email` errors plus a completed scheduler run
