### PR TITLE
Fix flash-of-unstyled-content on page load/refresh

### DIFF
--- a/client/src/app/routes.tsx
+++ b/client/src/app/routes.tsx
@@ -1,5 +1,5 @@
 import { lazy } from "react";
-import type { ComponentType } from "react";
+import type { ComponentType, LazyExoticComponent } from "react";
 import { MarketingRedirect } from "../pages/MarketingRedirect";
 import { getSiteLibrarySite } from "../data/siteLibrary";
 
@@ -11,64 +11,77 @@ export type AppRoute = {
   component: ComponentType<any>;
 };
 
-const Home = lazy(() => import("../pages/Home"));
-const Capture = lazy(() => import("../pages/Capture"));
-const CaptureAppPlaceholder = lazy(() => import("../pages/CaptureAppPlaceholder"));
-const CaptureLaunchAccess = lazy(() => import("../pages/CaptureLaunchAccess"));
-const BusinessSignUpFlow = lazy(() => import("../pages/BusinessSignUpFlow"));
-const CapturerSignUpFlow = lazy(() => import("../pages/CapturerSignUpFlow"));
-const OnboardingChecklist = lazy(() => import("../pages/OnboardingChecklist"));
-const HostedSessionSetup = lazy(() => import("../pages/HostedSessionSetup"));
-const HostedSessionWorkspace = lazy(() => import("../pages/HostedSessionWorkspace"));
-const RobotTeamEval = lazy(() => import("../pages/RobotTeamEval"));
-const Sites = lazy(() => import("../pages/Sites"));
-const SiteDetail = lazy(() => import("../pages/SiteDetail"));
-const Pricing = lazy(() => import("../pages/Pricing"));
-const Contact = lazy(() => import("../pages/Contact"));
-const Proof = lazy(() => import("../pages/Proof"));
-const Portal = lazy(() => import("../pages/Portal"));
-const Login = lazy(() => import("../pages/Login"));
-const ForgotPassword = lazy(() => import("../pages/ForgotPassword"));
-const Privacy = lazy(() => import("../pages/Privacy"));
-const Terms = lazy(() => import("../pages/Terms"));
-const Settings = lazy(() => import("../pages/Settings"));
-const AdminLeads = lazy(() => import("../pages/AdminLeads"));
-const AdminGrowthOpsScorecard = lazy(() => import("../pages/AdminGrowthOpsScorecard"));
-const AdminAustinLaunchScorecard = lazy(() => import("../pages/AdminAustinLaunchScorecard"));
-const AdminGrowthStudio = lazy(() => import("../pages/AdminGrowthStudio"));
-const AdminCompanyMetrics = lazy(() => import("../pages/AdminCompanyMetrics"));
-const Dashboard = lazy(() => import("../pages/Dashboard"));
-const OffWaitlistSignUpFlow = lazy(() => import("../pages/OffWaitlistSignUpFlow"));
-const RequestConsole = lazy(() => import("../pages/RequestConsole"));
-const DesignSystem = lazy(() => import("../pages/DesignSystem"));
+// A lazy route component that also exposes its raw module loader, so
+// main.tsx can preload the matched route's chunk before swapping out the
+// prerendered markup — avoiding a Suspense-fallback flash on first paint.
+export type PreloadableComponent<P = any> = LazyExoticComponent<ComponentType<P>> & {
+  preload: () => Promise<unknown>;
+};
+
+function lazyRoute<P = any>(
+  loader: () => Promise<{ default: ComponentType<P> }>,
+): PreloadableComponent<P> {
+  return Object.assign(lazy(loader), { preload: loader });
+}
+
+const Home = lazyRoute(() => import("../pages/Home"));
+const Capture = lazyRoute(() => import("../pages/Capture"));
+const CaptureAppPlaceholder = lazyRoute(() => import("../pages/CaptureAppPlaceholder"));
+const CaptureLaunchAccess = lazyRoute(() => import("../pages/CaptureLaunchAccess"));
+const BusinessSignUpFlow = lazyRoute(() => import("../pages/BusinessSignUpFlow"));
+const CapturerSignUpFlow = lazyRoute(() => import("../pages/CapturerSignUpFlow"));
+const OnboardingChecklist = lazyRoute(() => import("../pages/OnboardingChecklist"));
+const HostedSessionSetup = lazyRoute(() => import("../pages/HostedSessionSetup"));
+const HostedSessionWorkspace = lazyRoute(() => import("../pages/HostedSessionWorkspace"));
+const RobotTeamEval = lazyRoute(() => import("../pages/RobotTeamEval"));
+const Sites = lazyRoute(() => import("../pages/Sites"));
+const SiteDetail = lazyRoute(() => import("../pages/SiteDetail"));
+const Pricing = lazyRoute(() => import("../pages/Pricing"));
+const Contact = lazyRoute(() => import("../pages/Contact"));
+const Proof = lazyRoute(() => import("../pages/Proof"));
+const Portal = lazyRoute(() => import("../pages/Portal"));
+const Login = lazyRoute(() => import("../pages/Login"));
+const ForgotPassword = lazyRoute(() => import("../pages/ForgotPassword"));
+const Privacy = lazyRoute(() => import("../pages/Privacy"));
+const Terms = lazyRoute(() => import("../pages/Terms"));
+const Settings = lazyRoute(() => import("../pages/Settings"));
+const AdminLeads = lazyRoute(() => import("../pages/AdminLeads"));
+const AdminGrowthOpsScorecard = lazyRoute(() => import("../pages/AdminGrowthOpsScorecard"));
+const AdminAustinLaunchScorecard = lazyRoute(() => import("../pages/AdminAustinLaunchScorecard"));
+const AdminGrowthStudio = lazyRoute(() => import("../pages/AdminGrowthStudio"));
+const AdminCompanyMetrics = lazyRoute(() => import("../pages/AdminCompanyMetrics"));
+const Dashboard = lazyRoute(() => import("../pages/Dashboard"));
+const OffWaitlistSignUpFlow = lazyRoute(() => import("../pages/OffWaitlistSignUpFlow"));
+const RequestConsole = lazyRoute(() => import("../pages/RequestConsole"));
+const DesignSystem = lazyRoute(() => import("../pages/DesignSystem"));
 
 // Redesign — public pages (distinct surfaces per SCREENS.md)
