### PR TITLE
Self-serve pay-and-start flow for site policy evaluation runs

### DIFF
--- a/client/src/components/site/RobotEvalJobRequestButton.tsx
+++ b/client/src/components/site/RobotEvalJobRequestButton.tsx
@@ -1,20 +1,33 @@
-import { useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   AlertTriangle,
   CheckCircle2,
   ChevronDown,
   Clock3,
+  CreditCard,
   FileText,
+  Loader2,
+  LogIn,
   PlayCircle,
   Radio,
   ShieldCheck,
 } from "lucide-react";
+import { useLocation } from "wouter";
+import { useAuth } from "@/contexts/AuthContext";
+import { premiumCapabilities } from "@/data/content";
 import type { SiteLibrarySite } from "@/data/siteLibrary";
 import {
   buildRobotEvalJobRequestFromSite,
   defaultSimulatorEvalTasksForSite,
   type RobotEvalSimulatorTaskSelection,
 } from "@/lib/robotEvalJobRequest";
+
+const ROBOT_EVAL_RUN_PRICE_USD =
+  premiumCapabilities.find((capability) => capability.slug === "policy-benchmarking")
+    ?.price ?? null;
+
+const PROVISION_POLL_INTERVAL_MS = 3000;
+const PROVISION_POLL_MAX_ATTEMPTS = 20;
 
 type StatusState =
   | { kind: "idle" }
@@ -140,6 +153,18 @@ export function RobotEvalJobRequestPanel({
     taskOptions[0]?.taskId || "walk_to_target",
   ]);
 
+  const { currentUser, loading: authLoading } = useAuth();
+  const [, setLocation] = useLocation();
+  // null = still checking access for the signed-in buyer.
+  const [entitled, setEntitled] = useState<boolean | null>(null);
+  const [provisioning, setProvisioning] = useState(false);
+  const [provisioningTimedOut, setProvisioningTimedOut] = useState(false);
+  const [payState, setPayState] = useState<
+    { kind: "idle" } | { kind: "starting" } | { kind: "error"; message: string }
+  >({ kind: "idle" });
+  const autoStartedRef = useRef(false);
+  const cameFromCheckoutRef = useRef(false);
+
   const selectedTasks = taskOptions.filter((task) => selectedTaskIds.includes(task.taskId));
   const hasTasks = selectedTasks.length > 0;
   const disabled =
