### PR TITLE
Improve SEO and GEO coverage on public buyer pages

### DIFF
--- a/client/public/robots.txt
+++ b/client/public/robots.txt
@@ -39,6 +39,46 @@ Allow: /capture-app/launch-access
 Disallow: /world-models/*/start
 Disallow: /world-models/*/workspace
 
+# Anthropic's search-index crawler. Same public-page policy as other search
+# crawlers so Claude can cite Blueprint's public buyer pages in answers.
+User-agent: Claude-SearchBot
+Allow: /
+Disallow: /admin/
+Disallow: /dashboard/
+Disallow: /onboarding/
+Disallow: /settings/
+Disallow: /requests/
+Disallow: /portal
+Disallow: /sign-in
+Disallow: /login
+Disallow: /forgot-password
+Disallow: /signup
+Disallow: /off-waitlist-signup
+Disallow: /capture-app
+Allow: /capture-app/launch-access
+Disallow: /world-models/*/start
+Disallow: /world-models/*/workspace
+
+# Perplexity's answer-engine crawler. Same public-page policy so Perplexity
+# can index and cite public buyer pages.
+User-agent: PerplexityBot
+Allow: /
+Disallow: /admin/
+Disallow: /dashboard/
+Disallow: /onboarding/
+Disallow: /settings/
+Disallow: /requests/
+Disallow: /portal
+Disallow: /sign-in
+Disallow: /login
+Disallow: /forgot-password
+Disallow: /signup
+Disallow: /off-waitlist-signup
+Disallow: /capture-app
+Allow: /capture-app/launch-access
+Disallow: /world-models/*/start
+Disallow: /world-models/*/workspace
+
 # User-triggered fetches are not the ChatGPT Search crawl signal, but public
 # pages should still be reachable when a user asks ChatGPT to inspect them.
 User-agent: ChatGPT-User
@@ -59,12 +99,54 @@ Allow: /capture-app/launch-access
 Disallow: /world-models/*/start
 Disallow: /world-models/*/workspace
 
+# User-triggered fetches when someone asks Claude or Perplexity to inspect a
+# page directly; same public-page policy as ChatGPT-User.
+User-agent: Claude-User
+Allow: /
+Disallow: /admin/
+Disallow: /dashboard/
+Disallow: /onboarding/
+Disallow: /settings/
+Disallow: /requests/
+Disallow: /portal
+Disallow: /sign-in
+Disallow: /login
+Disallow: /forgot-password
+Disallow: /signup
+Disallow: /off-waitlist-signup
+Disallow: /capture-app
+Allow: /capture-app/launch-access
+Disallow: /world-models/*/start
+Disallow: /world-models/*/workspace
+
+User-agent: Perplexity-User
+Allow: /
+Disallow: /admin/
+Disallow: /dashboard/
+Disallow: /onboarding/
+Disallow: /settings/
+Disallow: /requests/
+Disallow: /portal
+Disallow: /sign-in
+Disallow: /login
+Disallow: /forgot-password
+Disallow: /signup
+Disallow: /off-waitlist-signup
+Disallow: /capture-app
+Allow: /capture-app/launch-access
+Disallow: /world-models/*/start
+Disallow: /world-models/*/workspace
+
 # These controls are for AI training/grounding outside public search surfaces.
 # Keeping them disallowed preserves the search-vs-training distinction.
+# (ClaudeBot is Anthropic's training crawler, distinct from Claude-SearchBot.)
 User-agent: GPTBot
 Disallow: /
 
 User-agent: Google-Extended
+Disallow: /
+
+User-agent: ClaudeBot
 Disallow: /
 
 User-agent: *

--- a/client/src/pages/About.tsx
+++ b/client/src/pages/About.tsx
@@ -1,5 +1,7 @@
-import { Helmet } from "@/lib/helmet";
 import { ArrowRight } from "lucide-react";