-const About = lazy(() => import("../pages/About"));
-const Governance = lazy(() => import("../pages/Governance"));
-const HowItWorks = lazy(() => import("../pages/HowItWorks"));
-const ForRobotTeams = lazy(() => import("../pages/ForRobotTeams"));
-const ForSiteOperators = lazy(() => import("../pages/ForSiteOperators"));
-const JoinBlueprint = lazy(() => import("../pages/JoinBlueprint"));
+const About = lazyRoute(() => import("../pages/About"));
+const Governance = lazyRoute(() => import("../pages/Governance"));
+const HowItWorks = lazyRoute(() => import("../pages/HowItWorks"));
+const ForRobotTeams = lazyRoute(() => import("../pages/ForRobotTeams"));
+const ForSiteOperators = lazyRoute(() => import("../pages/ForSiteOperators"));
+const JoinBlueprint = lazyRoute(() => import("../pages/JoinBlueprint"));
 
 // Redesign — buyer app (mock-data demo surfaces)
-const AppOverview = lazy(() => import("../pages/app/Overview"));
-const AppRuns = lazy(() => import("../pages/app/Runs"));
-const AppRunDetail = lazy(() => import("../pages/app/RunDetail"));
-const AppSitePacks = lazy(() => import("../pages/app/SitePacks"));
-const AppSiteDetail = lazy(() => import("../pages/app/SiteDetail"));
-const AppPolicies = lazy(() => import("../pages/app/Policies"));
-const AppDataPackages = lazy(() => import("../pages/app/DataPackages"));
-const AppEntitlements = lazy(() => import("../pages/app/Entitlements"));
+const AppOverview = lazyRoute(() => import("../pages/app/Overview"));
+const AppRuns = lazyRoute(() => import("../pages/app/Runs"));
+const AppRunDetail = lazyRoute(() => import("../pages/app/RunDetail"));
+const AppSitePacks = lazyRoute(() => import("../pages/app/SitePacks"));
+const AppSiteDetail = lazyRoute(() => import("../pages/app/SiteDetail"));
+const AppPolicies = lazyRoute(() => import("../pages/app/Policies"));
+const AppDataPackages = lazyRoute(() => import("../pages/app/DataPackages"));
+const AppEntitlements = lazyRoute(() => import("../pages/app/Entitlements"));
 
 // Redesign — ops console (mock-data demo surfaces)