@@ -147,6 +172,167 @@ export function RobotEvalJobRequestPanel({
     !hasTasks ||
     !site.robotEvalPublication?.readyToEvaluatePublishable ||
     !site.defaultRobotEvalSelection;
+
+  const fetchEntitled = useCallback(async () => {
+    if (!currentUser) {
+      return false;
+    }
+    try {
+      const { withFirebaseAuthHeaders } = await import("@/lib/firebaseAuthHeaders");
+      const headers = await withFirebaseAuthHeaders(currentUser);
+      const response = await fetch(
+        `/api/marketplace/entitlements/current?sku=${encodeURIComponent(site.slug)}`,
+        { headers },
+      );
+      if (!response.ok) {
+        return false;
+      }
+      const data = (await response.json().catch(() => ({}))) as {
+        entitlements?: Array<Record<string, unknown>>;
+      };
+      const entitlements = Array.isArray(data.entitlements) ? data.entitlements : [];
+      return entitlements.some(
+        (entitlement) => entitlement && entitlement.access_state === "provisioned",
+      );
+    } catch {
+      return false;
+    }
+  }, [currentUser, site.slug]);
+
+  useEffect(() => {
+    if (authLoading) {
+      return;
+    }
+    if (!currentUser) {
+      setEntitled(null);
+      return;
+    }
+    let cancelled = false;
+    setEntitled(null);
+    void fetchEntitled().then((value) => {
+      if (!cancelled) {
+        setEntitled(value);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [authLoading, currentUser, fetchEntitled]);
+
+  // Returning from Stripe Checkout: strip the marker param, then poll until the
+  // payment webhook provisions the entitlement.
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    const url = new URL(window.location.href);
+    const marker = url.searchParams.get("robotEvalCheckout");
+    if (!marker) {
+      return;
+    }
+    url.searchParams.delete("robotEvalCheckout");
+    window.history.replaceState({}, "", `${url.pathname}${url.search}${url.hash}`);
+    if (marker === "success") {
+      cameFromCheckoutRef.current = true;
+      setProvisioning(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!provisioning || authLoading || !currentUser || entitled === true) {
+      return;
+    }
+    let cancelled = false;
+    let attempts = 0;
+    const poll = async () => {
+      attempts += 1;
+      const value = await fetchEntitled();
+      if (cancelled) {
+        return;
+      }
+      if (value) {
+        setEntitled(true);
+        setProvisioning(false);
+        return;
+      }
+      if (attempts >= PROVISION_POLL_MAX_ATTEMPTS) {
+        setProvisioning(false);
+        setProvisioningTimedOut(true);
+        return;
+      }
+      timer = window.setTimeout(poll, PROVISION_POLL_INTERVAL_MS);
+    };
+    let timer = window.setTimeout(poll, PROVISION_POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
+  }, [provisioning, authLoading, currentUser, entitled, fetchEntitled]);
+
+  function goToSignIn() {
+    try {
+      sessionStorage.setItem("redirectAfterAuth", `/sites/${site.slug}#policy-run-request`);
+    } catch {
+      // Ignore storage failures; sign-in still works, just without the return hop.
+    }
+    setLocation("/sign-in");
+  }
+
+  async function startCheckout() {
+    if (!currentUser) {
+      goToSignIn();
+      return;
+    }
+    setPayState({ kind: "starting" });
+    try {
+      const { withCsrfHeader } = await import("@/lib/csrf");
+      const { withFirebaseAuthHeaders } = await import("@/lib/firebaseAuthHeaders");
+      const headers = await withFirebaseAuthHeaders(
+        currentUser,
+        await withCsrfHeader({ "Content-Type": "application/json" }),
+      );
+      const response = await fetch("/api/create-checkout-session", {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          sessionType: "robot-eval-run",
+          robotEvalRun: { siteSlug: site.slug },
+          successPath: `/sites/${site.slug}?robotEvalCheckout=success`,
+          cancelPath: `/sites/${site.slug}?robotEvalCheckout=cancelled`,
+        }),
+      });
+      const data = (await response.json().catch(() => ({}))) as {
+        sessionUrl?: string;
+        error?: string;
+      };
+      if (!response.ok || !data.sessionUrl) {
+        throw new Error(data.error || "Could not start checkout. Please try again.");
+      }
+      window.location.href = data.sessionUrl;
+    } catch (error) {
+      setPayState({
+        kind: "error",
+        message:
+          error instanceof Error ? error.message : "Could not start checkout. Please try again.",
+      });
+    }
+  }
+
+  // The buyer already clicked "Pay & start evaluation" before checkout, so once
+  // payment provisions access, submit the run they asked for exactly once.
+  useEffect(() => {
+    if (
+      entitled === true &&
+      cameFromCheckoutRef.current &&
+      !autoStartedRef.current &&
+      hasTasks &&
+      status.kind === "idle"
+    ) {
+      autoStartedRef.current = true;
+      void submitJobRequest();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [entitled, hasTasks, status.kind]);
 
   function toggleTask(task: RobotEvalSimulatorTaskSelection) {
     setSelectedTaskIds((current) => {
@@ -321,15 +507,96 @@ export function RobotEvalJobRequestPanel({
               </div>
             </fieldset>
 
-            <button
-              type="button"
-              disabled={disabled}
-              onClick={submitJobRequest}
-              className="inline-flex min-h-12 items-center justify-center bg-slate-950 px-4 text-sm font-semibold text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-55"
-            >
-              <PlayCircle className="mr-2 h-4 w-4" />
-              {status.kind === "submitting" ? "Submitting request" : "Request policy run"}
-            </button>
+            {authLoading || (currentUser && entitled === null && !provisioning) ? (
+              <button
+                type="button"
+                disabled
+                className="inline-flex min-h-12 cursor-wait items-center justify-center bg-slate-950 px-4 text-sm font-semibold text-white opacity-55"
+              >
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                {authLoading ? "Checking your account" : "Checking evaluation access"}
+              </button>
+            ) : !currentUser ? (
+              <div className="grid gap-2">
+                <button
+                  type="button"
+                  onClick={goToSignIn}
+                  className="inline-flex min-h-12 items-center justify-center bg-slate-950 px-4 text-sm font-semibold text-white transition hover:bg-slate-800"
+                >
+                  <LogIn className="mr-2 h-4 w-4" />
+                  Sign in to start an evaluation
+                </button>
+                <p className="text-xs leading-5 text-slate-600">
+                  Evaluation runs require a signed-in Blueprint account. You&apos;ll come
+                  back to this page after signing in.
+                </p>
+              </div>
+            ) : provisioning ? (
+              <div className="flex items-start gap-2 border border-emerald-200 bg-emerald-50 p-3 text-xs font-semibold leading-5 text-emerald-900">
+                <Loader2 className="mt-0.5 h-4 w-4 shrink-0 animate-spin" />
+                Payment received. Provisioning your evaluation access — your run will
+                start automatically in a moment.
+              </div>
+            ) : provisioningTimedOut && entitled !== true ? (
+              <div className="grid gap-2">
+                <p className="flex items-start gap-2 border border-amber-200 bg-amber-50 p-3 text-xs font-semibold leading-5 text-amber-950">
+                  <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                  Payment received, but access is still being provisioned. Refresh this
+                  page in a minute, or contact team@tryblueprint.io if it doesn&apos;t
+                  clear.
+                </p>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setProvisioningTimedOut(false);
+                    setProvisioning(true);
+                  }}
+                  className="inline-flex min-h-11 items-center justify-center border border-slate-950 px-4 text-sm font-semibold text-slate-950 transition hover:bg-slate-100"
+                >
+                  Check again
+                </button>
+              </div>
+            ) : entitled ? (
+              <button
+                type="button"
+                disabled={disabled}
+                onClick={submitJobRequest}
+                className="inline-flex min-h-12 items-center justify-center bg-slate-950 px-4 text-sm font-semibold text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-55"
+              >
+                <PlayCircle className="mr-2 h-4 w-4" />
+                {status.kind === "submitting" ? "Submitting request" : "Start evaluation run"}
+              </button>
+            ) : (
+              <div className="grid gap-2">
+                <button
+                  type="button"
+                  disabled={payState.kind === "starting" || !hasTasks}
+                  onClick={startCheckout}
+                  className="inline-flex min-h-12 items-center justify-center bg-slate-950 px-4 text-sm font-semibold text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-55"
+                >
+                  {payState.kind === "starting" ? (
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  ) : (
+                    <CreditCard className="mr-2 h-4 w-4" />
+                  )}
+                  {payState.kind === "starting"
+                    ? "Opening secure checkout"
+                    : ROBOT_EVAL_RUN_PRICE_USD
+                      ? `Pay & start evaluation — $${ROBOT_EVAL_RUN_PRICE_USD}`
+                      : "Pay & start evaluation"}
+                </button>
+                <p className="text-xs leading-5 text-slate-600">
+                  Secure Stripe Checkout. After payment your evaluation request is queued
+                  and forwarded to Pipeline automatically.
+                </p>
+                {payState.kind === "error" ? (
+                  <p className="flex items-start gap-2 border border-red-200 bg-red-50 p-3 text-xs font-semibold leading-5 text-red-700">
+                    <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                    {payState.message}
+                  </p>
+                ) : null}
+              </div>
+            )}
 
             {status.kind === "error" ? (
               <p className="flex items-start gap-2 border border-red-200 bg-red-50 p-3 text-xs font-semibold leading-5 text-red-700">

--- a/client/src/components/site/RobotEvalJobRequestButton.tsx
+++ b/client/src/components/site/RobotEvalJobRequestButton.tsx
@@ -180,10 +180,11 @@ export function RobotEvalJobRequestPanel({
     try {
       const { withFirebaseAuthHeaders } = await import("@/lib/firebaseAuthHeaders");
       const headers = await withFirebaseAuthHeaders(currentUser);
-      const response = await fetch(
-        `/api/marketplace/entitlements/current?sku=${encodeURIComponent(site.slug)}`,
-        { headers },
-      );
+      // Fetch all of the buyer's entitlements and match locally with the same
+      // rules the job-request route applies (slug/lineage tokens, "<token>-"
+      // sku prefixes, and the site-world-package-/hosted-session- aliases), so
+      // buyers the server would already allow are not shown checkout again.
+      const response = await fetch("/api/marketplace/entitlements/current", { headers });
       if (!response.ok) {
         return false;
       }
@@ -191,13 +192,54 @@ export function RobotEvalJobRequestPanel({
         entitlements?: Array<Record<string, unknown>>;
       };
       const entitlements = Array.isArray(data.entitlements) ? data.entitlements : [];
-      return entitlements.some(
-        (entitlement) => entitlement && entitlement.access_state === "provisioned",
-      );
+      const siteTokens = [
+        site.slug,
+        site.captureLineage?.siteSubmissionId,
+        site.captureLineage?.captureJobId,
+        site.captureLineage?.captureId,
+      ]
+        .map((token) => (token || "").trim().toLowerCase())
+        .filter(Boolean);
+      const matchFields = [
+        "sku",
+        "site_slug",
+        "siteSlug",
+        "site_id",
+        "siteId",
+        "site_submission_id",
+        "siteSubmissionId",
+        "capture_job_id",
+        "captureJobId",
+        "capture_id",
+        "captureId",
+        "listing_id",
+        "listingId",
+        "site_world_id",
+        "siteWorldId",
+      ];
+      return entitlements.some((entitlement) => {
+        if (!entitlement || entitlement.access_state !== "provisioned") {
+          return false;
+        }
+        return matchFields.some((field) => {
+          const value = entitlement[field];
+          const token = typeof value === "string" ? value.trim().toLowerCase() : "";
+          if (!token) {
+            return false;
+          }
+          return siteTokens.some(
+            (siteToken) =>
+              token === siteToken ||
+              token.startsWith(`${siteToken}-`) ||
+              token === `site-world-package-${siteToken}` ||
+              token === `hosted-session-${siteToken}`,
+          );
+        });
+      });
     } catch {
       return false;
     }
-  }, [currentUser, site.slug]);
+  }, [currentUser, site.slug, site.captureLineage]);
 
   useEffect(() => {
     if (authLoading) {
@@ -586,8 +628,8 @@ export function RobotEvalJobRequestPanel({
                       : "Pay & start evaluation"}
                 </button>
                 <p className="text-xs leading-5 text-slate-600">
-                  Secure Stripe Checkout. After payment your evaluation request is queued
-                  and forwarded to Pipeline automatically.
+                  Secure Stripe Checkout. Each payment covers one evaluation run — after
+                  payment your request is queued and forwarded to Pipeline automatically.
                 </p>
                 {payState.kind === "error" ? (
                   <p className="flex items-start gap-2 border border-red-200 bg-red-50 p-3 text-xs font-semibold leading-5 text-red-700">

--- a/client/tests/pages/Sites.test.tsx
+++ b/client/tests/pages/Sites.test.tsx
@@ -18,6 +18,34 @@ vi.mock("@/lib/firebaseAuthHeaders", () => ({
   })),
 }));
 
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => ({ currentUser: firebaseTestUser, loading: false }),
+}));
+
+// The eval panel checks the signed-in buyer's entitlements before offering a
+// run; answer that call with a provisioned site entitlement and route the
+// job-request POST to the provided handler.
+function mockPanelFetch(
+  jobRequestResponse: () => Promise<Response> | Response = () =>
+    ({ ok: true, json: async () => ({}) }) as Response,
+) {
+  return vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const url = String(input);
+    if (url.startsWith("/api/marketplace/entitlements/current")) {
+      return {
+        ok: true,
+        json: async () => ({
+          entitlements: [
+            { access_state: "provisioned", sku: "sw-chi-01-robot-eval-run" },
+            { access_state: "provisioned", sku: "hosted-session-triangle-robotics-lab" },
+          ],
+        }),
+      } as Response;
+    }
+    return jobRequestResponse();
+  });
+}
+
 afterEach(() => {
   vi.restoreAllMocks();
   firebaseTestUser.getIdToken.mockClear();
@@ -58,25 +86,33 @@ describe("Sites", () => {
   });
 
   it("posts a Unitree G1 MuJoCo simulator request from the one-page site flow", async () => {
-    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        status: "queued_for_pipeline",
-        pipelineForward: {
-          status: "forwarded",
-          accepted: true,
-          performed: true,
-          pipeline_status: "staged_for_control_plane",
-        },
-      }),
-    } as Response);
+    const fetchMock = mockPanelFetch(() =>
+      ({
+        ok: true,
+        json: async () => ({
+          status: "queued_for_pipeline",
+          pipelineForward: {
+            status: "forwarded",
+            accepted: true,
+            performed: true,
+            pipeline_status: "staged_for_control_plane",
+          },
+        }),
+      }) as Response,
+    );
 
     render(<SiteDetail params={{ slug: "sw-chi-01" }} />);
 
     expect(screen.getAllByText(/Request policy run/i).length).toBeGreaterThan(0);
     expect(screen.getByLabelText(/Navigate to a spot/i)).toBeChecked();
     expect(screen.getByText(/Blueprint chooses the evaluation worker/i)).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: /^Request policy run$/i }));
+    fireEvent.click(
+      await screen.findByRole(
+        "button",
+        { name: /^Start evaluation run$/i },
+        { timeout: 5000 },
+      ),
+    );
 
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(
@@ -93,7 +129,9 @@ describe("Sites", () => {
       // the same fix applied in SiteWorldDetail.test.tsx.
     }, { timeout: 5000 });
 
-    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    const init = fetchMock.mock.calls.find(
+      (call) => String(call[0]) === "/api/robot-eval/job-requests",
+    )?.[1] as RequestInit;
     const body = JSON.parse(String(init.body || "{}"));
     expect(body.schema_version).toBe("robot_eval_job_request.v1");
     expect(body.buyer_request_id).toBe(
@@ -238,6 +276,7 @@ describe("Sites", () => {
   });
 
   it("keeps simulator-only copy from implying generated-world rank fidelity", () => {
+    mockPanelFetch();
     const { container } = render(<SiteDetail params={{ slug: "sw-chi-01" }} />);
 
     expect(screen.getByText(/Scope: virtual evaluation/i)).toBeInTheDocument();
@@ -267,7 +306,8 @@ describe("Sites", () => {
     expect(screen.getByText(/No matching sites yet\./i)).toBeInTheDocument();
   });
 
-  it("renders a compact site detail page for a legacy slug alias", () => {
+  it("renders a compact site detail page for a legacy slug alias", async () => {
+    mockPanelFetch();
     render(<SiteDetail params={{ slug: "siteworld-f5fd54898cfb" }} />);
 
     expect(
@@ -276,7 +316,11 @@ describe("Sites", () => {
     expect(screen.getByText(/Lab · Southeast/i)).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: /Task pack/i })).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: /^Request policy run$/i }),
+      await screen.findByRole(
+        "button",
+        { name: /^Start evaluation run$/i },
+        { timeout: 5000 },
+      ),
     ).toBeInTheDocument();
     expect(screen.getByText(/Generated clips help review/i)).toBeInTheDocument();
   });

--- a/server/routes/api/create-checkout-session.ts
+++ b/server/routes/api/create-checkout-session.ts
@@ -12,6 +12,7 @@ import {
   type ExclusivityType,
   type LicenseTier,
 } from "../../../client/src/data/content";
+import { getSiteLibrarySite } from "../../../client/src/data/siteLibrary";
 import { findPublishedMarketplaceInventoryBySku } from "../../utils/marketplaceInventory";
 import {
   attachStripeCheckoutSessionToBuyerOrder,
@@ -21,7 +22,11 @@ import {
 import { stripeAvailable } from "../../constants/stripe";
 import { logger } from "../../logger";
 
-type PaymentSessionType = "onboarding" | "legacy-hourly" | "marketplace";
+type PaymentSessionType =
+  | "onboarding"
+  | "legacy-hourly"
+  | "marketplace"
+  | "robot-eval-run";
 
 type CheckoutRequestBody = {
   sessionType?: PaymentSessionType;
@@ -70,7 +75,17 @@ type CheckoutRequestBody = {
     addons?: string[];
     dataTier?: "basic" | "standard" | "premium";
   };
+  robotEvalRun?: {
+    siteSlug?: string;
+  };
 };
+
+export const ROBOT_EVAL_RUN_SKU_SUFFIX = "-robot-eval-run";
+export const ROBOT_EVAL_RUN_PRICE_CATALOG_SLUG = "policy-benchmarking";
+
+export function robotEvalRunSkuForSiteSlug(siteSlug: string) {
+  return `${siteSlug}${ROBOT_EVAL_RUN_SKU_SUFFIX}`;
+}
 
 const VALID_LICENSE_TIERS: ReadonlySet<LicenseTier> = new Set<LicenseTier>([
   "research",
@@ -501,6 +516,156 @@ export default async function handler(req: Request, res: Response) {
         checkoutSessionId: session.id,
         checkoutSessionUrl:
           typeof session.url === "string" ? session.url : null,
+        livemode: session.livemode,
+      });
+
+      return res.json({ sessionId: session.id, sessionUrl: session.url });
+    }
+
+    if (sessionType === "robot-eval-run") {
+      const firebaseUser = (res.locals.firebaseUser || {}) as {
+        uid?: string;
+        email?: string;
+      };
+      const buyerUserId =
+        typeof firebaseUser.uid === "string" ? firebaseUser.uid.trim() : "";
+      const buyerEmail =
+        typeof firebaseUser.email === "string" ? firebaseUser.email.trim() : "";
+      if (!buyerUserId) {
+        return res.status(401).json({
+          error: "Sign in to purchase a policy evaluation run.",
+        });
+      }
+
+      const siteSlug = String(body.robotEvalRun?.siteSlug || "").trim();
+      if (!siteSlug) {
+        return res.status(400).json({
+          error: "A site slug is required for a policy evaluation run.",
+        });
+      }
+
+      const site = getSiteLibrarySite(siteSlug);
+      if (!site) {
+        return res.status(404).json({ error: "Unknown site for policy evaluation run." });
+      }
+      if (
+        !site.robotEvalPublication?.readyToEvaluatePublishable ||
+        !site.defaultRobotEvalSelection
+      ) {
+        return res.status(409).json({
+          error:
+            "This site does not have a publication-ready evaluation package yet, so a run cannot be purchased.",
+        });
+      }
+
+      const evalService = premiumCapabilities.find(
+        (capability) => capability.slug === ROBOT_EVAL_RUN_PRICE_CATALOG_SLUG,
+      );
+      if (!evalService || !Number.isFinite(evalService.price) || evalService.price <= 0) {
+        return res.status(503).json({
+          error: "Policy evaluation run pricing is not configured.",
+        });
+      }
+      const priceUsd = roundToCurrency(evalService.price);
+
+      const sku = robotEvalRunSkuForSiteSlug(site.slug);
+      const successUrl = resolveUrl(
+        originBase,
+        body.successPath,
+        `/sites/${site.slug}?robotEvalCheckout=success`,
+      );
+      const cancelUrl = resolveUrl(
+        originBase,
+        body.cancelPath,
+        `/sites/${site.slug}?robotEvalCheckout=cancelled`,
+      );
+
+      const order = await createBuyerOrderDraft({
+        buyerUserId,
+        buyerEmail: buyerEmail || null,
+        sku,
+        title: `${site.name} — Policy Evaluation Run`,
+        description: evalService.description,
+        itemType: "robot_eval_run",
+        quantity: 1,
+        licenseTier: "commercial",
+        exclusivity: "non-exclusive",
+        addons: [],
+        inventorySource: "site-library",
+        liveInventoryRecordId: null,
+        // hosted_runtime is a provisionable delivery mode with no hourly
+        // expiry, so the paid webhook grants the marketplaceEntitlements doc
+        // that /api/robot-eval/job-requests requires — no manual review step.
+        deliveryMode: "hosted_runtime",
+        inventoryFulfillmentStatus: "auto_ready",
+        rightsStatus: null,
+        unitAmountCents: Math.round(priceUsd * 100),
+        totalAmountCents: Math.round(priceUsd * 100),
+        currency: "usd",
+        successUrl,
+        cancelUrl,
+      });
+      if (!order) {
+        return res.status(500).json({ error: "Order ledger is not available" });
+      }
+
+      let session: Stripe.Checkout.Session;
+      try {
+        session = await stripe.checkout.sessions.create({
+          client_reference_id: order.id,
+          mode: "payment",
+          payment_method_types: ["card"],
+          line_items: [
+            {
+              price_data: {
+                currency: "usd",
+                product_data: {
+                  name: `${site.name} — Policy Evaluation Run`,
+                  description:
+                    "Virtual policy-evaluation run on this captured site package. Blueprint queues the request and forwards it to Pipeline for scheduling.",
+                  metadata: {
+                    orderId: order.id,
+                    sku,
+                    itemType: "robot_eval_run",
+                    robotEvalSiteSlug: site.slug,
+                  },
+                },
+                unit_amount: Math.round(priceUsd * 100),
+              },
+              quantity: 1,
+            },
+          ],
+          metadata: {
+            order_id: order.id,
+            sessionKind: "robot_eval_run",
+            marketplaceSku: sku,
+            robotEvalSiteSlug: site.slug,
+            buyerUserId,
+          },
+          payment_intent_data: {
+            metadata: {
+              order_id: order.id,
+              marketplace_sku: sku,
+            },
+          },
+          success_url: successUrl,
+          cancel_url: cancelUrl,
+        });
+      } catch (error) {
+        await markBuyerOrderCheckoutFailure({
+          orderId: order.id,
+          reason:
+            error instanceof Error
+              ? error.message
+              : "Stripe failed to create the checkout session.",
+        });
+        throw error;
+      }
+
+      await attachStripeCheckoutSessionToBuyerOrder({
+        orderId: order.id,
+        checkoutSessionId: session.id,
+        checkoutSessionUrl: typeof session.url === "string" ? session.url : null,
         livemode: session.livemode,
       });
 

--- a/server/routes/api/create-checkout-session.ts
+++ b/server/routes/api/create-checkout-session.ts
@@ -19,6 +19,10 @@ import {
   createBuyerOrderDraft,
   markBuyerOrderCheckoutFailure,
 } from "../../utils/accounting";
+import {
+  betaDecisionForResponse,
+  evaluateBetaCohortGate,
+} from "../../utils/beta-cohort-policy";
 import { stripeAvailable } from "../../constants/stripe";
 import { logger } from "../../logger";
 
@@ -555,6 +559,22 @@ export default async function handler(req: Request, res: Response) {
         return res.status(409).json({
           error:
             "This site does not have a publication-ready evaluation package yet, so a run cannot be purchased.",
+        });
+      }
+
+      // The intake route applies the robot_eval_request beta-cohort gate before
+      // queueing anything; run the same gate here so a buyer is never charged
+      // for a run the intake route would immediately reject.
+      const betaCohortDecision = await evaluateBetaCohortGate({
+        gate: "robot_eval_request",
+        creatorId: buyerUserId,
+        source: "robot_eval_run_checkout",
+      });
+      if (betaCohortDecision && !betaCohortDecision.allowed) {
+        return res.status(betaCohortDecision.statusCode).json({
+          error: betaCohortDecision.message,
+          code: betaCohortDecision.reason,
+          beta_cohort_policy: betaDecisionForResponse(betaCohortDecision),
         });
       }
 

--- a/server/routes/robot-eval-job-requests.ts
+++ b/server/routes/robot-eval-job-requests.ts
@@ -574,6 +574,32 @@ router.post("/", verifyFirebaseToken, async (req, res) => {
     });
   }
 
+  // Paid self-serve entitlements (sku "<siteSlug>-robot-eval-run") cover exactly
+  // one accepted run. Consume them here — after acceptance, never on the 502
+  // forward-failure path above — so one $-per-run purchase cannot be replayed
+  // into unlimited runs. Back-office/site-package/hosted-session entitlements
+  // are untouched.
+  const verifiedEntitlement = entitlementCheck.entitlement;
+  const verifiedEntitlementId = stringValue(verifiedEntitlement.id);
+  const verifiedEntitlementSku = normalizedToken(verifiedEntitlement.sku);
+  const isFirestoreBackedEntitlement = !stringValue(verifiedEntitlement.proof_source);
+  if (
+    db &&
+    isFirestoreBackedEntitlement &&
+    verifiedEntitlementId &&
+    verifiedEntitlementSku.endsWith("-robot-eval-run")
+  ) {
+    await db.collection("marketplaceEntitlements").doc(verifiedEntitlementId).set(
+      {
+        access_state: "consumed",
+        consumed_at: queuedAt,
+        consumed_by_job_id: jobId,
+        updated_at: queuedAt,
+      },
+      { merge: true },
+    );
+  }
+
   return res.status(202).json({
     ok: true,
     status: "queued_for_pipeline",

--- a/server/tests/robot-eval-checkout-session.test.ts
+++ b/server/tests/robot-eval-checkout-session.test.ts
@@ -231,6 +231,25 @@ describe("robot-eval-run checkout session", () => {
     }
   });
 
+  it("does not create an order or Stripe session when the beta cohort gate is closed", async () => {
+    vi.stubEnv("BLUEPRINT_BETA_INVITE_CAP", "0");
+    const route = await startCheckoutRoute();
+    try {
+      const { response, payload } = await postCheckout(route, {
+        sessionType: "robot-eval-run",
+        robotEvalRun: { siteSlug: "sw-chi-01" },
+      });
+      expect(response.status).toBe(503);
+      expect(payload).toEqual(
+        expect.objectContaining({ code: "beta_intake_closed" }),
+      );
+      expect(firestoreState.collectionWrites).toEqual([]);
+      expect(stripeState.sessionCreates).toEqual([]);
+    } finally {
+      await stopServer(route.server);
+    }
+  });
+
   it("creates a catalog-priced order + checkout session whose paid webhook provisions an entitlement the job-request route accepts", async () => {
     const { siteLibrarySites } = await import("../../client/src/data/siteLibrary");
     const { premiumCapabilities } = await import("../../client/src/data/content");
@@ -433,6 +452,39 @@ describe("robot-eval-run checkout session", () => {
             pipeline_consumer: "BlueprintCapturePipeline",
           }),
         );
+
+        // A paid robot-eval-run entitlement covers exactly one accepted run:
+        // the accepted request consumes it, and a replay is rejected.
+        const consumedEntitlement =
+          firestoreState.collectionDocData.marketplaceEntitlements?.[
+            String(paidOrder?.entitlement_id)
+          ];
+        expect(consumedEntitlement).toEqual(
+          expect.objectContaining({
+            access_state: "consumed",
+            consumed_by_job_id: jobRequest.job_id,
+          }),
+        );
+
+        const replayResponse = await fetch(
+          `${jobRoute.baseUrl}/api/robot-eval/job-requests`,
+          {
+            method: "POST",
+            headers: {
+              "content-type": "application/json",
+              authorization: `Bearer ${BUYER_UID}`,
+            },
+            body: JSON.stringify(jobRequest),
+          },
+        );
+        const replayPayload = (await replayResponse.json()) as Record<string, unknown>;
+        expect(replayResponse.status).toBe(403);
+        expect(replayPayload).toEqual(
+          expect.objectContaining({
+            code: "robot_eval_provisioned_entitlement_not_found",
+          }),
+        );
+        expect(pipelineReceived).toHaveLength(1);
       } finally {
         await stopServer(jobRoute.server);
         await stopServer(pipelineStub.server);

--- a/server/tests/robot-eval-checkout-session.test.ts
+++ b/server/tests/robot-eval-checkout-session.test.ts
@@ -1,0 +1,445 @@
+// @vitest-environment node
+import express from "express";
+import fs from "node:fs/promises";
+import { createServer } from "node:http";
+import type { Server } from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const firestoreState = vi.hoisted(() => ({
+  collectionDocData: {} as Record<string, Record<string, Record<string, unknown>>>,
+  collectionWrites: [] as Array<{
+    collection: string;
+    id: string;
+    payload: Record<string, unknown>;
+    options?: Record<string, unknown>;
+  }>,
+}));
+
+const stripeState = vi.hoisted(() => ({
+  sessionCreates: [] as Array<Record<string, unknown>>,
+}));
+
+function buildQuery(
+  name: string,
+  filters: Array<{ field: string; value: unknown }> = [],
+): {
+  where: (field: string, op: string, value: unknown) => ReturnType<typeof buildQuery>;
+  limit: (_limit: number) => ReturnType<typeof buildQuery>;
+  get: () => Promise<{ docs: Array<{ id: string; data: () => Record<string, unknown> }> }>;
+} {
+  return {
+    where: (field: string, _op: string, value: unknown) =>
+      buildQuery(name, [...filters, { field, value }]),
+    limit: (_limit: number) => buildQuery(name, filters),
+    get: async () => ({
+      docs: Object.entries(firestoreState.collectionDocData[name] || {})
+        .filter(([, data]) =>
+          filters.every((filter) => data[filter.field] === filter.value),
+        )
+        .map(([id, data]) => ({
+          id,
+          data: () => data,
+        })),
+    }),
+  };
+}
+
+vi.mock("../../client/src/lib/firebaseAdmin", () => ({
+  default: {
+    firestore: {
+      FieldValue: {
+        serverTimestamp: () => ({ mocked: true }),
+      },
+    },
+  },
+  dbAdmin: {
+    collection: (name: string) => ({
+      doc: (id: string) => ({
+        get: async () => {
+          const data = firestoreState.collectionDocData[name]?.[id];
+          return {
+            exists: Boolean(data),
+            id,
+            data: () => data || {},
+          };
+        },
+        set: async (payload: Record<string, unknown>, options?: Record<string, unknown>) => {
+          firestoreState.collectionWrites.push({ collection: name, id, payload, options });
+          firestoreState.collectionDocData[name] = firestoreState.collectionDocData[name] || {};
+          firestoreState.collectionDocData[name][id] = options?.merge
+            ? {
+                ...(firestoreState.collectionDocData[name][id] || {}),
+                ...payload,
+              }
+            : { ...payload };
+        },
+      }),
+      where: (field: string, _op: string, value: unknown) =>
+        buildQuery(name, [{ field, value }]),
+    }),
+  },
+  authAdmin: {
+    verifyIdToken: async (token: string) => ({ uid: token, email: `${token}@example.com` }),
+  },
+}));
+
+vi.mock("stripe", () => ({
+  default: class StripeMock {
+    checkout = {
+      sessions: {
+        create: async (params: Record<string, unknown>) => {
+          stripeState.sessionCreates.push(params);
+          return {
+            id: "cs_test_robot_eval",
+            url: "https://checkout.stripe.com/pay/cs_test_robot_eval",
+            livemode: false,
+          };
+        },
+      },
+    };
+
+    constructor(_key: string, _options?: unknown) {}
+  },
+}));
+
+type StartedServer = {
+  baseUrl: string;
+  server: Server;
+};
+
+async function startExpressServer(app: express.Express): Promise<StartedServer> {
+  const server = createServer(app);
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("server failed to bind");
+  }
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    server,
+  };
+}
+
+async function stopServer(server: Server) {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+const BUYER_UID = "robot-team-buyer";
+const BUYER_EMAIL = "buyer@example.com";
+
+async function startCheckoutRoute() {
+  const { default: handler } = await import("../routes/api/create-checkout-session");
+  const app = express();
+  app.use(express.json({ limit: "1mb" }));
+  app.post(
+    "/api/create-checkout-session",
+    (req, res, next) => {
+      if (req.headers.authorization === `Bearer ${BUYER_UID}`) {
+        res.locals.firebaseUser = { uid: BUYER_UID, email: BUYER_EMAIL };
+      }
+      next();
+    },
+    handler,
+  );
+  return startExpressServer(app);
+}
+
+async function postCheckout(
+  route: StartedServer,
+  body: Record<string, unknown>,
+  authorized = true,
+) {
+  const response = await fetch(`${route.baseUrl}/api/create-checkout-session`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...(authorized ? { authorization: `Bearer ${BUYER_UID}` } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+  const payload = (await response.json().catch(() => ({}))) as Record<string, unknown>;
+  return { response, payload };
+}
+
+beforeEach(() => {
+  vi.stubEnv("STRIPE_SECRET_KEY", "sk_test_mock_robot_eval_key");
+  // The checkout module resolves success/cancel URLs against its allowed-origin
+  // fallback chain; pin a concrete origin so ambient test env values (e.g.
+  // BASE_URL="/") don't produce unparseable URLs.
+  vi.stubEnv("NEXT_PUBLIC_BASE_URL", "http://localhost:5173");
+  vi.stubEnv("BLUEPRINT_BETA_INVITE_CAP", "10");
+  vi.stubEnv("BLUEPRINT_BETA_COHORT_DAILY_LIMIT", "10");
+});
+
+afterEach(() => {
+  firestoreState.collectionDocData = {};
+  firestoreState.collectionWrites = [];
+  stripeState.sessionCreates = [];
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+  vi.resetModules();
+});
+
+describe("robot-eval-run checkout session", () => {
+  it("rejects unauthenticated buyers", async () => {
+    const route = await startCheckoutRoute();
+    try {
+      const { response } = await postCheckout(
+        route,
+        { sessionType: "robot-eval-run", robotEvalRun: { siteSlug: "sw-chi-01" } },
+        false,
+      );
+      expect(response.status).toBe(401);
+      expect(firestoreState.collectionWrites).toEqual([]);
+      expect(stripeState.sessionCreates).toEqual([]);
+    } finally {
+      await stopServer(route.server);
+    }
+  });
+
+  it("rejects unknown sites and sites without a publication-ready eval package", async () => {
+    const { siteLibrarySites } = await import("../../client/src/data/siteLibrary");
+    const unpublishedSite = siteLibrarySites.find(
+      (site) => !site.robotEvalPublication?.readyToEvaluatePublishable,
+    );
+    expect(unpublishedSite).toBeTruthy();
+
+    const route = await startCheckoutRoute();
+    try {
+      const unknown = await postCheckout(route, {
+        sessionType: "robot-eval-run",
+        robotEvalRun: { siteSlug: "no-such-site" },
+      });
+      expect(unknown.response.status).toBe(404);
+
+      const notReady = await postCheckout(route, {
+        sessionType: "robot-eval-run",
+        robotEvalRun: { siteSlug: unpublishedSite?.slug },
+      });
+      expect(notReady.response.status).toBe(409);
+
+      expect(firestoreState.collectionWrites).toEqual([]);
+      expect(stripeState.sessionCreates).toEqual([]);
+    } finally {
+      await stopServer(route.server);
+    }
+  });
+
+  it("creates a catalog-priced order + checkout session whose paid webhook provisions an entitlement the job-request route accepts", async () => {
+    const { siteLibrarySites } = await import("../../client/src/data/siteLibrary");
+    const { premiumCapabilities } = await import("../../client/src/data/content");
+    const site = siteLibrarySites.find(
+      (candidate) =>
+        candidate.robotEvalPublication?.readyToEvaluatePublishable &&
+        candidate.defaultRobotEvalSelection,
+    );
+    expect(site).toBeTruthy();
+    if (!site) {
+      return;
+    }
+    const catalogPrice = premiumCapabilities.find(
+      (capability) => capability.slug === "policy-benchmarking",
+    )?.price;
+    expect(typeof catalogPrice).toBe("number");
+
+    const route = await startCheckoutRoute();
+    try {
+      const { response, payload } = await postCheckout(route, {
+        sessionType: "robot-eval-run",
+        robotEvalRun: { siteSlug: site.slug },
+      });
+
+      expect(response.status).toBe(200);
+      expect(payload).toEqual(
+        expect.objectContaining({
+          sessionId: "cs_test_robot_eval",
+          sessionUrl: "https://checkout.stripe.com/pay/cs_test_robot_eval",
+        }),
+      );
+
+      const orderWrite = firestoreState.collectionWrites.find(
+        (write) => write.collection === "buyerOrders",
+      );
+      expect(orderWrite).toBeTruthy();
+      const order = orderWrite?.payload as Record<string, any>;
+      expect(order.buyer_user_id).toBe(BUYER_UID);
+      expect(order.item.sku).toBe(`${site.slug}-robot-eval-run`);
+      expect(order.item.item_type).toBe("robot_eval_run");
+      // hosted_runtime is a provisionable delivery mode, so payment provisions
+      // the entitlement without manual review and without hourly expiry.
+      expect(order.item.delivery_mode).toBe("hosted_runtime");
+      expect(order.pricing.unit_amount_cents).toBe(Math.round((catalogPrice as number) * 100));
+
+      const sessionParams = stripeState.sessionCreates[0] as Record<string, any>;
+      expect(sessionParams.mode).toBe("payment");
+      expect(sessionParams.client_reference_id).toBe(order.id);
+      expect(String(sessionParams.success_url)).toContain(
+        `/sites/${site.slug}?robotEvalCheckout=success`,
+      );
+      expect(sessionParams.metadata.sessionKind).toBe("robot_eval_run");
+
+      // Simulate the Stripe checkout.session.completed webhook.
+      const { markBuyerOrderPaidFromCheckout } = await import("../utils/accounting");
+      const paidOrder = await markBuyerOrderPaidFromCheckout({
+        orderId: order.id,
+        checkoutSessionId: "cs_test_robot_eval",
+        paymentIntentId: "pi_test_robot_eval",
+        customerId: "cus_test_robot_eval",
+        livemode: false,
+        eventId: "evt_test_robot_eval",
+        eventType: "checkout.session.completed",
+      });
+      expect(paidOrder?.entitlement_id).toBeTruthy();
+
+      const entitlement =
+        firestoreState.collectionDocData.marketplaceEntitlements?.[
+          String(paidOrder?.entitlement_id)
+        ];
+      expect(entitlement).toEqual(
+        expect.objectContaining({
+          buyer_user_id: BUYER_UID,
+          sku: `${site.slug}-robot-eval-run`,
+          access_state: "provisioned",
+          expires_at: null,
+        }),
+      );
+
+      // The provisioned entitlement must satisfy the job-request gate end to
+      // end, including the HMAC-signed forward to the Pipeline intake stub.
+      const inboxDir = await fs.mkdtemp(path.join(os.tmpdir(), "robot-eval-checkout-inbox-"));
+      const pipelineReceived: Array<Record<string, unknown>> = [];
+      const pipelineApp = express();
+      pipelineApp.use(express.json({ limit: "1mb" }));
+      pipelineApp.post("/api/live-pipeline/job-requests", (req, res) => {
+        pipelineReceived.push(req.body as Record<string, unknown>);
+        res.status(200).json({
+          accepted: true,
+          status: "staged_for_control_plane",
+          input_blockers: [],
+        });
+      });
+      const pipelineStub = await startExpressServer(pipelineApp);
+      vi.stubEnv("ROBOT_EVAL_JOB_REQUEST_INBOX_DIR", inboxDir);
+      vi.stubEnv(
+        "ROBOT_EVAL_JOB_REQUEST_FORWARD_URL",
+        `${pipelineStub.baseUrl}/api/live-pipeline/job-requests`,
+      );
+      vi.stubEnv("ROBOT_EVAL_JOB_REQUEST_FORWARD_TOKEN", "test-forward-token");
+      vi.stubEnv("ROBOT_EVAL_JOB_REQUEST_FORWARD_REQUIRED", "true");
+      const { buildRobotEvalJobRequest } = await import("../utils/robotEvalJobRequests");
+      const captureRoot = path.join(inboxDir, "captures", site.slug);
+      const lineage = site.captureLineage;
+      const jobRequest = buildRobotEvalJobRequest({
+        sitePackage: {
+          siteSlug: site.slug,
+          siteId: `site-${site.slug}`,
+          siteName: site.name,
+          siteSubmissionId: lineage?.siteSubmissionId || `site-submission-${site.slug}`,
+          captureJobId: lineage?.captureJobId || `capture-job-${site.slug}`,
+          captureId: lineage?.captureId || `capture-${site.slug}`,
+          captureRoot,
+          pipelinePrefix: `${captureRoot}/pipeline`,
+          accessState: "request_gated",
+          artifactUris: {
+            manifestUri: `${captureRoot}/pipeline/robot_eval_dataset/robot_eval_dataset_manifest.json`,
+            taskCardsUri: `${captureRoot}/pipeline/robot_eval_dataset/task_cards.json`,
+            scenarioCardsUri: `${captureRoot}/pipeline/robot_eval_dataset/scenario_cards.json`,
+            evalCardsUri: `${captureRoot}/pipeline/robot_eval_dataset/eval_cards.json`,
+            proofBoundariesUri: `${captureRoot}/pipeline/robot_eval_dataset/proof_boundaries.json`,
+            taskThresholdsUri: `${captureRoot}/pipeline/robot_eval_dataset/task_thresholds.json`,
+            publicationReadinessUri: `${captureRoot}/pipeline/robot_eval_dataset/publication_readiness.json`,
+            sceneAssetInventoryUri: `${captureRoot}/pipeline/simulation_automation/scene_asset_inventory.json`,
+            sceneAssetDependencyAuditUri: `${captureRoot}/pipeline/simulation_automation/scene_asset_dependency_audit.json`,
+            cpuPreflightScorecardUri: `${captureRoot}/pipeline/simulation_automation/cpu_preflight_scorecard.json`,
+            episodeSpecManifestUri: `${captureRoot}/pipeline/simulation_automation/episode_spec_manifest.json`,
+            cpuSimulatorPreflightManifestUri: `${captureRoot}/pipeline/simulation_automation/cpu_simulator_preflight_manifest.json`,
+            gpuHandoffPacketUri: `${captureRoot}/pipeline/simulation_automation/gpu_handoff_packet.json`,
+          },
+          publication: {
+            readyToEvaluatePublishable: true,
+            publicationLabel: "Ready to evaluate",
+          },
+        },
+        selection: {
+          taskId: site.defaultRobotEvalSelection?.taskId || "walk_to_target",
+          scenarioId: site.defaultRobotEvalSelection?.scenarioId || "scenario_default",
+          robotProfileId:
+            site.defaultRobotEvalSelection?.robotProfileId || "mobile_manipulator_rgb_v1",
+          policyId: site.defaultRobotEvalSelection?.policyId || "policy-api-fixture",
+        },
+        robotTeam: {
+          customerId: BUYER_UID,
+          companyName: "Robot Team Buyer",
+          contactEmail: BUYER_EMAIL,
+        },
+        entitlement: {
+          accessState: "request_gated",
+          approved: true,
+        },
+        policySubmission: {
+          policy_api_endpoint: {
+            endpoint_url: "https://robot-team.example/policy",
+            observation_schema_ref: "schemas/obs-v1.json",
+            action_schema_ref: "schemas/action-v1.json",
+          },
+        },
+        source: {
+          route: `/sites/${site.slug}`,
+          surface: "site-detail",
+        },
+      });
+
+      const { default: jobRequestsRouter } = await import(
+        "../routes/robot-eval-job-requests"
+      );
+      const jobApp = express();
+      jobApp.use(express.json({ limit: "1mb" }));
+      jobApp.use("/api/robot-eval/job-requests", jobRequestsRouter);
+      const jobRoute = await startExpressServer(jobApp);
+      try {
+        const jobResponse = await fetch(`${jobRoute.baseUrl}/api/robot-eval/job-requests`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            authorization: `Bearer ${BUYER_UID}`,
+          },
+          body: JSON.stringify(jobRequest),
+        });
+        const jobPayload = (await jobResponse.json()) as Record<string, any>;
+
+        expect(jobResponse.status).toBe(202);
+        expect(jobPayload).toEqual(
+          expect.objectContaining({ ok: true, status: "queued_for_pipeline" }),
+        );
+        expect(jobPayload.entitlementProof).toEqual(
+          expect.objectContaining({
+            entitlement_id: String(paidOrder?.entitlement_id),
+            access_state: "provisioned",
+          }),
+        );
+        expect(jobPayload.pipelineForward).toEqual(
+          expect.objectContaining({ status: "forwarded", performed: true, accepted: true }),
+        );
+        expect(pipelineReceived).toHaveLength(1);
+        expect(pipelineReceived[0]).toEqual(
+          expect.objectContaining({
+            queue_contract: "robot_eval_job_request_inbox.v1",
+            pipeline_consumer: "BlueprintCapturePipeline",
+          }),
+        );
+      } finally {
+        await stopServer(jobRoute.server);
+        await stopServer(pipelineStub.server);
+        await fs.rm(inboxDir, { recursive: true, force: true });
+      }
+    } finally {
+      await stopServer(route.server);
+    }
+  });
+});


### PR DESCRIPTION
## Problem

Choosing a site to evaluate did not reliably trigger BlueprintCapturePipeline. The webapp→pipeline wiring itself is real (`/api/robot-eval/job-requests` → HMAC-signed forward to the Pipeline intake), but the only UI that reaches it — `RobotEvalJobRequestPanel` on publication-ready sites — required a `marketplaceEntitlements` doc with `access_state: "provisioned"`, and there was **no self-serve way for a buyer to get one**. A signed-in buyer clicking "Request policy run" got a 403 (`robot_eval_provisioned_entitlement_not_found`), and the Pipeline forward never fired. There was also no payment step anywhere in the flow.

## Change

Simple sign-in → pay → run-starts flow, built entirely on the existing Firebase Auth + Stripe + buyer-order/entitlement machinery:

**Server** (`server/routes/api/create-checkout-session.ts`)
- New `sessionType: "robot-eval-run"` branch (mounted route already has CSRF + Firebase auth):
  - 401 without an authenticated buyer; 404 unknown site; 409 for sites without a publication-ready eval package (`robotEvalPublication.readyToEvaluatePublishable` + `defaultRobotEvalSelection`) — no fake supply.
  - Price comes from the existing `policy-benchmarking` catalog entry ($350) — server-authoritative, no client-authored amounts.
  - Creates a buyer order (sku `{siteSlug}-robot-eval-run`, `delivery_mode: "hosted_runtime"`) so the **existing** `checkout.session.completed` webhook auto-provisions the `marketplaceEntitlements` doc that the job-request gate requires — no manual review step, no hourly expiry, and no webhook changes needed.

**Client** (`client/src/components/site/RobotEvalJobRequestButton.tsx`)
- Signed out → "Sign in to start an evaluation" (uses the existing `redirectAfterAuth` hop back to the site page; email/password and Google both work).
- Signed in without access → "Pay & start evaluation — $350" → Stripe Checkout.
- Returning from checkout (`?robotEvalCheckout=success`) → polls `/api/marketplace/entitlements/current` until the webhook provisions access, then **submits the evaluation run automatically** (once), which queues it and forwards it to Pipeline. Timeout shows an honest "still provisioning" state with a retry.
- Signed in with a provisioned entitlement → "Start evaluation run" directly.
- Proof-boundary copy unchanged: the panel still claims only request construction/queueing/forwarding.

**Test** (`server/tests/robot-eval-checkout-session.test.ts`)
- Auth and site-readiness gating (401/404/409, no writes on rejection).
- Full chain: checkout session (catalog-priced order, provisionable delivery mode) → simulated paid webhook → provisioned entitlement → `POST /api/robot-eval/job-requests` accepted (202 `queued_for_pipeline`) and HMAC-forwarded to a stub Pipeline intake endpoint (`queue_contract: robot_eval_job_request_inbox.v1`, `pipeline_consumer: BlueprintCapturePipeline`).

No changes were needed in BlueprintCapturePipeline — its live intake (`/api/live-pipeline/job-requests`) already accepts the forward this flow produces.

## Verification

- `npx vitest run` on the new test plus all robot-eval and checkout suites: 41/41 passing.
- `npm run check` and `npm run build` pass.
- Graphify architecture pilot refreshed (`--no-viz`); canonical `graphify-out/` outputs unchanged.

Note for deploy: the run only reaches the pipeline in production when `ROBOT_EVAL_JOB_REQUEST_FORWARD_URL` / `ROBOT_EVAL_JOB_REQUEST_FORWARD_TOKEN` are configured on Render (fail-closed 502 otherwise, as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0191xPqjiXhX9rHeVpnUTjrj

---
_Generated by [Claude Code](https://claude.ai/code/session_0191xPqjiXhX9rHeVpnUTjrj)_