+
+import { SEO } from "@/components/SEO";
+import { breadcrumbJsonLd, webPageJsonLd } from "@/lib/seoStructuredData";
 
 import { Button, Eyebrow } from "@/components/blueprint";
 import {
@@ -46,14 +48,23 @@ const principles = [
 export default function About() {
   return (
     <>
-      <Helmet>
-        <title>About | Blueprint</title>
-        <meta
-          name="description"
-          content="Why Blueprint exists: turning one real facility into capture-backed policy evaluation runs with rights, privacy, and provenance kept visible."
-        />
-        <link rel="canonical" href="https://tryblueprint.io/about" />
-      </Helmet>
+      <SEO
+        title="About | Blueprint"
+        description="Why Blueprint exists: turning one real facility into capture-backed policy evaluation runs with rights, privacy, and provenance kept visible."
+        canonical="/about"
+        jsonLd={[
+          webPageJsonLd({
+            path: "/about",
+            name: "About Blueprint",
+            description:
+              "Why Blueprint exists: turning one real facility into capture-backed policy evaluation runs with rights, privacy, and provenance kept visible.",
+          }),
+          breadcrumbJsonLd([
+            { name: "Home", path: "/" },
+            { name: "About", path: "/about" },
+          ]),
+        ]}
+      />
 
       <div className="bg-canvas text-ink">
         {/* Hero — prose, max-w-prose (44rem) */}

--- a/client/src/pages/Contact.tsx
+++ b/client/src/pages/Contact.tsx
@@ -1,5 +1,4 @@
 import { useMemo, useState, type FormEvent } from "react";
-import { Helmet } from "@/lib/helmet";
 import { useLocation, useSearch } from "wouter";
 import { ArrowRight, Bot, MapPin, Camera, Mail } from "lucide-react";
 
@@ -11,6 +10,8 @@ import {
   StatusChip,
 } from "@/components/blueprint";
 import { MonochromeMedia } from "@/components/site/editorial";
+import { SEO } from "@/components/SEO";
+import { breadcrumbJsonLd, webPageJsonLd } from "@/lib/seoStructuredData";
 import { parseContactRequestPrefill } from "@/lib/contactRequestPrefill";
 import { withCsrfHeader } from "@/lib/csrf";
 
@@ -136,23 +137,33 @@ export default function Contact() {
 
   return (
     <>
-      <Helmet>
-        <title>
-          {isSiteOperator ? "Submit a Site | Blueprint" : "Start a Policy Evaluation | Blueprint"}
-        </title>
-        <meta
-          name="description"
-          content={
-            isSiteOperator
-              ? "Submit a site for Blueprint robot policy evaluation review. You control rights and access."
-              : "Start a Blueprint policy evaluation request for captured real-site tasks."
-          }
-        />
-        <link
-          rel="canonical"
-          href={`https://tryblueprint.io${isSiteOperator ? "/contact/site-operator" : "/contact/robot-team"}`}
-        />
-      </Helmet>
+      <SEO
+        title={isSiteOperator ? "Submit a Site | Blueprint" : "Start a Policy Evaluation | Blueprint"}
+        description={
+          isSiteOperator
+            ? "Submit a site for Blueprint robot policy evaluation review. You control rights and access."
+            : "Start a Blueprint policy evaluation request for captured real-site tasks."
+        }
+        canonical={isSiteOperator ? "/contact/site-operator" : "/contact/robot-team"}
+        jsonLd={[
+          webPageJsonLd({
+            path: isSiteOperator ? "/contact/site-operator" : "/contact/robot-team",
+            name: isSiteOperator
+              ? "Submit a Site to Blueprint"
+              : "Start a Blueprint Policy Evaluation",
+            description: isSiteOperator
+              ? "Structured intake for site operators submitting a facility for capture-backed robot evaluation review."
+              : "Structured intake for robot-team Policy Evaluation Run, Validated Evaluation Pack, and Policy Improvement Run requests.",
+          }),
+          breadcrumbJsonLd([
+            { name: "Home", path: "/" },
+            {
+              name: isSiteOperator ? "Submit a Site" : "Start a Policy Evaluation",
+              path: isSiteOperator ? "/contact/site-operator" : "/contact/robot-team",
+            },
+          ]),
+        ]}
+      />
 
       <div className="bg-canvas text-ink">
         {/* Hero */}

--- a/client/src/pages/ForRobotTeams.tsx
+++ b/client/src/pages/ForRobotTeams.tsx
@@ -1,5 +1,7 @@
-import { Helmet } from "@/lib/helmet";
 import { ArrowRight, Check } from "lucide-react";
+
+import { SEO } from "@/components/SEO";
+import { breadcrumbJsonLd, webPageJsonLd } from "@/lib/seoStructuredData";
 
 import {
   Button,
@@ -133,14 +135,23 @@ function HeroRankCard() {
 export default function ForRobotTeams() {
   return (
     <>
-      <Helmet>
-        <title>For Robot Teams | Blueprint</title>
-        <meta
-          name="description"
-          content="Blueprint ranks robot policies on real captured indoor sites — with provenance, task thresholds, and readiness evidence — before you commit field time."
-        />
-        <link rel="canonical" href="/for-robot-teams" />
-      </Helmet>
+      <SEO
+        title="For Robot Teams | Blueprint"
+        description="Blueprint ranks robot policies on real captured indoor sites — with provenance, task thresholds, and readiness evidence — before you commit field time."
+        canonical="/for-robot-teams"
+        jsonLd={[
+          webPageJsonLd({
+            path: "/for-robot-teams",
+            name: "Blueprint for Robot Teams",
+            description:
+              "Policy evaluation for robot teams: submit a policy API endpoint, Docker container, model checkpoint, traces, or teleop demos and rank policies on captured real-site task packs before field time.",
+          }),
+          breadcrumbJsonLd([
+            { name: "Home", path: "/" },
+            { name: "For Robot Teams", path: "/for-robot-teams" },
+          ]),
+        ]}
+      />
 
       <div className="bg-canvas text-ink">
         {/* Hero */}

--- a/client/src/pages/ForSiteOperators.tsx
+++ b/client/src/pages/ForSiteOperators.tsx
@@ -1,5 +1,7 @@
-import { Helmet } from "@/lib/helmet";
 import { ArrowRight, Check } from "lucide-react";
+
+import { SEO } from "@/components/SEO";
+import { breadcrumbJsonLd, webPageJsonLd } from "@/lib/seoStructuredData";
 
 import {
   Button,
@@ -117,14 +119,23 @@ const payoutMetrics = [
 export default function ForSiteOperators() {
   return (
     <>
-      <Helmet>
-        <title>For Site Operators | Blueprint</title>
-        <meta
-          name="description"
-          content="Blueprint helps site operators control access, privacy, and commercialization around real-site robot evaluation — with rights and provenance kept visible."
-        />
-        <link rel="canonical" href="/for-site-operators" />
-      </Helmet>
+      <SEO
+        title="For Site Operators | Blueprint"
+        description="Blueprint helps site operators control access, privacy, and commercialization around real-site robot evaluation — with rights and provenance kept visible."
+        canonical="/for-site-operators"
+        jsonLd={[
+          webPageJsonLd({
+            path: "/for-site-operators",
+            name: "Blueprint for Site Operators",
+            description:
+              "How site operators control access, privacy, rights, and commercialization when a captured real site becomes a robot evaluation surface.",
+          }),
+          breadcrumbJsonLd([
+            { name: "Home", path: "/" },
+            { name: "For Site Operators", path: "/for-site-operators" },
+          ]),
+        ]}
+      />
 
       <div className="bg-canvas text-ink">
         {/* Hero */}

--- a/client/src/pages/Governance.tsx
+++ b/client/src/pages/Governance.tsx
@@ -1,5 +1,7 @@
-import { Helmet } from "@/lib/helmet";
 import { ShieldCheck } from "lucide-react";
+
+import { SEO } from "@/components/SEO";
+import { breadcrumbJsonLd, webPageJsonLd } from "@/lib/seoStructuredData";
 
 import {
   Card,
@@ -67,14 +69,23 @@ const guarantees = [
 export default function Governance() {
   return (
     <>
-      <Helmet>
-        <title>Governance | Blueprint</title>
-        <meta
-          name="description"
-          content="Blueprint's trust page: rights, privacy, and provenance kept visible across every listing, manifest, and hosted-access surface."
-        />
-        <link rel="canonical" href="https://tryblueprint.io/governance" />
-      </Helmet>
+      <SEO
+        title="Governance | Blueprint"
+        description="Blueprint's trust page: rights, privacy, and provenance kept visible across every listing, manifest, and hosted-access surface."
+        canonical="/governance"
+        jsonLd={[
+          webPageJsonLd({
+            path: "/governance",
+            name: "Blueprint Governance",
+            description:
+              "Rights, privacy, and provenance kept visible across every Blueprint listing, manifest, and hosted-access surface.",
+          }),
+          breadcrumbJsonLd([
+            { name: "Home", path: "/" },
+            { name: "Governance", path: "/governance" },
+          ]),
+        ]}
+      />
 
       <div className="bg-canvas text-ink">
         {/* Hero — dark #0d0d0b + evidence grid */}

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1,4 +1,9 @@
 import { SEO } from "@/components/SEO";
+import {
+  organizationJsonLd,
+  webPageJsonLd,
+  websiteJsonLd,
+} from "@/lib/seoStructuredData";
 import { Button, Eyebrow, PolicyRankBar, ProofBoundary } from "@/components/blueprint";
 import { TileGrid } from "@/components/site/TileGrid";
 import {
@@ -87,14 +92,16 @@ export default function Home() {
         description="Blueprint helps robot teams compare policies on captured real-site task packs, with provenance, rights, and proof boundaries attached. Rank policies before committing field time."
         canonical="/"
         image="https://tryblueprint.io/redesign/robot-hero.png"
-        jsonLd={{
-          "@context": "https://schema.org",
-          "@type": "WebPage",
-          name: "Blueprint Robot Policy Evaluation",
-          description:
-            "Capture-backed policy evaluation for comparing robot policies before field time.",
-          url: "https://tryblueprint.io/",
-        }}
+        jsonLd={[
+          organizationJsonLd(),
+          websiteJsonLd(),
+          webPageJsonLd({
+            path: "/",
+            name: "Blueprint Robot Policy Evaluation",
+            description:
+              "Capture-backed policy evaluation for comparing robot policies before field time.",
+          }),
+        ]}
       />
 
       <div className="bg-canvas text-ink-900">

--- a/client/src/pages/HowItWorks.tsx
+++ b/client/src/pages/HowItWorks.tsx
@@ -1,4 +1,5 @@
 import { SEO } from "@/components/SEO";
+import { breadcrumbJsonLd, webPageJsonLd } from "@/lib/seoStructuredData";
 import {
   Eyebrow,
   ProofBoundary,
@@ -214,6 +215,18 @@ export default function HowItWorks() {
         title="How It Works | Blueprint"
         description="Capture first, package the proof, evaluate policies, and decide the next test. See how Blueprint moves from a real indoor capture to a rank-fidelity comparison without overclaiming readiness."
         canonical="/how-it-works"
+        jsonLd={[
+          webPageJsonLd({
+            path: "/how-it-works",
+            name: "How Blueprint Works",
+            description:
+              "How Blueprint moves from a real indoor capture to a rank-fidelity policy comparison: capture first, package the proof, evaluate policies, and decide the next test.",
+          }),
+          breadcrumbJsonLd([
+            { name: "Home", path: "/" },
+            { name: "How It Works", path: "/how-it-works" },
+          ]),
+        ]}
       />
 
       {/* Hero */}

--- a/client/src/pages/Pricing.tsx
+++ b/client/src/pages/Pricing.tsx
@@ -1,4 +1,5 @@
 import { SEO } from "@/components/SEO";
+import { breadcrumbJsonLd, faqJsonLd, webPageJsonLd } from "@/lib/seoStructuredData";
 import {
   Button,
   Eyebrow,
@@ -161,6 +162,19 @@ export default function Pricing() {
         title="Pricing | Blueprint"
         description="Priced as evaluation infrastructure: quick-look evals, a robot-team subscription, site supply reviews, and yearly site monitoring — bounded to the reviewed site, task, and access scope."
         canonical="/pricing"
+        jsonLd={[
+          webPageJsonLd({
+            path: "/pricing",
+            name: "Blueprint Pricing",
+            description:
+              "Planning ranges for robot-team evaluation subscriptions, lite quick-look evals, operator site supply reviews, and yearly deployed-site monitoring.",
+          }),
+          breadcrumbJsonLd([
+            { name: "Home", path: "/" },
+            { name: "Pricing", path: "/pricing" },
+          ]),
+          faqJsonLd(faqItems),
+        ]}
       />
 
       {/* Hero */}

--- a/client/src/pages/Vision.tsx
+++ b/client/src/pages/Vision.tsx
@@ -1,5 +1,7 @@
-import { Helmet } from "@/lib/helmet";
 import { ArrowRight } from "lucide-react";
+
+import { SEO } from "@/components/SEO";
+import { breadcrumbJsonLd, webPageJsonLd } from "@/lib/seoStructuredData";
 
 import { Button, Eyebrow } from "@/components/blueprint";
 import {
@@ -84,14 +86,23 @@ const invariants = [
 export default function Vision() {
   return (
     <>
-      <Helmet>
-        <title>Vision | Blueprint</title>
-        <meta
-          name="description"
-          content="Blueprint's long-horizon vision: start as the neutral way to know which robot policy works at a real site, become the standard the market routes deployment decisions through, then climb into prediction, data, and site-specific policies — capture-first the whole way."
-        />
-        <link rel="canonical" href="https://tryblueprint.io/vision" />
-      </Helmet>
+      <SEO
+        title="Vision | Blueprint"
+        description="Blueprint's long-horizon vision: start as the neutral way to know which robot policy works at a real site, become the standard the market routes deployment decisions through, then climb into prediction, data, and site-specific policies — capture-first the whole way."
+        canonical="/vision"
+        jsonLd={[
+          webPageJsonLd({
+            path: "/vision",
+            name: "Blueprint Vision",
+            description:
+              "Blueprint's long-horizon vision: the neutral way to know which robot policy works at a real site, capture-first the whole way.",
+          }),
+          breadcrumbJsonLd([
+            { name: "Home", path: "/" },
+            { name: "Vision", path: "/vision" },
+          ]),
+        ]}
+      />
 
       <div className="bg-canvas text-ink">
         {/* Hero */}

--- a/scripts/prerender.tsx
+++ b/scripts/prerender.tsx
@@ -25,6 +25,7 @@ import About from "../client/src/pages/About";
 import Vision from "../client/src/pages/Vision";
 import Governance from "../client/src/pages/Governance";
 import ForSiteOperators from "../client/src/pages/ForSiteOperators";
+import ForRobotTeams from "../client/src/pages/ForRobotTeams";
 import { siteLibrarySites } from "../client/src/data/siteLibrary";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -272,7 +273,9 @@ const PrerenderRobotTeamEvalSummary = () => (
     body="Pick a site task, add policies, tell us the robot, and choose 100 or 500 episodes."
     primaryHref="/contact/robot-team?persona=robot-team&buyerType=robot_team&interest=policy-evaluation-run&path=policy-evaluation-run"
     primaryLabel="Start"
-    canonical="/robot-team/eval"
+    // The live RobotTeamEval page canonicalizes to /for-robot-teams (the
+    // advertised citation target), so the prerendered shell must match.
+    canonical="/for-robot-teams"
   />
 );
 
@@ -427,7 +430,10 @@ const staticRoutes: StaticRoute[] = [
   ),
   { path: "/proof", component: PrerenderProofSummary, shell: "bare" },
   ...proofAliasRoutes,
-  { path: "/for-robot-teams", component: PrerenderRobotTeamEvalSummary, shell: "bare" },
+  // /for-robot-teams is the canonical citation target advertised in the
+  // sitemap and llms.txt, so crawlers must see the real page, not a summary
+  // shell whose canonical points elsewhere.
+  { path: "/for-robot-teams", component: ForRobotTeams },
   { path: "/robot-team/eval", component: PrerenderRobotTeamEvalSummary, shell: "bare" },
   // Live public pages (also advertised in the sitemap) prerender as their
   // real components so crawlers and no-JS agents see the actual content.


### PR DESCRIPTION
## Summary

Closes the SEO/GEO gaps found in an audit of the public buyer pages. The existing foundation (prerender pipeline, sitemap, `llms.txt`, SEO component) was solid; this PR brings the pages that had drifted outside that system back into it and makes the AI-crawler policy explicit.

### SEO fixes

- **Fix invalid relative canonical URLs** on `/for-robot-teams` and `/for-site-operators` (`href="/for-robot-teams"` → absolute `https://tryblueprint.io/...`). Relative canonicals are ignored or misresolved by crawlers.
- **Migrate six pages off raw Helmet blocks to the shared `SEO` component** (About, Vision, Governance, Contact, ForRobotTeams, ForSiteOperators), so they now emit Open Graph, Twitter card, robots, and canonical tags like the rest of the site.
- **Prerender `/for-robot-teams` as the real page** instead of a bare summary shell whose canonical pointed at `/robot-team/eval` — that route is the canonical citation target advertised in `sitemap.xml` and `llms.txt`, so crawlers must see the actual content and a self-referencing canonical. The `/robot-team/eval` shell canonical now matches its live page (`/for-robot-teams`).

### Structured data (SEO + GEO)

- **Home**: Organization + WebSite + WebPage JSON-LD entities (linked via `@id`), using the existing `seoStructuredData` helpers that were previously only used on FAQ/Sites pages.
- **Pricing**: FAQPage JSON-LD generated from the page's visible FAQ content (6 Q&As) — a top citation format for AI answer engines — plus WebPage + BreadcrumbList.
- **How It Works, About, Vision, Governance, Contact, For Robot Teams, For Site Operators**: WebPage + BreadcrumbList JSON-LD.

### GEO (robots.txt)

- Added explicit `Claude-SearchBot`, `Claude-User`, `PerplexityBot`, and `Perplexity-User` groups with the same public-page policy as the existing `OAI-SearchBot`/`ChatGPT-User` groups, so Claude and Perplexity can index and cite public buyer pages.
- Added `ClaudeBot` (Anthropic's training crawler) to the existing training opt-out block alongside `GPTBot` and `Google-Extended`, preserving the repo's deliberate search-vs-training distinction. Drop that stanza if you'd rather be included in training corpora.

## Verification

- `npm run check` — clean
- `npm run build` — clean; inspected the prerendered HTML for every touched route: absolute self-referencing canonicals, OG/Twitter tags, and JSON-LD present and `JSON.parse`-valid (Organization/WebSite/WebPage on home, FAQPage with 6 questions on pricing)
- `npx vitest run` — 343 files / 1694 tests pass
- graphify pilot refresh ran (`--no-viz`); canonical `graphify-out/` outputs unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019EHwEYUuV6CLCmBQyCkvpy

---
_Generated by [Claude Code](https://claude.ai/code/session_019EHwEYUuV6CLCmBQyCkvpy)_