-const OpsQueue = lazy(() => import("../pages/ops/Queue"));
-const OpsCaptureSupply = lazy(() => import("../pages/ops/CaptureSupply"));
-const OpsCityLaunch = lazy(() => import("../pages/ops/CityLaunch"));
-const OpsEvidenceReview = lazy(() => import("../pages/ops/EvidenceReview"));
-const OpsBuyerHandoff = lazy(() => import("../pages/ops/BuyerHandoff"));
-const OpsSpendControls = lazy(() => import("../pages/ops/SpendControls"));
+const OpsQueue = lazyRoute(() => import("../pages/ops/Queue"));
+const OpsCaptureSupply = lazyRoute(() => import("../pages/ops/CaptureSupply"));
+const OpsCityLaunch = lazyRoute(() => import("../pages/ops/CityLaunch"));
+const OpsEvidenceReview = lazyRoute(() => import("../pages/ops/EvidenceReview"));
+const OpsBuyerHandoff = lazyRoute(() => import("../pages/ops/BuyerHandoff"));
+const OpsSpendControls = lazyRoute(() => import("../pages/ops/SpendControls"));
 
-const NotFound = lazy(() => import("../pages/NotFound"));
+const NotFound = lazyRoute(() => import("../pages/NotFound"));
 
 const HomeRedirect = () => <MarketingRedirect to="/" />;
 
@@ -312,3 +325,31 @@ export const appRoutes: AppRoute[] = [
   // 404
   { layout: "public", component: NotFound },
 ];
+
+function hasPreload(component: ComponentType<any>): component is PreloadableComponent {
+  return typeof (component as { preload?: unknown }).preload === "function";
+}
+
+// Mirrors wouter's <Switch>/<Route> first-match-wins semantics (literal
+// segments plus `:param` segments) so main.tsx can resolve the same route
+// the live <Router> will render, without rendering it.
+export function matchAppRoute(pathname: string): AppRoute | undefined {
+  const segments = pathname.split("/").filter(Boolean);
+  const staticMatch = appRoutes.find((route) => {
+    if (!route.path) return false;
+    const routeSegments = route.path.split("/").filter(Boolean);
+    if (routeSegments.length !== segments.length) return false;
+    return routeSegments.every(
+      (segment, index) => segment.startsWith(":") || segment === segments[index],
+    );
+  });
+
+  return staticMatch ?? appRoutes.find((route) => !route.path);
+}
+
+// Preloads the JS chunk for the route matching `pathname`, if it's lazy. Used
+// on initial boot so the first client render doesn't suspend (see main.tsx).
+export function preloadMatchedRoute(pathname: string): Promise<unknown> | null {
+  const component = matchAppRoute(pathname)?.component;
+  return component && hasPreload(component) ? component.preload() : null;
+}

--- a/client/src/app/routes.tsx
+++ b/client/src/app/routes.tsx
@@ -21,7 +21,19 @@ export type PreloadableComponent<P = any> = LazyExoticComponent<ComponentType<P>
 function lazyRoute<P = any>(
   loader: () => Promise<{ default: ComponentType<P> }>,
 ): PreloadableComponent<P> {
-  return Object.assign(lazy(loader), { preload: loader });
+  // Memoized so a manual preload() call and React.lazy's own internal
+  // call (on first render of this component) resolve the exact same
+  // promise — calling the raw loader twice would only warm the module
+  // cache, not React.lazy's internal payload, so React would still
+  // suspend on a fresh, separate thenable.
+  let modulePromise: Promise<{ default: ComponentType<P> }> | undefined;
+  const load = () => {
+    if (!modulePromise) {
+      modulePromise = loader();
+    }
+    return modulePromise;
+  };
+  return Object.assign(lazy(load), { preload: load });
 }
 
 const Home = lazyRoute(() => import("../pages/Home"));

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -13,7 +13,7 @@ import { Analytics } from "./components/Analytics";
 import { AuthProvider } from "./contexts/AuthContext";
 import ProtectedRoute from "./components/ProtectedRoute";
 import { installClientLogger } from "./utils/clientLogger";
-import { appRoutes } from "./app/routes";
+import { appRoutes, preloadMatchedRoute } from "./app/routes";
 
 installClientLogger();
 
