### PR TITLE
Mirror capture_submissions rules hardening + composite index (parity with BlueprintCapture#53)

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -17,6 +17,20 @@
           "order": "ASCENDING"
         }
       ]
+    },
+    {
+      "collectionGroup": "capture_submissions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "creator_id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "submitted_at",
+          "order": "DESCENDING"
+        }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/firestore.rules
+++ b/firestore.rules
@@ -143,7 +143,8 @@ service cloud.firestore {
         'queued',
         'not_started',
         'blocked_raw_validation',
-        'blocked_local_storage'
+        'blocked_local_storage',
+        'blocked_local_capture_limits'
       ];
     }
 
@@ -226,6 +227,24 @@ service cloud.firestore {
 
     function hasOnlyCaptureSubmissionClientCreateKeys(data) {
       return data.keys().hasOnly(captureSubmissionClientCreateKeys());
+    }
+
+    function captureSubmissionIsClientUploaded(data) {
+      return ('operational_state' in data)
+        && data.operational_state is map
+        && ('upload_state' in data.operational_state)
+        && data.operational_state.upload_state == 'uploaded';
+    }
+
+    // Client upload transitions are monotonic: once the client has reported
+    // the raw upload as fully uploaded, the record belongs to the backend.
+    // The only client write still permitted is an idempotent re-assertion of
+    // the uploaded/submitted terminal state (a replayed completion write) —
+    // never a regression to uploading/failed or to a failure status.
+    function captureSubmissionUploadTransitionIsMonotonic(existing, incoming) {
+      return !captureSubmissionIsClientUploaded(existing)
+        || (captureSubmissionIsClientUploaded(incoming)
+          && incoming.status == 'submitted');
     }
 
     function hasValidClientCaptureSubmissionPayload(data) {
@@ -364,6 +383,7 @@ service cloud.firestore {
         && request.resource.data.creator_id == resource.data.creator_id
         && captureSubmissionExistingStatusAllowsClientUpdate(resource.data)
         && hasValidClientCaptureSubmissionPayload(request.resource.data)
+        && captureSubmissionUploadTransitionIsMonotonic(resource.data, request.resource.data)
         && request.resource.data.diff(resource.data).affectedKeys()
           .hasOnly(captureSubmissionClientUpdateKeys());
       allow delete: if false; // backend only

--- a/firestore.rules
+++ b/firestore.rules
@@ -238,13 +238,17 @@ service cloud.firestore {
 
     // Client upload transitions are monotonic: once the client has reported
     // the raw upload as fully uploaded, the record belongs to the backend.
-    // The only client write still permitted is an idempotent re-assertion of
-    // the uploaded/submitted terminal state (a replayed completion write) —
-    // never a regression to uploading/failed or to a failure status.
+    // The only client write still permitted is a replayed completion write
+    // (the client never received the ack and re-sends the same terminal
+    // payload, possibly with refreshed registration timestamps) — never a
+    // regression to uploading/failed or a failure status, and never a
+    // rewrite of operational_state or upload_error after handoff.
     function captureSubmissionUploadTransitionIsMonotonic(existing, incoming) {
       return !captureSubmissionIsClientUploaded(existing)
         || (captureSubmissionIsClientUploaded(incoming)
-          && incoming.status == 'submitted');
+          && incoming.status == 'submitted'
+          && incoming.diff(existing).affectedKeys()
+            .hasOnly(['created_at', 'submitted_at', 'lifecycle']));
     }
 
     function hasValidClientCaptureSubmissionPayload(data) {


### PR DESCRIPTION
## Summary

Keeps `firestore.rules` byte-identical with BlueprintCapture (parity guard XR-01) after the capture-side public-beta closure pass (ognjhunt/BlueprintCapture#53):

- **Monotonic client upload transitions** on `capture_submissions`: once a client reports `operational_state.upload_state == "uploaded"`, the only client write still permitted is an idempotent re-assertion of the uploaded/submitted terminal state (a replayed completion write) — never a regression to `uploading`/`failed` or a failure status. Retry-after-failure stays allowed.
- **`blocked_local_capture_limits`** added to the client QA states so the iOS over-limit failure write is rules-compatible.
- **`firestore.indexes.json`** becomes the union of both repos' required composite indexes (`agentRuns` + `capture_submissions` `creator_id ASC / submitted_at DESC`, needed by the Android capture-history query) — an indexes deploy replaces the full set, so each repo's manifest must carry both.

`scripts/check-firestore-rules-parity.sh` passes against the BlueprintCapture head (`7942054`).

## Deploy coordination

Land together with ognjhunt/BlueprintCapture#53. Whichever repo deploys `firestore:rules`/`firestore:indexes` last must contain these contents; the emulator contract suite covering the new behavior lives in `BlueprintCapture/cloud/firestore-rules-tests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmBm3iJ5vhtEmSmsFsH4hx

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmBm3iJ5vhtEmSmsFsH4hx)_