@@ -83,13 +83,29 @@ const app = (
 
 const rootElement = document.getElementById("root")!;
 
-// Prerendered HTML serves SEO crawlers that don't run JS.
-// Lazy-loaded routes inside Suspense produce a LoadingScreen fallback on first
-// render, which never matches the prerendered markup. React's hydration then
-// fails and leaves duplicate DOM nodes. Clearing the prerendered content and
-// using createRoot avoids the mismatch entirely — the JS bundle renders the
-// real page almost immediately.
-if (rootElement.hasChildNodes()) {
-  rootElement.textContent = "";
+// Prerendered HTML serves SEO crawlers that don't run JS, and gives users a
+// real first paint before the JS bundle runs. Hydrating it isn't viable here
+// (prerendering uses renderToStaticMarkup, which emits no hydration markers),
+// so we clear it and do a client render instead. Clearing immediately and
+// rendering would otherwise flash a blank screen + LoadingScreen fallback
+// while the matched route's lazy chunk loads, so we preload that chunk first
+// and only swap once it (or a timeout) resolves — turning two visible paints
+// into one.
+const ROUTE_PRELOAD_TIMEOUT_MS = 3000;
+
+function mountApp() {
+  if (rootElement.hasChildNodes()) {
+    rootElement.textContent = "";
+  }
+  createRoot(rootElement).render(app);
 }
-createRoot(rootElement).render(app);
+
+const routePreload = preloadMatchedRoute(window.location.pathname);
+if (routePreload) {
+  const timeout = new Promise((resolve) => setTimeout(resolve, ROUTE_PRELOAD_TIMEOUT_MS));
+  Promise.race([routePreload, timeout])
+    .catch(() => {})
+    .then(mountApp);
+} else {
+  mountApp();
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -87,11 +87,14 @@ const rootElement = document.getElementById("root")!;
 // real first paint before the JS bundle runs. Hydrating it isn't viable here
 // (prerendering uses renderToStaticMarkup, which emits no hydration markers),
 // so we clear it and do a client render instead. Clearing immediately and
-// rendering would otherwise flash a blank screen + LoadingScreen fallback
-// while the matched route's lazy chunk loads, so we preload that chunk first
-// and only swap once it (or a timeout) resolves — turning two visible paints
-// into one.
+// rendering would otherwise flash the prerendered markup to blank + a
+// LoadingScreen fallback while the matched route's lazy chunk loads, so when
+// there's prerendered markup worth protecting we preload that chunk first and
+// only swap once it (or a timeout) resolves. Routes with no prerendered markup
+// (app-shell.html) have nothing to protect, so they mount immediately and get
+// the normal Suspense LoadingScreen fallback like before.
 const ROUTE_PRELOAD_TIMEOUT_MS = 3000;
+const hasPrerenderedMarkup = rootElement.hasChildNodes();
 
 function mountApp() {
   if (rootElement.hasChildNodes()) {
@@ -100,7 +103,7 @@ function mountApp() {
   createRoot(rootElement).render(app);
 }
 
-const routePreload = preloadMatchedRoute(window.location.pathname);
+const routePreload = hasPrerenderedMarkup ? preloadMatchedRoute(window.location.pathname) : null;
 if (routePreload) {
   const timeout = new Promise((resolve) => setTimeout(resolve, ROUTE_PRELOAD_TIMEOUT_MS));
   Promise.race([routePreload, timeout])

--- a/scripts/prerender.tsx
+++ b/scripts/prerender.tsx
@@ -460,127 +460,6 @@ const staticRoutes: StaticRoute[] = [
 
 const rootPattern = /<div id="root"><\/div>/;
 
-type DeferredClientAsset = {
-  href: string;
-  crossorigin: boolean;
-};
-
-type DeferredClientEntry = {
-  src: string;
-  crossorigin: boolean;
-};
-
-function shouldDeferStylesheet(href: string) {
-  return href.startsWith("/assets/");
-}
-
-function deferClientBoot(template: string) {
-  const entries: DeferredClientEntry[] = [];
-  const modulePreloads: DeferredClientAsset[] = [];
-  const stylesheets: DeferredClientAsset[] = [];
-  let html = template.replace(
-    /\s*<script\b([^>]*\btype="module"[^>]*)><\/script>/gi,
-    (match, attributes: string) => {
-      const src = attributes.match(/\bsrc="([^"]+)"/i)?.[1];
-      if (!src) {
-        return match;
-      }
-      entries.push({
-        src,
-        crossorigin: /\bcrossorigin\b/i.test(attributes),
-      });
-      return "";
-    },
-  );
-
-  html = html.replace(
-    /\s*<link\b([^>]*\brel="modulepreload"[^>]*)>/gi,
-    (match, attributes: string) => {
-      const href = attributes.match(/\bhref="([^"]+)"/i)?.[1];
-      if (!href) {
-        return match;
-      }
-      modulePreloads.push({
-        href,
-        crossorigin: /\bcrossorigin\b/i.test(attributes),
-      });
-      return "";
-    },
-  );
-
-  html = html.replace(
-    /\s*<link\b([^>]*\brel="stylesheet"[^>]*)>/gi,
-    (match, attributes: string) => {
-      const href = attributes.match(/\bhref="([^"]+)"/i)?.[1];
-      if (!href || !shouldDeferStylesheet(href)) {
-        return match;
-      }
-      stylesheets.push({
-        href,
-        crossorigin: /\bcrossorigin\b/i.test(attributes),
-      });
-      return "";
-    },
-  );
-
-  if (entries.length === 0 && modulePreloads.length === 0 && stylesheets.length === 0) {
-    return html;
-  }
-
-  const payload = JSON.stringify({ entries, modulePreloads, stylesheets });
-  const bootstrap = `<script data-blueprint-deferred-client-boot>
-(() => {
-  const bootDelayMs = 1000;
-  const assets = ${payload};
-  let booted = false;
-  let bootTimer = 0;
-  const appendStylesheet = ({ href, crossorigin }) => {
-    const link = document.createElement("link");
-    link.rel = "stylesheet";
-    link.href = href;
-    if (crossorigin) link.crossOrigin = "";
-    document.head.appendChild(link);
-  };
-  const appendModulePreload = ({ href, crossorigin }) => {
-    const link = document.createElement("link");
-    link.rel = "modulepreload";
-    link.href = href;
-    if (crossorigin) link.crossOrigin = "";
-    document.head.appendChild(link);
-  };
-  const appendModuleScript = ({ src, crossorigin }) => {
-    const script = document.createElement("script");
-    script.type = "module";
-    script.src = src;
-    if (crossorigin) script.crossOrigin = "";
-    document.head.appendChild(script);
-  };
-  const boot = () => {
-    if (booted) return;
-    booted = true;
-    if (bootTimer) window.clearTimeout(bootTimer);
-    assets.stylesheets.forEach(appendStylesheet);
-    assets.modulePreloads.forEach(appendModulePreload);
-    assets.entries.forEach(appendModuleScript);
-  };
-  const bootOnInteraction = () => boot();
-  const scheduleBoot = () => {
-    bootTimer = window.setTimeout(boot, bootDelayMs);
-  };
-  ["pointerdown", "keydown", "touchstart", "focusin"].forEach((eventName) => {
-    window.addEventListener(eventName, bootOnInteraction, { once: true, capture: true });
-  });
-  if (document.readyState === "complete") {
-    scheduleBoot();
-  } else {
-    window.addEventListener("load", scheduleBoot, { once: true });
-  }
-})();
-</script>`;
-
-  return html.replace("</body>", `${bootstrap}\n  </body>`);
-}
-
 function routePathToFile(distPath: string, routePath: string) {
   if (routePath === "/") {
     return path.join(distPath, "index.html");
@@ -648,8 +527,8 @@ function stripViteThemeStyle(template: string) {
   return template.replace(/\s*<style\s+data-vite-theme[^>]*>[\s\S]*?<\/style>\s*/i, "\n");
 }
 
-// The prerendered shell is a transient, pre-boot snapshot that the deferred
-// client boot replaces once React hydrates. Eager/above-the-fold images in that
+// The prerendered shell is a transient snapshot that the client JS bundle
+// replaces on boot (see main.tsx). Eager/above-the-fold images in that
 // snapshot are the only resources left that block the document `load` event, so
 // force every prerendered <img> to lazy + async-decode. This keeps the live app's
 // authored loading strategy intact (React re-renders the real <img> on boot) while
@@ -679,16 +558,16 @@ function deferImageLoading(template: string) {
 async function main() {
   const distPath = path.resolve(__dirname, "..", "dist", "public");
   const templatePath = path.join(distPath, "index.html");
-  const template = deferClientBoot(
-    stripViteThemeStyle(stripDefaultSeo(await fs.promises.readFile(templatePath, "utf8"))),
+  const template = stripViteThemeStyle(
+    stripDefaultSeo(await fs.promises.readFile(templatePath, "utf8")),
   );
 
   if (!rootPattern.test(template)) {
     throw new Error("Could not locate the root element in the built HTML template.");
   }
 
-  // Emit a minimal SPA boot shell: empty root + deferred client boot, no route
-  // markup or imagery. serveStatic serves this for client-rendered routes without
+  // Emit a minimal SPA boot shell: empty root, no route markup or imagery.
+  // serveStatic serves this for client-rendered routes without
   // a dedicated prerendered document (e.g. /app, /ops, /join, private/admin views)
   // instead of the heavy homepage markup, so those routes parse a ~3KB shell rather
   // than the ~39KB home document on first load. createRoot (not hydration) renders

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -74,7 +74,7 @@ export function serveStatic(app: Express, distPathOverride?: string) {
     throw new Error(`Could not read the built client index: ${indexPath}`);
   }
 
-  // Minimal SPA boot shell (empty root + deferred boot, no homepage markup/images).
+  // Minimal SPA boot shell (empty root, no homepage markup/images).
   // Used as the catch-all fallback for client-rendered routes that have no dedicated
   // prerendered document, so they parse a ~3KB shell instead of the ~39KB homepage.
   const shellHtml = readCachedHtml(path.resolve(distPath, "app-shell.html")) ?? indexHtml;


### PR DESCRIPTION
## Summary

Every page load/refresh briefly showed broken, unstyled markup before snapping into the real styled page — reported as "a 0.5s delay where I see elements of the page, like the logo or an image."

Root cause: `scripts/prerender.tsx` had a `deferClientBoot()` step that stripped the app's compiled `<link rel=stylesheet>` and `<script type=module>` tags out of every prerendered page and replaced them with a bootstrap script that waited up to **1000ms** (or until first user interaction) before injecting them back in. This was added in a prior commit ("Hit sub-50ms page-load budget across all 108 routes") purely to game `scripts/measure-page-load-performance.ts`'s raw `DOMContentLoaded`/`load` timing budget — that script only measures the static document's load event, so withholding all CSS/JS made it look artificially fast while making the real page unusable for up to a second: real users got fully unstyled HTML (no Tailwind) until the delay elapsed, then a second flash to blank when `main.tsx` cleared the DOM and showed a `LoadingScreen` spinner while the matched route's lazy chunk loaded.

- `scripts/prerender.tsx`: removed `deferClientBoot`/`shouldDeferStylesheet` — prerendered pages now ship normal, immediate `<link rel=stylesheet>` / `<script type=module>` tags instead of an artificially delayed bootstrap script.
- `client/src/app/routes.tsx`: added a `lazyRoute()` helper so each lazy page component also exposes its raw module loader, plus `matchAppRoute()`/`preloadMatchedRoute()` helpers that mirror `<Switch>`'s path-matching.
- `client/src/main.tsx`: preloads the matched route's chunk *before* clearing the prerendered markup and mounting React, so the swap from prerendered HTML to the live app happens in one step instead of flashing blank + a spinner while the chunk downloads.
- `server/vite.ts`: updated a stale comment referencing the removed mechanism.

## Trade-off

This reverts the literal page-load-budget optimization from the prior commit (it will no longer hit the synthetic sub-50ms number, since CSS/JS now load immediately like a normal app). That budget script only measures raw document timing, not when the app is actually usable, so it was rewarding exactly this regression. Real UX correctness wins here.

## Verification

- `npm run check` — passes.
- `npm run build` — passes; verified the prerendered HTML output no longer contains the deferred-boot script and ships normal stylesheet/script tags.
- `npm run test:build-output` / static-serving tests — same single pre-existing failure as on unmodified `main` (an unrelated homepage-copy assertion that's already stale against current content), no new failures.
- Full `vitest run` — identical pass/fail counts before and after this change (81 pre-existing failures unrelated to this fix, confirmed by diffing against unmodified `main`).
- Production build + Playwright: served the built app and measured the CSS/JS requests firing within ~25ms of navigation (previously up to 1000ms), and confirmed the rendered page is visually identical at 80ms post-navigation and at network-idle — no flash.

## Test plan

- [ ] Visit a few routes (`/`, `/capture`, `/sites`, `/pricing`) on a deployed preview and confirm there's no flash of unstyled/blank content on load or refresh.


---
_Generated by [Claude Code](https://claude.ai/code/session_017i5HCZxiQwnPW2vJqzDszF)_