### PR TITLE
Backend scaling round 1: leader election, snapshot caches, indexes, earnings aggregate

### DIFF
--- a/docs/backend-scaling-architecture-2026-07-20.md
+++ b/docs/backend-scaling-architecture-2026-07-20.md
@@ -1,0 +1,172 @@
+# Shared Backend Scaling Architecture — Audit & Target Design (2026-07-20)
+
+Scope: the shared backend serving `BlueprintCapture` (iOS creators), `Blueprint-WebApp`
+(buyer/ops/gateway), and `BlueprintCapturePipeline` (GPU materialization). Goal: support the
+first 1,000–10,000 captured locations, thousands of creators, and 10k payouts/month on the
+existing primary stack (Firebase/Firestore, Firebase Storage/GCS, Stripe, Render, Redis,
+Backblaze B2 for webapp assets) — cheaply, without contract breaks, and without introducing
+new primary services.
+
+This document is the cross-repo canonical write-up. Companion changes land in all three
+repos on branch `claude/website-app-communication-pt8osh`.
+
+## 1. As-built summary
+
+- **Data plane**: one Firestore database (`blueprint-8c1ca`), one GCS bucket
+  (`blueprint-8c1ca.appspot.com`) holding raw capture truth (`scenes/**/raw/**`), derived
+  pipeline artifacts (`scenes/**/pipeline/**`), and buyer delivery prefixes. Backblaze B2
+  carries webapp media assets only.
+- **Control plane**: iOS uploads a raw bundle + `capture_upload_complete.json` →
+  `extract-frames` (4GiB Cloud Function) materializes frames + handoff → Pub/Sub →
+  pipeline Cloud Run Job (CPU) fanning into four GPU Cloud Run services (SAM3, VIP-inpaint,
+  DeepPrivacy2, video-to-world) plus off-GCP GPU providers (RunPod/Vast/DO/GCP/AWS) for
+  robot-eval. Status returns to the webapp via HMAC-signed sync (`webapp_sync.py`) and to
+  capture state via the secret-protected `updateCaptureStatus` function.
+- **Money plane**: Stripe Checkout + Connect with a Firestore projection ledger
+  (`buyerOrders`, `creatorPayouts`, `creatorPayoutDisbursements`, `stripeWebhookEvents`),
+  webhook dedupe, funding-policy gates, and a transactional double-pay guard.
+- **Gateway**: one Express process on Render (starter) serving all HTTP + WebSocket traffic
+  and ~20 in-process automation workers on `setInterval`.
+
+Correctness posture is strong (idempotent handoffs, fail-closed auth on money paths,
+webhook dedupe, monotonic capture-state rules). Operational scalability is the gap.
+
+## 2. What breaks first at 1k–10k locations
+
+Ranked by (probability × blast radius), with evidence from the audit:
+
+1. **Horizontal scale-out duplicates all automation** — the webapp scheduler
+   (`server/utils/opsAutomationScheduler.ts`) runs ~20 workers in-process with no leader
+   election. A second Render instance duplicates payout-exception triage, lifecycle emails,
+   and Notion writes. This silently forbids the most basic scaling move.
+2. **Hot mobile endpoints multiply Firestore reads** —
+   `/v1/creator/city-launch/targets` performs one prospects query per active city
+   (N+1, up to 1000 docs each) with in-memory haversine per app-open;
+   `/v1/opportunities/feed` (capture cloud functions) re-scans up to 500 `demand_signals`
+   + 200 `capture_jobs` per request. Thousands of creators → millions of reads/day for
+   data that changes on minutes-to-hours cadence.
+3. **Unbounded per-creator scans in the money path** — `/v1/creator/earnings`, `/qc`,
+   `/captures`, and every payout disbursement scan the creator's entire history
+   (`creatorCaptures`, `creatorPayouts` with no limit). Cost and latency grow linearly with
+   creator tenure; a 10k-capture creator makes each earnings call expensive.
+4. **Index drift** — the webapp repo declares only 2 composite indexes while many
+   `where().orderBy()` queries need more; console-only indexes are a deploy-time landmine.
+   The pipeline declared `createdAtShard` sharded indexes but nothing writes the field.
+5. **Unbounded storage growth with contradictory retention declarations** — three repos
+   declare different lifecycle policies for the same bucket (10-year Coldline in
+   BlueprintCapture's `storage.lifecycle.json`; delete-raw-at-180d in the pipeline's
+   `deploy/storage/primary-capture-bucket-lifecycle.json`; nothing in the webapp). Derived
+   artifacts run 2.5× raw. Nothing has TTLs: `creatorClientTelemetry`,
+   `stripeWebhookEvents`, `idempotencyKeys`, `sessionEvents` grow forever.
+6. **Compute waste per capture** — production pipeline retries re-run *all* lanes (dispatch
+   path bypasses the `run_e2e` resume ledger; Cloud Tasks 5× × Cloud Run 3× = worst-case
+   ~15× on a poison capture). `extractFrames` has no `maxInstances` (unbounded 4GiB
+   scale-out), ~30 serial GCS HEAD polls, and per-frame object writes (~900 objects per
+   3-minute capture).
+7. **Hot counter contention** — `stats/inboundRequests` takes multi-field increments per
+   lead on a single doc (~1 sustained write/s/doc ceiling).
+8. **Payments throughput ops** — Stripe webhooks process synchronously on the single web
+   dyno; reconciliation at 10k payouts/month scans collections with no running aggregates.
+
+## 3. Target design (first principles, same stack)
+
+**Read path rule: no request-scoped fan-out for shared data.** Anything read by many
+creators (feed, city targets, launch status inputs) is served from a short-TTL snapshot
+(60–120 s, in-process + optional Redis), refreshed at most once per TTL per instance —
+never re-scanned per request. Opportunity data staleness tolerance is minutes; the cache is
+advisory-read, so capture truth is untouched.
+
+**Per-creator data rule: bounded, ordered, aggregated.** Every per-creator list query has
+`orderBy` + `limit` + a matching composite index. Lifetime totals come from a maintained
+aggregate document (`creatorEarningsAggregates/{creatorId}`), updated transactionally with
+payout writes and lazily backfilled from a one-time scan — never recomputed from full scans
+per request.
+
+**Single-writer rule for schedulers.** Exactly one instance runs automation lanes,
+enforced by a Redis lease (SET NX PX + renewal) with a Firestore-transaction lease as
+fallback. Workers are lease-checked per tick, so failover is automatic within one lease TTL.
+
+**Counters shard.** High-frequency counters use N-way sharded increment docs summed on
+read (or on a slow schedule), not single hot docs.
+
+**Storage: one canonical lifecycle, raw truth is archived — never deleted.** Raw capture
+bundles are the moat and the training corpus (`WORLD_MODEL_STRATEGY_CONTEXT.md` data
+priority). Canonical policy (pipeline repo owns it; capture repo mirrors it):
+- `scenes/**` (raw truth): Nearline @30d → Coldline @90d → **Archive @365d, no delete**.
+  At 10k locations × ~1.2 GiB raw p50 ≈ 12 TiB ≈ ~$15/month in Archive — preserving the
+  corpus is two orders of magnitude cheaper than one recapture.
+- Derived/regenerable (`tmp/`, `staging/`, `debug/`): delete @14d.
+- Buyer delivery / hosted sessions / robot-eval jobs: delete @365d (regenerable from raw).
+This replaces both the 10-year-Coldline declaration and the delete-raw-at-180d
+declaration; the delete-at-180d cost ceiling is met by Archive instead of deletion.
+
+**Firestore TTLs for operational exhaust.** `creatorClientTelemetry`,
+`stripeWebhookEvents`, `idempotencyKeys`, `sessionEvents`, `growth_events` carry an
+`expires_at` timestamp with a documented TTL policy (gcloud-applied; scripts checked in).
+Money-plane ledger collections (`creatorPayouts`, `buyerOrders`, disbursements) are
+permanent.
+
+**Compute: bounded, idempotent, resumable.**
+- Every Cloud Function sets `maxInstances` (and concurrency where meaningful) so bursts
+  are queued, not billed unbounded.
+- The pipeline dispatch path gains stage-level resume: each lane short-circuits when its
+  canonical output artifact already exists for the same input fingerprint, so Cloud
+  Tasks/Cloud Run retries only re-run the failed lane.
+- `captures.createdAtShard` is actually populated (hash of capture id mod 16) so the
+  declared sharded indexes take load off the monotonic `createdAt` index.
+- GCS existence probes in `extractFrames` run in parallel, not serially, cutting billed
+  wall-clock at 4 GiB.
+
+**Payments at 10k/month.** Keep the (good) idempotency and funding gates; add the earnings
+aggregate (above) so earnings/disbursement reads stop scaling with tenure, and bound
+disbursement queries to payable statuses via composite index. Queue-based webhook
+processing and an append-only journal export are deliberate follow-ups (§5) — they change
+operational shape and deserve their own review.
+
+## 4. Landed in this change set (round 1)
+
+Blueprint-WebApp:
+- Redis/Firestore leased leader election around the ops automation scheduler.
+- Snapshot cache (TTL) for city-launch activations/prospects; targets + launch-status
+  endpoints read the snapshot instead of N+1 per request.
+- Missing composite indexes added to `firestore.indexes.json`.
+- Bounded + indexed per-creator queries; `creatorEarningsAggregates` with lazy backfill;
+  disbursement queries restricted to payable statuses.
+- Sharded `stats/inboundRequests` counters.
+- `expires_at` stamped on telemetry/webhook-event/idempotency docs + TTL apply script.
+
+BlueprintCapture (cloud functions + app):
+- `maxInstances` on all functions; feed handlers serve from a TTL snapshot of
+  demand signals/jobs/weights; demand-snapshot refresh debounced instead of per-submission.
+- Parallelized GCS availability probes in `extractFrames`.
+- App: capture history query gains `orderBy`+pagination; referrals query gains a limit.
+- Canonical lifecycle mirror replaces the 10-year local policy file.
+
+BlueprintCapturePipeline:
+- `createdAtShard` populated on capture records.
+- Stage-level resume markers on the production dispatch path.
+- Canonical bucket lifecycle updated: raw archived at 365d instead of deleted at 180d;
+  cost note updated.
+
+## 5. Deliberate follow-ups (not in this change set)
+
+- Move Stripe webhook processing onto a queue with DLQ + append-only journal/BigQuery
+  export for reconciliation (operational shape change — needs ops review).
+- Split automation workers into a dedicated Render background worker service.
+- Frame packing (tar/composite objects) for `extractFrames` output — requires a
+  coordinated pipeline contract rev; per-frame objects are the current contract.
+- CDN in front of buyer delivery downloads (egress $0.12/GiB today).
+- Retire the legacy iOS Backblaze `StorageManager` path and rotate the exposed B2 key
+  (credentials currently hardcoded in the binary — key rotation is an ops action).
+- Warm-pool strategy for GPU privacy services (min-instances vs cold model loads) once
+  sustained load justifies idle spend.
+- k6 load test of the gateway (BLR-041) once leader election lands.
+
+## 6. Invariants preserved
+
+- Raw capture bundle structure, provenance/rights metadata, `capture_bridge_handoff.v1`,
+  webapp sync payload `v1`, robot-eval status projection `v1`, canonical package layout:
+  untouched.
+- All caches serve advisory read surfaces (feeds, targets); capture truth, payout
+  correctness paths, and qualification decisions never read from cache.
+- World-model/GPU backends remain swappable; no new primary services introduced.

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -31,6 +31,220 @@
           "order": "DESCENDING"
         }
       ]
+    },
+    {
+      "collectionGroup": "inboundRequests",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "inboundRequests",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "priority",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "inboundRequests",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "priority",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "inboundRequests",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "priority",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "inboundRequests",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "priority",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "status",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "action_ledger",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "updated_at",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "growth_campaign_events",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "campaign_id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "received_at",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "growthCampaigns",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "send_status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "created_at",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "cityLaunchCoverageRuns",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "citySlug",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAtIso",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "ad_studio_runs",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "city",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "updated_at_iso",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "meta_ads_cli_runs",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "city",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAtIso",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "creatorCaptures",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "creator_id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "created_at",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "creatorPayouts",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "creator_id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "updated_at",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "creatorPayouts",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "creator_id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "creatorPayoutDisbursements",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "creator_id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/render.optional.env.example
+++ b/render.optional.env.example
@@ -79,6 +79,17 @@ BLUEPRINT_EXPERIMENT_AUTOROLLOUT_MIN_RELATIVE_LIFT=
 # Optional watchdogs and cadence tuning
 ########################################
 
+# Scheduler leader election escape hatch: force this instance to run all
+# automation lanes regardless of the Redis/Firestore lease (single-instance
+# behavior). Leave unset on multi-instance deployments.
+BLUEPRINT_OPS_AUTOMATION_FORCE_LEADER=
+
+# City-launch feed snapshot cache TTL (ms, default 90000, 0 disables caching).
+BLUEPRINT_CITY_LAUNCH_SNAPSHOT_TTL_MS=
+
+# creatorClientTelemetry expires_at retention window (days, default 90).
+BLUEPRINT_CREATOR_TELEMETRY_RETENTION_DAYS=
+
 BLUEPRINT_SITE_ACCESS_OVERDUE_WATCHDOG_ENABLED=1
 BLUEPRINT_FINANCE_REVIEW_OVERDUE_WATCHDOG_ENABLED=1
 BLUEPRINT_CAPTURER_REMINDER_ENABLED=1

--- a/scripts/apply_firestore_ttl_policies.sh
+++ b/scripts/apply_firestore_ttl_policies.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# Apply Firestore TTL policies for operational-exhaust collections.
+#
+# Idempotent: `gcloud firestore fields ttls update` converges on the desired
+# state, so re-running is safe. TTL deletion is asynchronous (typically within
+# 24h of expiry) and only removes documents whose TTL field holds a timestamp
+# in the past.
+#
+# Covered collections (round 1 of the backend scaling plan,
+# docs/backend-scaling-architecture-2026-07-20.md):
+#   - creatorClientTelemetry.expires_at  (stamped by POST /v1/creator/client-telemetry,
+#     default 90 days, tunable via BLUEPRINT_CREATOR_TELEMETRY_RETENTION_DAYS)
+#   - idempotencyKeys.expiresAt          (already stamped by server/utils/idempotency.ts)
+#
+# Money-plane ledger collections (creatorPayouts, creatorPayoutDisbursements,
+# buyerOrders) are permanent and must never get a TTL policy.
+# stripeWebhookEvents and sessionEvents do not carry an expiry field yet;
+# they are round-2 follow-ups.
+#
+# Usage:
+#   ./scripts/apply_firestore_ttl_policies.sh [--project PROJECT_ID]
+#
+# Requires: gcloud authenticated with Firestore admin permissions.
+
+set -euo pipefail
+
+PROJECT_ID="${FIREBASE_PROJECT_ID:-blueprint-8c1ca}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --project)
+      PROJECT_ID="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      echo "Usage: $0 [--project PROJECT_ID]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+apply_ttl() {
+  local collection_group="$1"
+  local field="$2"
+  echo "Enabling TTL on ${collection_group}.${field} (project ${PROJECT_ID})..."
+  gcloud firestore fields ttls update "${field}" \
+    --collection-group="${collection_group}" \
+    --enable-ttl \
+    --project="${PROJECT_ID}"
+}
+
+apply_ttl "creatorClientTelemetry" "expires_at"
+apply_ttl "idempotencyKeys" "expiresAt"
+
+echo "Done. Verify with:"
+echo "  gcloud firestore fields ttls list --project=${PROJECT_ID}"

--- a/scripts/apply_firestore_ttl_policies.sh
+++ b/scripts/apply_firestore_ttl_policies.sh
@@ -12,11 +12,14 @@
 #   - creatorClientTelemetry.expires_at  (stamped by POST /v1/creator/client-telemetry,
 #     default 90 days, tunable via BLUEPRINT_CREATOR_TELEMETRY_RETENTION_DAYS)
 #   - idempotencyKeys.expiresAt          (already stamped by server/utils/idempotency.ts)
+#   - stripeWebhookEvents.expires_at     (dedupe records only; stamped by
+#     beginStripeWebhookEvent, default 180 days, tunable via
+#     BLUEPRINT_STRIPE_WEBHOOK_EVENT_RETENTION_DAYS)
 #
 # Money-plane ledger collections (creatorPayouts, creatorPayoutDisbursements,
 # buyerOrders) are permanent and must never get a TTL policy.
-# stripeWebhookEvents and sessionEvents do not carry an expiry field yet;
-# they are round-2 follow-ups.
+# sessionEvents (written by the iOS client) does not carry an expiry field
+# yet; it is a follow-up in the BlueprintCapture repo.
 #
 # Usage:
 #   ./scripts/apply_firestore_ttl_policies.sh [--project PROJECT_ID]
@@ -53,6 +56,7 @@ apply_ttl() {
 
 apply_ttl "creatorClientTelemetry" "expires_at"
 apply_ttl "idempotencyKeys" "expiresAt"
+apply_ttl "stripeWebhookEvents" "expires_at"
 
 echo "Done. Verify with:"
 echo "  gcloud firestore fields ttls list --project=${PROJECT_ID}"

--- a/server/routes/admin-leads.ts
+++ b/server/routes/admin-leads.ts
@@ -8,6 +8,10 @@ import {
   encryptFieldValue,
 } from "../utils/field-encryption";
 import {
+  incrementInboundRequestStats,
+  readInboundRequestStats,
+} from "../utils/inboundRequestStats";
+import {
   createCaptureHandoffToken,
   verifyCaptureHandoffToken,
 } from "../utils/capture-handoff-token";
@@ -1731,19 +1735,10 @@ router.patch(
       }
 
       if (previousData.status !== qualification_state) {
-        await db
-          .collection("stats")
-          .doc("inboundRequests")
-          .set(
-            {
-              [`byStatus.${previousData.status}`]:
-                admin.firestore.FieldValue.increment(-1),
-              [`byStatus.${qualification_state}`]:
-                admin.firestore.FieldValue.increment(1),
-              updatedAt: admin.firestore.FieldValue.serverTimestamp(),
-            },
-            { merge: true }
-          );
+        await incrementInboundRequestStats(db, {
+          [`byStatus.${previousData.status}`]: -1,
+          [`byStatus.${qualification_state}`]: 1,
+        });
       }
 
       // Add note if provided
@@ -2334,11 +2329,7 @@ router.get("/stats/summary", requireAdmin, async (req: Request, res: Response) =
       return res.status(500).json({ error: "Database not available" });
     }
 
-    const statsSnapshot = await db
-      .collection("stats")
-      .doc("inboundRequests")
-      .get();
-    const statsData = statsSnapshot.exists ? statsSnapshot.data() ?? {} : {};
+    const statsData = (await readInboundRequestStats(db)) as Record<string, any>;
 
     const statusCounts: Record<string, number> = {
       submitted: statsData.byStatus?.submitted ?? 0,

--- a/server/routes/creator.ts
+++ b/server/routes/creator.ts
@@ -5,6 +5,8 @@ import { logger } from "../logger";
 import {
   listCreatorPayouts,
   mapCreatorPayoutStatusForLedger,
+  readCreatorEarningsAggregate,
+  summarizeCreatorEarnings,
 } from "../utils/accounting";
 import {
   recordBetaOpsFailureSignal,
@@ -24,11 +26,22 @@ import {
 import { reviewCityLaunchCandidateBatch } from "../utils/cityLaunchCandidateReview";
 import { dispatchCityLaunchCandidatePaperclipHandoff } from "../utils/cityLaunchCandidatePaperclipHandoff";
 import { intakeCityLaunchCandidateSignals } from "../utils/cityLaunchLedgers";
+import { deriveCreatedAtShard } from "../utils/captureShard";
 import { creatorIdFromRequest } from "../utils/creatorIdentity";
 import { clientVersionSatisfiesMinimum } from "../utils/client-runtime-config";
 import { loadClientRuntimeConfig } from "./client-runtime-config";
 
 const router = Router();
+
+// Bounded read windows for per-creator queries (backed by the creator_id +
+// created_at / updated_at composite indexes in firestore.indexes.json).
+const QC_RECENT_CAPTURE_LIMIT = 500;
+const PAYOUT_LEDGER_FETCH_LIMIT = 200;
+
+const TELEMETRY_RETENTION_DAYS = Math.max(
+  1,
+  Math.trunc(Number(process.env.BLUEPRINT_CREATOR_TELEMETRY_RETENTION_DAYS) || 90),
+);
 
 const DEFAULT_NOTIFICATION_PREFERENCES = {
   nearby_jobs: true,
@@ -256,25 +269,15 @@ router.get("/earnings", async (req: Request, res: Response) => {
     return res.status(400).json({ error: "Missing creator id" });
   }
 
-  const payouts = await listCreatorPayouts(creatorId);
-  const totalEarnedCents = payouts.reduce((sum, payout) => {
-    return payout.status === "paid"
-      ? sum + payout.approved_amount_cents
-      : sum;
-  }, 0);
-  const pendingPayoutCents = payouts.reduce((sum, payout) => {
-    return ["approved", "in_transit", "review_required"].includes(payout.status)
-      ? sum + payout.approved_amount_cents
-      : sum;
-  }, 0);
-  const scansCompleted = payouts.filter((payout) =>
-    ["approved", "in_transit", "paid"].includes(payout.status),
-  ).length;
+  // Lifetime totals come from the maintained earnings aggregate (lazily
+  // backfilled on first read) instead of scanning the full payout history.
+  const aggregate = await readCreatorEarningsAggregate(creatorId);
+  const earnings = summarizeCreatorEarnings(aggregate);
 
   return res.json({
-    total_earned_cents: totalEarnedCents,
-    pending_payout_cents: pendingPayoutCents,
-    scans_completed: scansCompleted,
+    total_earned_cents: earnings.totalEarnedCents,
+    pending_payout_cents: earnings.pendingPayoutCents,
+    scans_completed: earnings.scansCompleted,
   });
 });
 
@@ -288,14 +291,18 @@ router.get("/captures", async (req: Request, res: Response) => {
     return res.status(400).json({ error: "Missing creator id" });
   }
 
+  // Bounded, index-backed read (creator_id + created_at composite) instead of
+  // scanning the creator's full capture history per request.
+  const limit = Math.min(Math.max(Math.trunc(toNumber(req.query.limit) ?? 50), 1), 200);
   const snapshot = await db
     .collection("creatorCaptures")
     .where("creator_id", "==", creatorId)
+    .orderBy("created_at", "desc")
+    .limit(limit)
     .get();
   const captures = snapshot.docs
     .map((doc) => serializeCapture(doc))
-    .sort((a, b) => new Date(b.captured_at).getTime() - new Date(a.captured_at).getTime())
-    .slice(0, 50);
+    .sort((a, b) => new Date(b.captured_at).getTime() - new Date(a.captured_at).getTime());
 
   return res.json(captures);
 });
@@ -494,6 +501,10 @@ router.post("/captures", async (req: Request, res: Response) => {
       { label: "Payout", completed_at: null, state: "pending" },
     ],
     created_at: admin.firestore.FieldValue.serverTimestamp(),
+    // Additive Firestore hotspot-guard field: deterministic capture-id hash
+    // shard (sha256 mod 16) so created_at queries can migrate to the sharded
+    // composite indexes without a write-time hotspot. See captureShard.ts.
+    createdAtShard: deriveCreatedAtShard(captureId),
     updated_at: admin.firestore.FieldValue.serverTimestamp(),
   };
 
@@ -808,6 +819,10 @@ router.post("/client-telemetry", async (req: Request, res: Response) => {
     source: "blueprint_capture_native_client",
     beta_alert_candidate: true,
     received_at: admin.firestore.FieldValue.serverTimestamp(),
+    // Operational exhaust, not capture truth: expires via the Firestore TTL
+    // policy on creatorClientTelemetry.expires_at
+    // (scripts/apply_firestore_ttl_policies.sh).
+    expires_at: new Date(Date.now() + TELEMETRY_RETENTION_DAYS * 24 * 60 * 60 * 1000),
   };
 
   const telemetryRef = db.collection("creatorClientTelemetry").doc(telemetryDocId);
@@ -997,9 +1012,13 @@ router.get("/qc", async (req: Request, res: Response) => {
     return res.status(400).json({ error: "Missing creator id" });
   }
 
+  // QC stats are advisory: compute them over a bounded recent window instead
+  // of the creator's unbounded capture history.
   const snapshot = await db
     .collection("creatorCaptures")
     .where("creator_id", "==", creatorId)
+    .orderBy("created_at", "desc")
+    .limit(QC_RECENT_CAPTURE_LIMIT)
     .get();
 
   let pendingCount = 0;
@@ -1055,7 +1074,7 @@ router.get("/payouts/ledger", async (req: Request, res: Response) => {
     return res.status(400).json({ error: "Missing creator id" });
   }
 
-  const entries = (await listCreatorPayouts(creatorId))
+  const entries = (await listCreatorPayouts(creatorId, { limit: PAYOUT_LEDGER_FETCH_LIMIT }))
     .filter((entry) => entry.approved_amount_cents > 0)
     .slice(0, 50)
     .map((entry) => ({

--- a/server/routes/inbound-request.ts
+++ b/server/routes/inbound-request.ts
@@ -15,6 +15,7 @@ import { createRequestReviewToken } from "../utils/request-review-auth";
 import { createSlaTracker } from "../utils/sla-enforcement";
 import { runInboundQualificationForRequest } from "../agents";
 import { logGrowthEvent } from "../utils/growth-events";
+import { incrementInboundRequestStats } from "../utils/inboundRequestStats";
 import { runHighIntentLeadEnrichmentForRequest } from "../utils/highIntentLeadEnrichment";
 import { createLifecycleCadenceForInboundRequest } from "../utils/lifecycle-cadence";
 import { isLocalLaunchSmokeProfile } from "../utils/launch-readiness";
@@ -1451,27 +1452,14 @@ router.post("/", async (req: Request, res: Response) => {
       );
     });
 
-    await db
-      .collection("stats")
-      .doc("inboundRequests")
-      .set(
-        {
-          total: admin.firestore.FieldValue.increment(1),
-          [`byStatus.submitted`]: admin.firestore.FieldValue.increment(1),
-          [`byPriority.${priority}`]: admin.firestore.FieldValue.increment(1),
-          [`byQueue.${routing.queueKey}`]: admin.firestore.FieldValue.increment(1),
-          [`byRequestPath.${commercialRequestPath}`]:
-            admin.firestore.FieldValue.increment(1),
-          ...(routing.growthWedge
-            ? {
-                [`byWedge.${routing.growthWedge}`]:
-                  admin.firestore.FieldValue.increment(1),
-              }
-            : {}),
-          updatedAt: admin.firestore.FieldValue.serverTimestamp(),
-        },
-        { merge: true }
-      );
+    await incrementInboundRequestStats(db, {
+      total: 1,
+      [`byStatus.submitted`]: 1,
+      [`byPriority.${priority}`]: 1,
+      [`byQueue.${routing.queueKey}`]: 1,
+      [`byRequestPath.${commercialRequestPath}`]: 1,
+      ...(routing.growthWedge ? { [`byWedge.${routing.growthWedge}`]: 1 } : {}),
+    });
 
     if (buyerType === "robot_team") {
       await emitRobotTeamFitChecked().catch(() => null);

--- a/server/tests/accounting-ledgers.test.ts
+++ b/server/tests/accounting-ledgers.test.ts
@@ -95,30 +95,49 @@ function makeDocRef(collectionName: string, id: string) {
 
 type MockDocRef = ReturnType<typeof makeDocRef>;
 
+type QueryFilter = { field: string; op: string; value: unknown };
+
+function queryMatches(data: StoredDoc, filter: QueryFilter): boolean {
+  if (filter.op === "==") {
+    return data[filter.field] === filter.value;
+  }
+  if (filter.op === "in") {
+    return (
+      Array.isArray(filter.value) &&
+      (filter.value as unknown[]).includes(data[filter.field])
+    );
+  }
+  throw new Error(`Unsupported operator ${filter.op}`);
+}
+
+function makeQuery(collectionName: string, filters: QueryFilter[]) {
+  return {
+    where: (field: string, op: string, value: unknown) =>
+      makeQuery(collectionName, [...filters, { field, op, value }]),
+    get: async () => {
+      const docs = Array.from(state.docs.entries())
+        .filter(([key, data]) => {
+          if (!key.startsWith(`${collectionName}/`)) {
+            return false;
+          }
+          return filters.every((filter) => queryMatches(data, filter));
+        })
+        .map(([key, data]) => {
+          const id = key.slice(collectionName.length + 1);
+          return makeQueryDoc(collectionName, id, data);
+        });
+      return { docs };
+    },
+  };
+}
+
 vi.mock("../../client/src/lib/firebaseAdmin", () => ({
   default: {},
   dbAdmin: {
     collection: (collectionName: string) => ({
       doc: (id: string) => makeDocRef(collectionName, id),
-      where: (field: string, op: string, value: unknown) => ({
-        get: async () => {
-          if (op !== "==") {
-            throw new Error(`Unsupported operator ${op}`);
-          }
-          const docs = Array.from(state.docs.entries())
-            .filter(([key, data]) => {
-              if (!key.startsWith(`${collectionName}/`)) {
-                return false;
-              }
-              return data[field] === value;
-            })
-            .map(([key, data]) => {
-              const id = key.slice(collectionName.length + 1);
-              return makeQueryDoc(collectionName, id, data);
-            });
-          return { docs };
-        },
-      }),
+      where: (field: string, op: string, value: unknown) =>
+        makeQuery(collectionName, [{ field, op, value }]),
     }),
     // Minimal serializable-transaction emulation: reads see live state, writes
     // are buffered and committed atomically once the callback resolves.

--- a/server/tests/automation-leader-lease.test.ts
+++ b/server/tests/automation-leader-lease.test.ts
@@ -1,0 +1,307 @@
+// @vitest-environment node
+//
+// Leader election for the ops automation scheduler: exactly one instance may
+// hold the "ops-automation-leader" lease at a time (Redis SET NX PX when Redis
+// is configured, Firestore transaction lease otherwise), non-holders keep
+// retrying, and a released or expired lease is claimable by another instance.
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  createAutomationLeaderLease,
+  type LeaseFirestoreClient,
+  type LeaseRedisClient,
+} from "../utils/automationLeaderLease";
+
+function makeFakeRedis() {
+  const store = new Map<string, { value: string; expiresAtMs: number }>();
+  let nowMs = 0;
+  const alive = (key: string) => {
+    const entry = store.get(key);
+    if (!entry) {
+      return null;
+    }
+    if (entry.expiresAtMs <= nowMs) {
+      store.delete(key);
+      return null;
+    }
+    return entry;
+  };
+  const client: LeaseRedisClient = {
+    set: async (key, value, options) => {
+      if (options.NX && alive(key)) {
+        return null;
+      }
+      store.set(key, { value, expiresAtMs: nowMs + options.PX });
+      return "OK";
+    },
+    eval: async (script, { keys, arguments: args }) => {
+      const entry = alive(keys[0]);
+      if (!entry || entry.value !== args[0]) {
+        return 0;
+      }
+      if (script.includes("pexpire")) {
+        entry.expiresAtMs = nowMs + Number(args[1]);
+        return 1;
+      }
+      store.delete(keys[0]);
+      return 1;
+    },
+  };
+  return {
+    client,
+    holder: (key: string) => alive(key)?.value ?? null,
+    advance: (ms: number) => {
+      nowMs += ms;
+    },
+  };
+}
+
+function makeFakeFirestore() {
+  const docs = new Map<string, Record<string, unknown>>();
+  let txChain: Promise<unknown> = Promise.resolve();
+  const firestore: LeaseFirestoreClient = {
+    collection: (collectionName: string) => ({
+      doc: (id: string) =>
+        ({ __path: `${collectionName}/${id}` }) as unknown as FirebaseFirestore.DocumentReference,
+    }),
+    runTransaction: async (updateFunction) => {
+      const run = txChain.then(async () => {
+        const writes: Array<() => void> = [];
+        const tx = {
+          get: async (ref: { __path: string }) => {
+            const data = docs.get(ref.__path);
+            return {
+              exists: Boolean(data),
+              data: () => (data ? { ...data } : undefined),
+            };
+          },
+          set: (
+            ref: { __path: string },
+            payload: Record<string, unknown>,
+            options?: { merge?: boolean },
+          ) => {
+            writes.push(() => {
+              const existing = options?.merge ? docs.get(ref.__path) || {} : {};
+              docs.set(ref.__path, { ...existing, ...payload });
+            });
+          },
+        } as unknown as FirebaseFirestore.Transaction;
+        const result = await updateFunction(tx);
+        for (const write of writes) {
+          write();
+        }
+        return result;
+      });
+      txChain = run.catch(() => undefined);
+      return run as ReturnType<typeof updateFunction>;
+    },
+  };
+  return {
+    firestore,
+    holder: () =>
+      (docs.get("opsAutomationLeases/ops-automation-leader")?.holder_id as
+        | string
+        | null
+        | undefined) ?? null,
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("automation leader lease (Redis)", () => {
+  it("grants the lease to one instance and keeps the other in standby", async () => {
+    const redis = makeFakeRedis();
+    const first = createAutomationLeaderLease({
+      instanceId: "instance-a",
+      getRedisClient: () => redis.client,
+      getFirestore: () => null,
+      isForced: () => false,
+    });
+    const second = createAutomationLeaderLease({
+      instanceId: "instance-b",
+      getRedisClient: () => redis.client,
+      getFirestore: () => null,
+      isForced: () => false,
+    });
+
+    expect(await first.tick()).toBe(true);
+    expect(await second.tick()).toBe(false);
+    expect(first.isLeader()).toBe(true);
+    expect(second.isLeader()).toBe(false);
+    expect(redis.holder("ops-automation-leader")).toBe("instance-a");
+
+    // Renewal keeps the same holder.
+    expect(await first.tick()).toBe(true);
+    expect(redis.holder("ops-automation-leader")).toBe("instance-a");
+  });
+
+  it("lets a standby instance take over after the lease expires", async () => {
+    const redis = makeFakeRedis();
+    const first = createAutomationLeaderLease({
+      instanceId: "instance-a",
+      ttlMs: 60_000,
+      getRedisClient: () => redis.client,
+      getFirestore: () => null,
+      isForced: () => false,
+    });
+    const second = createAutomationLeaderLease({
+      instanceId: "instance-b",
+      ttlMs: 60_000,
+      getRedisClient: () => redis.client,
+      getFirestore: () => null,
+      isForced: () => false,
+    });
+
+    expect(await first.tick()).toBe(true);
+    redis.advance(61_000);
+    expect(await second.tick()).toBe(true);
+    expect(redis.holder("ops-automation-leader")).toBe("instance-b");
+    // The stale leader loses the lease on its next tick.
+    expect(await first.tick()).toBe(false);
+  });
+
+  it("releases the lease on stop so another instance can acquire immediately", async () => {
+    const redis = makeFakeRedis();
+    const first = createAutomationLeaderLease({
+      instanceId: "instance-a",
+      getRedisClient: () => redis.client,
+      getFirestore: () => null,
+      isForced: () => false,
+    });
+    const second = createAutomationLeaderLease({
+      instanceId: "instance-b",
+      getRedisClient: () => redis.client,
+      getFirestore: () => null,
+      isForced: () => false,
+    });
+
+    expect(await first.tick()).toBe(true);
+    await first.stop();
+    expect(redis.holder("ops-automation-leader")).toBeNull();
+    expect(await second.tick()).toBe(true);
+  });
+});
+
+describe("automation leader lease (Firestore fallback)", () => {
+  it("grants the lease via transaction and blocks a second holder until expiry", async () => {
+    let nowMs = 1_000_000;
+    const backing = makeFakeFirestore();
+    const first = createAutomationLeaderLease({
+      instanceId: "instance-a",
+      ttlMs: 60_000,
+      now: () => nowMs,
+      getRedisClient: () => null,
+      getFirestore: () => backing.firestore,
+      isForced: () => false,
+    });
+    const second = createAutomationLeaderLease({
+      instanceId: "instance-b",
+      ttlMs: 60_000,
+      now: () => nowMs,
+      getRedisClient: () => null,
+      getFirestore: () => backing.firestore,
+      isForced: () => false,
+    });
+
+    expect(await first.tick()).toBe(true);
+    expect(await second.tick()).toBe(false);
+    expect(backing.holder()).toBe("instance-a");
+
+    // Renewal by the holder extends the lease.
+    nowMs += 30_000;
+    expect(await first.tick()).toBe(true);
+    expect(await second.tick()).toBe(false);
+
+    // After expiry the standby instance claims the lease.
+    nowMs += 61_000;
+    expect(await second.tick()).toBe(true);
+    expect(backing.holder()).toBe("instance-b");
+  });
+
+  it("clears the holder on stop", async () => {
+    const backing = makeFakeFirestore();
+    const lease = createAutomationLeaderLease({
+      instanceId: "instance-a",
+      getRedisClient: () => null,
+      getFirestore: () => backing.firestore,
+      isForced: () => false,
+    });
+
+    expect(await lease.tick()).toBe(true);
+    await lease.stop();
+    expect(backing.holder()).toBeNull();
+  });
+
+  it("fails closed when the transaction errors", async () => {
+    const lease = createAutomationLeaderLease({
+      instanceId: "instance-a",
+      getRedisClient: () => null,
+      getFirestore: () =>
+        ({
+          collection: () => ({ doc: () => ({}) }),
+          runTransaction: async () => {
+            throw new Error("firestore unavailable");
+          },
+        }) as unknown as LeaseFirestoreClient,
+      isForced: () => false,
+    });
+
+    expect(await lease.tick()).toBe(false);
+    expect(lease.isLeader()).toBe(false);
+  });
+});
+
+describe("automation leader lease (defaults and overrides)", () => {
+  it("acts as leader when no coordination store is available", async () => {
+    const lease = createAutomationLeaderLease({
+      getRedisClient: () => null,
+      getFirestore: () => null,
+      isForced: () => false,
+    });
+    expect(await lease.tick()).toBe(true);
+    expect(lease.isLeader()).toBe(true);
+  });
+
+  it("honors the force-leader kill switch even without acquiring the lease", async () => {
+    const redis = makeFakeRedis();
+    const holder = createAutomationLeaderLease({
+      instanceId: "instance-a",
+      getRedisClient: () => redis.client,
+      getFirestore: () => null,
+      isForced: () => false,
+    });
+    expect(await holder.tick()).toBe(true);
+
+    vi.stubEnv("BLUEPRINT_OPS_AUTOMATION_FORCE_LEADER", "true");
+    const forced = createAutomationLeaderLease({
+      instanceId: "instance-b",
+      getRedisClient: () => redis.client,
+      getFirestore: () => null,
+    });
+    expect(forced.isLeader()).toBe(true);
+    expect(await forced.tick()).toBe(true);
+  });
+
+  it("falls back to Firestore when Redis errors", async () => {
+    const backing = makeFakeFirestore();
+    const lease = createAutomationLeaderLease({
+      instanceId: "instance-a",
+      getRedisClient: () =>
+        ({
+          set: async () => {
+            throw new Error("redis down");
+          },
+          eval: async () => {
+            throw new Error("redis down");
+          },
+        }) as LeaseRedisClient,
+      getFirestore: () => backing.firestore,
+      isForced: () => false,
+    });
+
+    expect(await lease.tick()).toBe(true);
+    expect(backing.holder()).toBe("instance-a");
+  });
+});

--- a/server/tests/capture-shard.test.ts
+++ b/server/tests/capture-shard.test.ts
@@ -1,0 +1,49 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+
+import {
+  CREATED_AT_SHARD_COUNT,
+  deriveCreatedAtShard,
+} from "../utils/captureShard";
+
+describe("deriveCreatedAtShard", () => {
+  it("pins the canonical shard count", () => {
+    expect(CREATED_AT_SHARD_COUNT).toBe(16);
+  });
+
+  it("is deterministic for the same capture id", () => {
+    expect(deriveCreatedAtShard("capture-abc-123")).toBe(
+      deriveCreatedAtShard("capture-abc-123"),
+    );
+  });
+
+  it("matches the pinned cross-language reference derivation", () => {
+    // Reference values from
+    // int(hashlib.sha256(capture_id.encode()).hexdigest(), 16) % 16 — the
+    // derivation documented in BlueprintCapturePipeline's
+    // BETA_CAPACITY_COST_STORAGE_MODEL doc. These must never change: a stored
+    // createdAtShard is only useful if readers/backfills derive the same value.
+    expect(deriveCreatedAtShard("cap-1")).toBe(10);
+    expect(deriveCreatedAtShard("capture-abc-123")).toBe(10);
+    expect(deriveCreatedAtShard("scene-9/capture-77")).toBe(7);
+    expect(deriveCreatedAtShard("CAP-1")).toBe(9);
+  });
+
+  it("always lands in [0, shardCount)", () => {
+    for (let i = 0; i < 200; i += 1) {
+      const shard = deriveCreatedAtShard(`capture-${i}`);
+      expect(Number.isInteger(shard)).toBe(true);
+      expect(shard).toBeGreaterThanOrEqual(0);
+      expect(shard).toBeLessThan(CREATED_AT_SHARD_COUNT);
+    }
+  });
+
+  it("supports explicit shard counts and rejects invalid ones", () => {
+    expect(deriveCreatedAtShard("cap-1", 1)).toBe(0);
+    const shard = deriveCreatedAtShard("cap-1", 32);
+    expect(shard).toBeGreaterThanOrEqual(0);
+    expect(shard).toBeLessThan(32);
+    expect(() => deriveCreatedAtShard("cap-1", 0)).toThrow();
+    expect(() => deriveCreatedAtShard("cap-1", 2.5)).toThrow();
+  });
+});

--- a/server/tests/city-launch-snapshot.test.ts
+++ b/server/tests/city-launch-snapshot.test.ts
@@ -1,0 +1,129 @@
+// @vitest-environment node
+//
+// TTL snapshot cache for the shared city-launch feed inputs: within the TTL a
+// single Firestore fan-out (activations + per-city prospects + candidate
+// signals) serves every request, concurrent refreshes collapse into one
+// loader (single-flight), and an expired snapshot is reloaded.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const listCityLaunchActivations = vi.hoisted(() => vi.fn());
+const listCityLaunchProspects = vi.hoisted(() => vi.fn());
+const listCityLaunchCandidateSignals = vi.hoisted(() => vi.fn());
+
+vi.mock("../utils/cityLaunchLedgers", async () => {
+  const actual = await vi.importActual("../utils/cityLaunchLedgers");
+  return {
+    ...actual,
+    listCityLaunchActivations,
+    listCityLaunchProspects,
+    listCityLaunchCandidateSignals,
+  };
+});
+
+import {
+  __resetCityLaunchSnapshotForTests,
+  getCityLaunchSnapshot,
+} from "../utils/cityLaunchSnapshot";
+
+const activation = {
+  city: "Austin, TX",
+  citySlug: "austin-tx",
+  founderApproved: true,
+  status: "activation_ready",
+};
+
+beforeEach(() => {
+  __resetCityLaunchSnapshotForTests();
+  vi.stubEnv("BLUEPRINT_CITY_LAUNCH_SNAPSHOT_TTL_MS", "90000");
+  listCityLaunchActivations.mockReset().mockResolvedValue([activation]);
+  listCityLaunchProspects.mockReset().mockResolvedValue([
+    { id: "prospect-1", citySlug: "austin-tx", status: "approved", lat: 30.2, lng: -97.7 },
+  ]);
+  listCityLaunchCandidateSignals.mockReset().mockResolvedValue([
+    { id: "candidate-1", city: "Austin, TX", citySlug: "austin-tx", status: "queued", lat: 30.3, lng: -97.8 },
+  ]);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.useRealTimers();
+});
+
+describe("city launch snapshot cache", () => {
+  it("serves repeated requests from one load within the TTL", async () => {
+    const first = await getCityLaunchSnapshot();
+    const second = await getCityLaunchSnapshot();
+
+    expect(second).toBe(first);
+    expect(listCityLaunchActivations).toHaveBeenCalledTimes(1);
+    expect(listCityLaunchProspects).toHaveBeenCalledTimes(1);
+    expect(listCityLaunchCandidateSignals).toHaveBeenCalledTimes(1);
+    expect(first.prospectsByCitySlug.get("austin-tx")).toHaveLength(1);
+    expect(first.candidateSignals).toHaveLength(1);
+  });
+
+  it("reloads after the TTL expires", async () => {
+    vi.useFakeTimers();
+    const first = await getCityLaunchSnapshot();
+    await vi.advanceTimersByTimeAsync(89_000);
+    expect(await getCityLaunchSnapshot()).toBe(first);
+
+    await vi.advanceTimersByTimeAsync(2_000);
+    const reloaded = await getCityLaunchSnapshot();
+    expect(reloaded).not.toBe(first);
+    expect(listCityLaunchActivations).toHaveBeenCalledTimes(2);
+  });
+
+  it("collapses concurrent refreshes into a single in-flight load", async () => {
+    let releaseLoad: (value: (typeof activation)[]) => void = () => undefined;
+    listCityLaunchActivations.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          releaseLoad = resolve;
+        }),
+    );
+
+    const [first, second, third] = await (async () => {
+      const pending = Promise.all([
+        getCityLaunchSnapshot(),
+        getCityLaunchSnapshot(),
+        getCityLaunchSnapshot(),
+      ]);
+      releaseLoad([activation]);
+      return pending;
+    })();
+
+    expect(second).toBe(first);
+    expect(third).toBe(first);
+    expect(listCityLaunchActivations).toHaveBeenCalledTimes(1);
+  });
+
+  it("captures per-source errors instead of caching a rejection", async () => {
+    const prospectsError = new Error("prospects unavailable");
+    listCityLaunchActivations.mockResolvedValue([
+      activation,
+      { city: "Chicago, IL", citySlug: "chicago-il", founderApproved: true, status: "executing" },
+    ]);
+    listCityLaunchProspects.mockImplementation(async (city: string) => {
+      if (city === "Chicago, IL") {
+        throw prospectsError;
+      }
+      return [];
+    });
+    listCityLaunchCandidateSignals.mockRejectedValue(new Error("signals unavailable"));
+
+    const snapshot = await getCityLaunchSnapshot();
+    expect(snapshot.activationsError).toBeNull();
+    expect(snapshot.prospectErrorsByCitySlug.get("chicago-il")).toBe(prospectsError);
+    expect(snapshot.prospectsByCitySlug.get("austin-tx")).toEqual([]);
+    expect(snapshot.candidateSignals).toEqual([]);
+    expect(snapshot.candidateSignalsError).toBeInstanceOf(Error);
+  });
+
+  it("bypasses caching when the TTL is zero", async () => {
+    vi.stubEnv("BLUEPRINT_CITY_LAUNCH_SNAPSHOT_TTL_MS", "0");
+    await getCityLaunchSnapshot();
+    await getCityLaunchSnapshot();
+    expect(listCityLaunchActivations).toHaveBeenCalledTimes(2);
+  });
+});

--- a/server/tests/creator-capture-contract.test.ts
+++ b/server/tests/creator-capture-contract.test.ts
@@ -140,6 +140,9 @@ describe("creator capture registration contract", () => {
         rights_profile: "commercial_full",
         platform: "ios",
       });
+      // Firestore createdAt hotspot guard: deterministic capture-id hash shard
+      // (sha256("cap-1") % 16 === 10) written alongside created_at.
+      expect(doc.createdAtShard).toBe(10);
     } finally {
       await stopServer(server);
     }

--- a/server/tests/creator-earnings-aggregate.test.ts
+++ b/server/tests/creator-earnings-aggregate.test.ts
@@ -1,0 +1,404 @@
+// @vitest-environment node
+//
+// creatorEarningsAggregates/{creatorId} keeps lifetime per-status payout
+// totals so /earnings and disbursement reads stop scanning a creator's full
+// payout history. The aggregate is lazily backfilled from one full scan and
+// then maintained inside the same transactions that write creatorPayouts
+// entries — these tests cover create → increment, disburse/settle → bucket
+// moves, and the missing-aggregate backfill path.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type StoredDoc = Record<string, unknown>;
+
+const state = vi.hoisted(() => ({
+  docs: new Map<string, Record<string, unknown>>(),
+  txChain: Promise.resolve() as Promise<unknown>,
+}));
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function deepMerge(
+  target: Record<string, unknown>,
+  source: Record<string, unknown>,
+): Record<string, unknown> {
+  const merged: Record<string, unknown> = { ...target };
+  for (const [key, value] of Object.entries(source)) {
+    const existing = merged[key];
+    if (isPlainObject(existing) && isPlainObject(value)) {
+      merged[key] = deepMerge(existing, value);
+      continue;
+    }
+    merged[key] = clone(value);
+  }
+  return merged;
+}
+
+function docKey(collection: string, id: string): string {
+  return `${collection}/${id}`;
+}
+
+function readDoc(collection: string, id: string): StoredDoc | undefined {
+  const stored = state.docs.get(docKey(collection, id));
+  return stored ? clone(stored) : undefined;
+}
+
+function writeDoc(
+  collection: string,
+  id: string,
+  payload: StoredDoc,
+  options?: { merge?: boolean },
+) {
+  const existing = readDoc(collection, id) || {};
+  state.docs.set(
+    docKey(collection, id),
+    options?.merge ? deepMerge(existing, payload) : clone(payload),
+  );
+}
+
+function snapshotFor(collection: string, id: string) {
+  const data = readDoc(collection, id);
+  return {
+    id,
+    exists: Boolean(data),
+    data: () => (data ? clone(data) : undefined),
+  };
+}
+
+function refFor(collection: string, id: string) {
+  return {
+    id,
+    __collection: collection,
+    get: async () => snapshotFor(collection, id),
+    set: async (payload: StoredDoc, options?: { merge?: boolean }) =>
+      writeDoc(collection, id, payload, options),
+  };
+}
+
+type QueryFilter = { field: string; op: string; value: unknown };
+
+function matchesFilter(data: StoredDoc, filter: QueryFilter): boolean {
+  if (filter.op === "==") {
+    return data[filter.field] === filter.value;
+  }
+  if (filter.op === "in") {
+    return (
+      Array.isArray(filter.value) &&
+      (filter.value as unknown[]).includes(data[filter.field])
+    );
+  }
+  throw new Error(`Unsupported operator ${filter.op}`);
+}
+
+function runQuery(collection: string, filters: QueryFilter[]) {
+  const docs = Array.from(state.docs.entries())
+    .filter(([key, data]) => {
+      if (!key.startsWith(`${collection}/`)) {
+        return false;
+      }
+      return filters.every((filter) => matchesFilter(data, filter));
+    })
+    .map(([key, data]) => {
+      const id = key.slice(collection.length + 1);
+      return { id, data: () => clone(data), ref: refFor(collection, id) };
+    });
+  return { docs };
+}
+
+function makeQuery(collection: string, filters: QueryFilter[]) {
+  return {
+    __collection: collection,
+    __filters: filters,
+    where: (field: string, op: string, value: unknown) =>
+      makeQuery(collection, [...filters, { field, op, value }]),
+    get: async () => runQuery(collection, filters),
+  };
+}
+
+type MockRef = ReturnType<typeof refFor>;
+type MockQuery = ReturnType<typeof makeQuery>;
+
+const dbAdmin = {
+  collection: (collection: string) => ({
+    doc: (id: string) => refFor(collection, id),
+    where: (field: string, op: string, value: unknown) =>
+      makeQuery(collection, [{ field, op, value }]),
+  }),
+  // Serialized transactions with buffered writes, mirroring Firestore's
+  // serializable isolation. tx.get supports both document refs and queries
+  // (the aggregate backfill scans inside a transaction).
+  runTransaction: async <T>(
+    updateFn: (tx: {
+      get: (target: MockRef | MockQuery) => Promise<unknown>;
+      set: (ref: MockRef, payload: StoredDoc, options?: { merge?: boolean }) => void;
+    }) => Promise<T>,
+  ): Promise<T> => {
+    const run = state.txChain.then(async () => {
+      const writes: Array<() => void> = [];
+      const tx = {
+        get: async (target: MockRef | MockQuery) => {
+          if ("__filters" in target) {
+            return runQuery(target.__collection, target.__filters);
+          }
+          return snapshotFor(target.__collection, target.id);
+        },
+        set: (ref: MockRef, payload: StoredDoc, options?: { merge?: boolean }) => {
+          writes.push(() => writeDoc(ref.__collection, ref.id, payload, options));
+        },
+      };
+      const result = await updateFn(tx);
+      for (const write of writes) {
+        write();
+      }
+      return result;
+    });
+    state.txChain = run.catch(() => undefined);
+    return run;
+  },
+};
+
+vi.mock("../../client/src/lib/firebaseAdmin", () => ({
+  default: {},
+  dbAdmin,
+}));
+
+const FUNDED_RECOMMENDATION = {
+  status: "baseline",
+  base_payout_cents: 4500,
+  recommended_payout_cents: 4500,
+  payout_funding_policy: {
+    mode: "buyer_revenue_linked",
+    buyer_order_id: "order-paid-1",
+    realized_buyer_revenue_cents: 10000,
+  },
+  reasons: [],
+};
+
+async function upsertFundedPayout(captureId: string) {
+  const { upsertCreatorPayoutFromPipeline } = await import("../utils/accounting");
+  state.docs.set(docKey("capture_submissions", captureId), {
+    creator_id: "creator-123",
+    status: "submitted",
+    payout_cents: 0,
+  });
+  return upsertCreatorPayoutFromPipeline({
+    captureId,
+    sceneId: "scene-1",
+    captureJobId: "job-1",
+    buyerRequestId: "req-1",
+    siteSubmissionId: "site-1",
+    qualificationState: "qualified_ready",
+    opportunityState: "handoff_ready",
+    recommendation: FUNDED_RECOMMENDATION,
+    recommendationUri: "gs://bucket/payout.json",
+    stripeConnectAccountId: "acct_creator_123",
+  });
+}
+
+function seedPayout(params: {
+  id: string;
+  creatorId?: string;
+  status: string;
+  amountCents: number;
+}) {
+  state.docs.set(docKey("creatorPayouts", params.id), {
+    id: params.id,
+    creator_id: params.creatorId || "creator-123",
+    capture_id: params.id,
+    status: params.status,
+    approved_amount_cents: params.amountCents,
+    base_payout_cents: params.amountCents,
+    created_at: "2026-07-03T00:00:00.000Z",
+    updated_at: "2026-07-03T00:00:00.000Z",
+    approved_at: "2026-07-03T00:00:00.000Z",
+  });
+}
+
+beforeEach(() => {
+  state.docs.clear();
+  state.txChain = Promise.resolve();
+  vi.resetModules();
+});
+
+describe("creator earnings aggregate", () => {
+  it("backfills the aggregate from a one-time full scan when it is missing", async () => {
+    const { readCreatorEarningsAggregate, summarizeCreatorEarnings } = await import(
+      "../utils/accounting"
+    );
+
+    seedPayout({ id: "cap-paid", status: "paid", amountCents: 4500 });
+    seedPayout({ id: "cap-approved", status: "approved", amountCents: 2500 });
+    seedPayout({ id: "cap-review", status: "review_required", amountCents: 1000 });
+    seedPayout({
+      id: "cap-other-creator",
+      creatorId: "creator-999",
+      status: "paid",
+      amountCents: 9999,
+    });
+
+    const aggregate = await readCreatorEarningsAggregate("creator-123");
+    expect(aggregate.entry_count).toBe(3);
+    expect(aggregate.status_totals.paid).toEqual({
+      count: 1,
+      approved_amount_cents: 4500,
+    });
+    expect(aggregate.status_totals.approved).toEqual({
+      count: 1,
+      approved_amount_cents: 2500,
+    });
+    expect(summarizeCreatorEarnings(aggregate)).toEqual({
+      totalEarnedCents: 4500,
+      pendingPayoutCents: 3500,
+      scansCompleted: 2,
+    });
+
+    // The backfill materialized the aggregate document.
+    expect(readDoc("creatorEarningsAggregates", "creator-123")).toMatchObject({
+      creator_id: "creator-123",
+      entry_count: 3,
+    });
+
+    // Subsequent reads serve the stored aggregate, not a fresh scan.
+    seedPayout({ id: "cap-unseen", status: "paid", amountCents: 7777 });
+    const cached = await readCreatorEarningsAggregate("creator-123");
+    expect(cached.entry_count).toBe(3);
+  });
+
+  it("stays absent until first read, then the backfill captures earlier writes", async () => {
+    const { readCreatorEarningsAggregate } = await import("../utils/accounting");
+
+    await upsertFundedPayout("cap-1");
+    // Payout writes never create the aggregate on their own.
+    expect(readDoc("creatorEarningsAggregates", "creator-123")).toBeUndefined();
+
+    const aggregate = await readCreatorEarningsAggregate("creator-123");
+    expect(aggregate.entry_count).toBe(1);
+    expect(aggregate.status_totals.approved).toEqual({
+      count: 1,
+      approved_amount_cents: 4500,
+    });
+  });
+
+  it("increments the aggregate when a payout entry is created and re-upserts idempotently", async () => {
+    const { readCreatorEarningsAggregate } = await import("../utils/accounting");
+
+    // Materialize an empty aggregate first so deltas maintain it.
+    await readCreatorEarningsAggregate("creator-123");
+
+    await upsertFundedPayout("cap-1");
+    let aggregate = await readCreatorEarningsAggregate("creator-123");
+    expect(aggregate.entry_count).toBe(1);
+    expect(aggregate.status_totals.approved).toEqual({
+      count: 1,
+      approved_amount_cents: 4500,
+    });
+
+    // Re-running the pipeline upsert replaces the previous slice instead of
+    // double counting.
+    await upsertFundedPayout("cap-1");
+    aggregate = await readCreatorEarningsAggregate("creator-123");
+    expect(aggregate.entry_count).toBe(1);
+    expect(aggregate.status_totals.approved).toEqual({
+      count: 1,
+      approved_amount_cents: 4500,
+    });
+  });
+
+  it("moves buckets approved -> in_transit -> paid across disbursement and settlement", async () => {
+    const {
+      applyCreatorPayoutWebhook,
+      beginCreatorPayoutDisbursement,
+      finalizeCreatorPayoutDisbursement,
+      readCreatorEarningsAggregate,
+      summarizeCreatorEarnings,
+    } = await import("../utils/accounting");
+
+    await readCreatorEarningsAggregate("creator-123");
+    await upsertFundedPayout("cap-1");
+
+    const disbursement = await beginCreatorPayoutDisbursement({
+      creatorId: "creator-123",
+      stripeConnectAccountId: "acct_creator_123",
+    });
+    expect(disbursement).not.toBeNull();
+
+    let aggregate = await readCreatorEarningsAggregate("creator-123");
+    expect(aggregate.status_totals.approved).toEqual({
+      count: 0,
+      approved_amount_cents: 0,
+    });
+    expect(aggregate.status_totals.in_transit).toEqual({
+      count: 1,
+      approved_amount_cents: 4500,
+    });
+    expect(aggregate.entry_count).toBe(1);
+
+    await finalizeCreatorPayoutDisbursement({
+      disbursementId: disbursement!.disbursement.id,
+      stripePayoutId: "po_test_123",
+    });
+    await applyCreatorPayoutWebhook({
+      stripePayoutId: "po_test_123",
+      eventId: "evt_payout_paid_1",
+      eventType: "payout.paid",
+      status: "paid",
+    });
+
+    aggregate = await readCreatorEarningsAggregate("creator-123");
+    expect(aggregate.status_totals.in_transit).toEqual({
+      count: 0,
+      approved_amount_cents: 0,
+    });
+    expect(aggregate.status_totals.paid).toEqual({
+      count: 1,
+      approved_amount_cents: 4500,
+    });
+    expect(summarizeCreatorEarnings(aggregate)).toEqual({
+      totalEarnedCents: 4500,
+      pendingPayoutCents: 0,
+      scansCompleted: 1,
+    });
+  });
+
+  it("moves buckets to disbursement_failed when a disbursement fails", async () => {
+    const { failCreatorPayoutDisbursement, readCreatorEarningsAggregate } = await import(
+      "../utils/accounting"
+    );
+
+    seedPayout({ id: "cap-1", status: "in_transit", amountCents: 4500 });
+    state.docs.set(docKey("creatorPayoutDisbursements", "disb-1"), {
+      id: "disb-1",
+      creator_id: "creator-123",
+      stripe_connect_account_id: "acct_creator_123",
+      payout_entry_ids: ["cap-1"],
+      status: "in_transit",
+      created_at: "2026-07-03T00:00:00.000Z",
+      updated_at: "2026-07-03T00:00:00.000Z",
+    });
+    await readCreatorEarningsAggregate("creator-123");
+
+    await failCreatorPayoutDisbursement({
+      disbursementId: "disb-1",
+      reason: "stripe transfer failed",
+    });
+
+    const aggregate = await readCreatorEarningsAggregate("creator-123");
+    expect(aggregate.status_totals.in_transit).toEqual({
+      count: 0,
+      approved_amount_cents: 0,
+    });
+    expect(aggregate.status_totals.disbursement_failed).toEqual({
+      count: 1,
+      approved_amount_cents: 4500,
+    });
+    expect(aggregate.entry_count).toBe(1);
+    expect(readDoc("creatorPayouts", "cap-1")).toMatchObject({
+      status: "disbursement_failed",
+    });
+  });
+});

--- a/server/tests/creator-payout-double-pay.test.ts
+++ b/server/tests/creator-payout-double-pay.test.ts
@@ -94,32 +94,51 @@ function refFor(collection: string, id: string) {
   };
 }
 
+type QueryFilter = { field: string; op: string; value: unknown };
+
+function matchesFilter(data: StoredDoc, filter: QueryFilter): boolean {
+  if (filter.op === "==") {
+    return data[filter.field] === filter.value;
+  }
+  if (filter.op === "in") {
+    return (
+      Array.isArray(filter.value) &&
+      (filter.value as unknown[]).includes(data[filter.field])
+    );
+  }
+  throw new Error(`Unsupported operator ${filter.op}`);
+}
+
+function makeQuery(collectionName: string, filters: QueryFilter[]) {
+  return {
+    where: (field: string, op: string, value: unknown) =>
+      makeQuery(collectionName, [...filters, { field, op, value }]),
+    get: async () => {
+      const docs = Array.from(state.docs.entries())
+        .filter(([key, data]) => {
+          if (!key.startsWith(`${collectionName}/`)) {
+            return false;
+          }
+          return filters.every((filter) => matchesFilter(data, filter));
+        })
+        .map(([key, data]) => {
+          const id = key.slice(collectionName.length + 1);
+          return {
+            id,
+            data: () => clone(data),
+            ref: refFor(collectionName, id),
+          };
+        });
+      return { docs };
+    },
+  };
+}
+
 function makeCollection(collectionName: string) {
   return {
     doc: (id: string) => refFor(collectionName, id),
-    where: (field: string, op: string, value: unknown) => ({
-      get: async () => {
-        if (op !== "==") {
-          throw new Error(`Unsupported operator ${op}`);
-        }
-        const docs = Array.from(state.docs.entries())
-          .filter(([key, data]) => {
-            if (!key.startsWith(`${collectionName}/`)) {
-              return false;
-            }
-            return data[field] === value;
-          })
-          .map(([key, data]) => {
-            const id = key.slice(collectionName.length + 1);
-            return {
-              id,
-              data: () => clone(data),
-              ref: refFor(collectionName, id),
-            };
-          });
-        return { docs };
-      },
-    }),
+    where: (field: string, op: string, value: unknown) =>
+      makeQuery(collectionName, [{ field, op, value }]),
   };
 }
 

--- a/server/tests/creator-payout-launch-gate.test.ts
+++ b/server/tests/creator-payout-launch-gate.test.ts
@@ -9,8 +9,11 @@ const state = vi.hoisted(() => ({
   betaCohortAdmissions: new Map<string, Record<string, unknown>>(),
 }));
 
-vi.mock("../utils/accounting", () => ({
-  listCreatorPayouts: vi.fn(async (creatorId: string) =>
+vi.mock("../utils/accounting", async () => {
+  const actual = await vi.importActual<typeof import("../utils/accounting")>(
+    "../utils/accounting",
+  );
+  const listCreatorPayouts = vi.fn(async (creatorId: string) =>
     Array.from(state.creatorCaptures.values())
       .filter((payload) => payload.creator_id === creatorId)
       .map((payload) => ({
@@ -23,11 +26,23 @@ vi.mock("../utils/accounting", () => ({
         paid_at: String(payload.status || "") === "paid" ? String(payload.captured_at || "") : null,
         updated_at: String(payload.captured_at || ""),
       })),
-  ),
-  mapCreatorPayoutStatusForLedger: vi.fn((status: string) =>
-    status === "paid" ? "paid" : "pending",
-  ),
-}));
+  );
+  return {
+    listCreatorPayouts,
+    mapCreatorPayoutStatusForLedger: vi.fn((status: string) =>
+      status === "paid" ? "paid" : "pending",
+    ),
+    summarizeCreatorEarnings: actual.summarizeCreatorEarnings,
+    readCreatorEarningsAggregate: vi.fn(async (creatorId: string) =>
+      actual.buildCreatorEarningsAggregateFromEntries(
+        creatorId,
+        (await listCreatorPayouts(creatorId)) as unknown as Parameters<
+          typeof actual.buildCreatorEarningsAggregateFromEntries
+        >[1],
+      ),
+    ),
+  };
+});
 
 vi.mock("../../client/src/lib/firebaseAdmin", () => {
   const collectionStore = (name: string) => {

--- a/server/tests/inbound-request-stats.test.ts
+++ b/server/tests/inbound-request-stats.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../client/src/lib/firebaseAdmin", () => ({
+  default: {
+    firestore: {
+      FieldValue: {
+        increment: (value: number) => ({ __increment: value }),
+        serverTimestamp: () => ({ __serverTimestamp: true }),
+      },
+    },
+  },
+  dbAdmin: null,
+}));
+
+import {
+  INBOUND_REQUEST_STATS_SHARD_COUNT,
+  incrementInboundRequestStats,
+  pickInboundRequestStatsShard,
+  readInboundRequestStats,
+} from "../utils/inboundRequestStats";
+
+class FakeTimestamp {
+  constructor(
+    public _seconds: number,
+    public _nanoseconds: number,
+  ) {}
+}
+
+function fakeDb(options: {
+  baseData?: Record<string, unknown> | null;
+  shardDocs?: Array<Record<string, unknown>>;
+  onShardSet?: (docId: string, payload: Record<string, unknown>) => void;
+}) {
+  const shardsCollection = {
+    doc: (docId: string) => ({
+      set: async (payload: Record<string, unknown>, opts: unknown) => {
+        expect(opts).toEqual({ merge: true });
+        options.onShardSet?.(docId, payload);
+      },
+    }),
+    get: async () => ({
+      docs: (options.shardDocs ?? []).map((data) => ({ data: () => data })),
+    }),
+  };
+  const baseDoc = {
+    get: async () => ({
+      exists: options.baseData != null,
+      data: () => options.baseData ?? undefined,
+    }),
+    collection: (name: string) => {
+      expect(name).toBe("shards");
+      return shardsCollection;
+    },
+  };
+  return {
+    collection: (name: string) => {
+      expect(name).toBe("stats");
+      return { doc: (id: string) => (expect(id).toBe("inboundRequests"), baseDoc) };
+    },
+  } as never;
+}
+
+describe("pickInboundRequestStatsShard", () => {
+  it("always lands inside the shard range", () => {
+    expect(pickInboundRequestStatsShard(() => 0)).toBe("0");
+    expect(pickInboundRequestStatsShard(() => 0.999999)).toBe(
+      String(INBOUND_REQUEST_STATS_SHARD_COUNT - 1),
+    );
+  });
+});
+
+describe("incrementInboundRequestStats", () => {
+  it("writes increments and a timestamp to one shard", async () => {
+    const writes: Array<{ docId: string; payload: Record<string, unknown> }> = [];
+    const db = fakeDb({
+      onShardSet: (docId, payload) => writes.push({ docId, payload }),
+    });
+
+    await incrementInboundRequestStats(
+      db,
+      { total: 1, "byStatus.submitted": 1, "byStatus.in_review": -1 },
+      () => 0.5,
+    );
+
+    expect(writes).toHaveLength(1);
+    expect(writes[0].docId).toBe(String(Math.floor(0.5 * INBOUND_REQUEST_STATS_SHARD_COUNT)));
+    expect(writes[0].payload).toEqual({
+      updatedAt: { __serverTimestamp: true },
+      total: { __increment: 1 },
+      "byStatus.submitted": { __increment: 1 },
+      "byStatus.in_review": { __increment: -1 },
+    });
+  });
+});
+
+describe("readInboundRequestStats", () => {
+  it("sums the legacy base doc with every shard, keeping non-numeric base fields", async () => {
+    const db = fakeDb({
+      baseData: {
+        total: 100,
+        byStatus: { submitted: 60, in_review: 40 },
+        updatedAt: new FakeTimestamp(1, 2),
+      },
+      shardDocs: [
+        { total: 3, byStatus: { submitted: 2, qa_passed: 1 }, updatedAt: new FakeTimestamp(3, 4) },
+        { total: 1, byStatus: { in_review: -1 }, byPriority: { high: 1 } },
+      ],
+    });
+
+    const stats = (await readInboundRequestStats(db)) as Record<string, any>;
+
+    expect(stats.total).toBe(104);
+    expect(stats.byStatus).toEqual({ submitted: 62, in_review: 39, qa_passed: 1 });
+    expect(stats.byPriority).toEqual({ high: 1 });
+    expect(stats.updatedAt).toBeInstanceOf(FakeTimestamp);
+    expect((stats.updatedAt as FakeTimestamp)._seconds).toBe(1);
+  });
+
+  it("returns shard-only sums when the base doc is missing", async () => {
+    const db = fakeDb({
+      baseData: null,
+      shardDocs: [{ total: 2, byStatus: { submitted: 2 } }],
+    });
+    const stats = (await readInboundRequestStats(db)) as Record<string, any>;
+    expect(stats.total).toBe(2);
+    expect(stats.byStatus).toEqual({ submitted: 2 });
+  });
+});

--- a/server/utils/accounting.ts
+++ b/server/utils/accounting.ts
@@ -7,6 +7,7 @@ const BUYER_ORDER_COLLECTION = "buyerOrders";
 const BUYER_ENTITLEMENT_COLLECTION = "marketplaceEntitlements";
 const CREATOR_PAYOUT_COLLECTION = "creatorPayouts";
 const CREATOR_PAYOUT_DISBURSEMENT_COLLECTION = "creatorPayoutDisbursements";
+const CREATOR_EARNINGS_AGGREGATE_COLLECTION = "creatorEarningsAggregates";
 const STRIPE_WEBHOOK_EVENT_COLLECTION = "stripeWebhookEvents";
 const STRIPE_CHECKOUT_LINK_COLLECTION = "stripeCheckoutSessions";
 const STRIPE_PAYMENT_INTENT_LINK_COLLECTION = "stripePaymentIntents";
@@ -213,6 +214,25 @@ export type CreatorPayoutDisbursementRecord = {
   failure_reason: string | null;
   last_webhook_event_id: string | null;
   last_webhook_event_type: string | null;
+};
+
+export type CreatorEarningsStatusTotals = Partial<
+  Record<CreatorPayoutStatus, { count: number; approved_amount_cents: number }>
+>;
+
+/**
+ * Running lifetime totals per payout status for one creator, maintained
+ * transactionally with every creatorPayouts write and lazily backfilled from a
+ * one-time history scan. Earnings/ledger reads use this instead of scanning
+ * the creator's full payout history per request.
+ */
+export type CreatorEarningsAggregateRecord = {
+  creator_id: string;
+  schema: "blueprint/creator-earnings-aggregate/v1";
+  status_totals: CreatorEarningsStatusTotals;
+  entry_count: number;
+  backfilled_at: string;
+  updated_at: string;
 };
 
 type BuyerOrderDraftInput = {
@@ -1061,24 +1081,25 @@ export async function markBuyerOrderDisputedFromCharge(params: {
     "held_for_dispute",
   ]);
 
+  const firestore = db;
   for (const captureId of captureIds) {
-    const payoutSnapshot = await db
-      .collection(CREATOR_PAYOUT_COLLECTION)
-      .doc(captureId)
-      .get();
-    if (!payoutSnapshot.exists) {
-      continue;
-    }
-    const payout = copyCreatorPayout(payoutSnapshot.data() as Record<string, unknown>);
-    if (!holdableStatuses.has(payout.status)) {
-      unresolvedPayoutIds.push(payout.id);
-      continue;
-    }
+    const payoutRef = firestore.collection(CREATOR_PAYOUT_COLLECTION).doc(captureId);
+    const result = await firestore.runTransaction<
+      { outcome: "missing" } | { outcome: "held" | "unresolved"; payoutId: string }
+    >(async (tx) => {
+      const payoutSnapshot = await tx.get(payoutRef);
+      if (!payoutSnapshot.exists) {
+        return { outcome: "missing" };
+      }
+      const payout = copyCreatorPayout(payoutSnapshot.data() as Record<string, unknown>);
+      const aggregateRef = earningsAggregateRef(firestore, payout.creator_id);
+      const aggregateSnapshot = await tx.get(aggregateRef);
+      if (!holdableStatuses.has(payout.status)) {
+        return { outcome: "unresolved", payoutId: payout.id };
+      }
 
-    await db
-      .collection(CREATOR_PAYOUT_COLLECTION)
-      .doc(payout.id)
-      .set(
+      tx.set(
+        firestore.collection(CREATOR_PAYOUT_COLLECTION).doc(payout.id),
         {
           status: "held_for_dispute",
           failure_reason: "Buyer payment dispute opened before payout settlement.",
@@ -1093,7 +1114,29 @@ export async function markBuyerOrderDisputedFromCharge(params: {
         },
         { merge: true },
       );
-    heldPayoutIds.push(payout.id);
+      updateEarningsAggregateInTx({
+        tx,
+        ref: aggregateRef,
+        snapshot: aggregateSnapshot,
+        creatorId: payout.creator_id,
+        changes: [
+          {
+            previous: payoutAggregateSlice(payout),
+            next: {
+              status: "held_for_dispute",
+              approvedAmountCents: payout.approved_amount_cents,
+            },
+          },
+        ],
+      });
+      return { outcome: "held", payoutId: payout.id };
+    });
+
+    if (result.outcome === "held") {
+      heldPayoutIds.push(result.payoutId);
+    } else if (result.outcome === "unresolved") {
+      unresolvedPayoutIds.push(result.payoutId);
+    }
   }
 
   await db
@@ -1456,6 +1499,219 @@ function buildPayoutDisbursementFundingReport(
   };
 }
 
+type PayoutAggregateSlice = {
+  status: CreatorPayoutStatus;
+  approvedAmountCents: number;
+};
+
+function payoutAggregateSlice(entry: CreatorPayoutRecord): PayoutAggregateSlice {
+  return {
+    status: entry.status,
+    approvedAmountCents: entry.approved_amount_cents,
+  };
+}
+
+function emptyCreatorEarningsAggregate(
+  creatorId: string,
+): CreatorEarningsAggregateRecord {
+  const timestamp = nowIso();
+  return {
+    creator_id: creatorId,
+    schema: "blueprint/creator-earnings-aggregate/v1",
+    status_totals: {},
+    entry_count: 0,
+    backfilled_at: timestamp,
+    updated_at: timestamp,
+  };
+}
+
+function copyCreatorEarningsAggregate(
+  creatorId: string,
+  value: Record<string, unknown> | undefined,
+): CreatorEarningsAggregateRecord {
+  const data = value || {};
+  const statusTotals: CreatorEarningsStatusTotals = {};
+  for (const [status, bucket] of Object.entries(toRecord(data.status_totals))) {
+    const record = toRecord(bucket);
+    statusTotals[status as CreatorPayoutStatus] = {
+      count: Math.max(0, Math.floor(asNumber(record.count))),
+      approved_amount_cents: Math.max(
+        0,
+        Math.floor(asNumber(record.approved_amount_cents)),
+      ),
+    };
+  }
+  return {
+    creator_id: asString(data.creator_id) || creatorId,
+    schema: "blueprint/creator-earnings-aggregate/v1",
+    status_totals: statusTotals,
+    entry_count: Math.max(0, Math.floor(asNumber(data.entry_count))),
+    backfilled_at: asString(data.backfilled_at) || nowIso(),
+    updated_at: asString(data.updated_at) || nowIso(),
+  };
+}
+
+function applyEarningsAggregateChange(
+  aggregate: CreatorEarningsAggregateRecord,
+  previous: PayoutAggregateSlice | null,
+  next: PayoutAggregateSlice | null,
+): CreatorEarningsAggregateRecord {
+  const statusTotals: CreatorEarningsStatusTotals = { ...aggregate.status_totals };
+  const adjust = (slice: PayoutAggregateSlice, direction: 1 | -1) => {
+    const bucket = statusTotals[slice.status] || {
+      count: 0,
+      approved_amount_cents: 0,
+    };
+    statusTotals[slice.status] = {
+      count: Math.max(0, bucket.count + direction),
+      approved_amount_cents: Math.max(
+        0,
+        bucket.approved_amount_cents +
+          direction * Math.max(0, Math.floor(slice.approvedAmountCents)),
+      ),
+    };
+  };
+  if (previous) {
+    adjust(previous, -1);
+  }
+  if (next) {
+    adjust(next, 1);
+  }
+  return {
+    ...aggregate,
+    status_totals: statusTotals,
+    entry_count: Math.max(
+      0,
+      aggregate.entry_count - (previous ? 1 : 0) + (next ? 1 : 0),
+    ),
+    updated_at: nowIso(),
+  };
+}
+
+export function buildCreatorEarningsAggregateFromEntries(
+  creatorId: string,
+  entries: CreatorPayoutRecord[],
+): CreatorEarningsAggregateRecord {
+  return entries.reduce(
+    (aggregate, entry) =>
+      applyEarningsAggregateChange(aggregate, null, payoutAggregateSlice(entry)),
+    emptyCreatorEarningsAggregate(creatorId),
+  );
+}
+
+function earningsAggregateRef(
+  firestore: NonNullable<typeof db>,
+  creatorId: string,
+) {
+  return firestore
+    .collection(CREATOR_EARNINGS_AGGREGATE_COLLECTION)
+    .doc(creatorId);
+}
+
+function updateEarningsAggregateInTx(params: {
+  tx: FirebaseFirestore.Transaction;
+  ref: FirebaseFirestore.DocumentReference;
+  snapshot: FirebaseFirestore.DocumentSnapshot;
+  creatorId: string;
+  changes: Array<{
+    previous: PayoutAggregateSlice | null;
+    next: PayoutAggregateSlice | null;
+  }>;
+}) {
+  // The aggregate is only maintained once the lazy backfill materialized it;
+  // until then the backfill scan will observe these writes directly.
+  if (!params.snapshot.exists || params.changes.length === 0) {
+    return;
+  }
+  let aggregate = copyCreatorEarningsAggregate(
+    params.creatorId,
+    params.snapshot.data() as Record<string, unknown> | undefined,
+  );
+  for (const change of params.changes) {
+    aggregate = applyEarningsAggregateChange(
+      aggregate,
+      change.previous,
+      change.next,
+    );
+  }
+  params.tx.set(params.ref, aggregate);
+}
+
+export async function readCreatorEarningsAggregate(
+  creatorId: string,
+): Promise<CreatorEarningsAggregateRecord> {
+  if (!db || !creatorId) {
+    return emptyCreatorEarningsAggregate(creatorId);
+  }
+  const firestore = db;
+  const ref = earningsAggregateRef(firestore, creatorId);
+
+  const snapshot = await ref.get();
+  if (snapshot.exists) {
+    return copyCreatorEarningsAggregate(
+      creatorId,
+      snapshot.data() as Record<string, unknown> | undefined,
+    );
+  }
+
+  // Lazy backfill: one full history scan inside a transaction; from then on
+  // every payout write maintains the aggregate incrementally.
+  return firestore.runTransaction(async (tx) => {
+    const existing = await tx.get(ref);
+    if (existing.exists) {
+      return copyCreatorEarningsAggregate(
+        creatorId,
+        existing.data() as Record<string, unknown> | undefined,
+      );
+    }
+    const payoutSnapshot = await tx.get(
+      firestore
+        .collection(CREATOR_PAYOUT_COLLECTION)
+        .where("creator_id", "==", creatorId),
+    );
+    const aggregate = buildCreatorEarningsAggregateFromEntries(
+      creatorId,
+      payoutSnapshot.docs.map((doc) =>
+        copyCreatorPayout(doc.data() as Record<string, unknown>),
+      ),
+    );
+    tx.set(ref, aggregate);
+    return aggregate;
+  });
+}
+
+export function summarizeCreatorEarnings(
+  aggregate: CreatorEarningsAggregateRecord,
+): {
+  totalEarnedCents: number;
+  pendingPayoutCents: number;
+  scansCompleted: number;
+} {
+  const bucket = (status: CreatorPayoutStatus) =>
+    aggregate.status_totals[status] || { count: 0, approved_amount_cents: 0 };
+  const pendingStatuses: CreatorPayoutStatus[] = [
+    "approved",
+    "in_transit",
+    "review_required",
+  ];
+  const completedStatuses: CreatorPayoutStatus[] = [
+    "approved",
+    "in_transit",
+    "paid",
+  ];
+  return {
+    totalEarnedCents: bucket("paid").approved_amount_cents,
+    pendingPayoutCents: pendingStatuses.reduce(
+      (sum, status) => sum + bucket(status).approved_amount_cents,
+      0,
+    ),
+    scansCompleted: completedStatuses.reduce(
+      (sum, status) => sum + bucket(status).count,
+      0,
+    ),
+  };
+}
+
 export async function upsertCreatorPayoutFromPipeline(params: {
   captureId: string;
   sceneId: string | null;
@@ -1477,14 +1733,7 @@ export async function upsertCreatorPayoutFromPipeline(params: {
     return null;
   }
 
-  const existingSnapshot = await db
-    .collection(CREATOR_PAYOUT_COLLECTION)
-    .doc(params.captureId)
-    .get();
-  const existing = existingSnapshot.exists
-    ? copyCreatorPayout(existingSnapshot.data() as Record<string, unknown>)
-    : null;
-
+  const firestore = db;
   const recommendationStatus = asString(params.recommendation.status);
   const basePayoutCents = Math.max(
     0,
@@ -1502,81 +1751,110 @@ export async function upsertCreatorPayoutFromPipeline(params: {
     ? verifiedPayoutFundingPolicy(params.recommendation, basePayoutCents)
     : notRequiredPayoutFunding();
 
-  let nextStatus: CreatorPayoutStatus = "pending_qualification";
-  if (!isQualifiedReady) {
-    nextStatus = "pending_qualification";
-  } else if (recommendationStatus === "review_required") {
-    nextStatus = "review_required";
-  } else if (basePayoutCents <= 0) {
-    nextStatus = "ineligible";
-  } else if (funding.status !== "verified") {
-    nextStatus = "review_required";
-  } else {
-    nextStatus = "approved";
-  }
-
-  const preservesSettledStatus = Boolean(
-    existing && ["in_transit", "paid"].includes(existing.status),
-  );
-  if (preservesSettledStatus) {
-    nextStatus = existing!.status;
-  }
-  const payloadFunding = preservesSettledStatus
-    ? {
-        policy: existing!.payout_funding_policy,
-        status: existing!.funding_status,
-        blockers: existing!.funding_blockers,
-        reconciliation: existing!.payout_funding_reconciliation,
-      }
-    : funding;
-
-  const approvedAt =
-    nextStatus === "approved" || nextStatus === "in_transit" || nextStatus === "paid"
-      ? existing?.approved_at || nowIso()
-      : existing?.approved_at || null;
-
-  const payload: CreatorPayoutRecord = {
-    id: params.captureId,
-    creator_id: creatorId,
-    capture_id: params.captureId,
-    scene_id: params.sceneId,
-    capture_job_id: params.captureJobId,
-    buyer_request_id: params.buyerRequestId,
-    site_submission_id: params.siteSubmissionId,
-    qualification_state: params.qualificationState,
-    opportunity_state: params.opportunityState,
-    status: nextStatus,
-    recommended_status: recommendationStatus,
-    base_payout_cents: Math.max(
-      0,
-      Math.floor(asNumber(params.recommendation.base_payout_cents)),
-    ),
-    approved_amount_cents: basePayoutCents,
-    recommendation: params.recommendation,
-    recommendation_uri: params.recommendationUri,
-    payout_funding_policy: payloadFunding.policy,
-    funding_status: payloadFunding.status,
-    funding_blockers: payloadFunding.blockers,
-    payout_funding_reconciliation: payloadFunding.reconciliation,
-    stripe_connect_account_id:
-      params.stripeConnectAccountId || existing?.stripe_connect_account_id || null,
-    disbursement_id: existing?.disbursement_id || null,
-    stripe_payout_id: existing?.stripe_payout_id || null,
-    last_webhook_event_id: existing?.last_webhook_event_id || null,
-    last_webhook_event_type: existing?.last_webhook_event_type || null,
-    failure_reason:
-      payloadFunding.blockers[0] ||
-      (nextStatus === "approved" ? null : existing?.failure_reason || null),
-    created_at: existing?.created_at || nowIso(),
-    updated_at: nowIso(),
-    approved_at: approvedAt,
-    paid_at: existing?.paid_at || null,
-  };
-
-  await db
+  const payoutRef = firestore
     .collection(CREATOR_PAYOUT_COLLECTION)
-    .doc(params.captureId)
-    .set(payload, { merge: true });
+    .doc(params.captureId);
+  const aggregateRef = earningsAggregateRef(firestore, creatorId);
+
+  // The payout entry and the creator earnings aggregate move together in one
+  // transaction so the aggregate can never drift from the ledger.
+  const payload = await firestore.runTransaction<CreatorPayoutRecord>(async (tx) => {
+    const [existingSnapshot, aggregateSnapshot] = await Promise.all([
+      tx.get(payoutRef),
+      tx.get(aggregateRef),
+    ]);
+    const existing = existingSnapshot.exists
+      ? copyCreatorPayout(existingSnapshot.data() as Record<string, unknown>)
+      : null;
+
+    let nextStatus: CreatorPayoutStatus = "pending_qualification";
+    if (!isQualifiedReady) {
+      nextStatus = "pending_qualification";
+    } else if (recommendationStatus === "review_required") {
+      nextStatus = "review_required";
+    } else if (basePayoutCents <= 0) {
+      nextStatus = "ineligible";
+    } else if (funding.status !== "verified") {
+      nextStatus = "review_required";
+    } else {
+      nextStatus = "approved";
+    }
+
+    const preservesSettledStatus = Boolean(
+      existing && ["in_transit", "paid"].includes(existing.status),
+    );
+    if (preservesSettledStatus) {
+      nextStatus = existing!.status;
+    }
+    const payloadFunding = preservesSettledStatus
+      ? {
+          policy: existing!.payout_funding_policy,
+          status: existing!.funding_status,
+          blockers: existing!.funding_blockers,
+          reconciliation: existing!.payout_funding_reconciliation,
+        }
+      : funding;
+
+    const approvedAt =
+      nextStatus === "approved" || nextStatus === "in_transit" || nextStatus === "paid"
+        ? existing?.approved_at || nowIso()
+        : existing?.approved_at || null;
+
+    const nextPayload: CreatorPayoutRecord = {
+      id: params.captureId,
+      creator_id: creatorId,
+      capture_id: params.captureId,
+      scene_id: params.sceneId,
+      capture_job_id: params.captureJobId,
+      buyer_request_id: params.buyerRequestId,
+      site_submission_id: params.siteSubmissionId,
+      qualification_state: params.qualificationState,
+      opportunity_state: params.opportunityState,
+      status: nextStatus,
+      recommended_status: recommendationStatus,
+      base_payout_cents: Math.max(
+        0,
+        Math.floor(asNumber(params.recommendation.base_payout_cents)),
+      ),
+      approved_amount_cents: basePayoutCents,
+      recommendation: params.recommendation,
+      recommendation_uri: params.recommendationUri,
+      payout_funding_policy: payloadFunding.policy,
+      funding_status: payloadFunding.status,
+      funding_blockers: payloadFunding.blockers,
+      payout_funding_reconciliation: payloadFunding.reconciliation,
+      stripe_connect_account_id:
+        params.stripeConnectAccountId || existing?.stripe_connect_account_id || null,
+      disbursement_id: existing?.disbursement_id || null,
+      stripe_payout_id: existing?.stripe_payout_id || null,
+      last_webhook_event_id: existing?.last_webhook_event_id || null,
+      last_webhook_event_type: existing?.last_webhook_event_type || null,
+      failure_reason:
+        payloadFunding.blockers[0] ||
+        (nextStatus === "approved" ? null : existing?.failure_reason || null),
+      created_at: existing?.created_at || nowIso(),
+      updated_at: nowIso(),
+      approved_at: approvedAt,
+      paid_at: existing?.paid_at || null,
+    };
+
+    tx.set(payoutRef, nextPayload, { merge: true });
+    updateEarningsAggregateInTx({
+      tx,
+      ref: aggregateRef,
+      snapshot: aggregateSnapshot,
+      creatorId,
+      changes: [
+        {
+          previous: existing ? payoutAggregateSlice(existing) : null,
+          next: payoutAggregateSlice(nextPayload),
+        },
+      ],
+    });
+    return nextPayload;
+  });
+
+  const nextStatus = payload.status;
 
   if (nextStatus === "approved") {
     await updateCreatorCaptureProjection({
@@ -1590,7 +1868,7 @@ export async function upsertCreatorPayoutFromPipeline(params: {
       creatorId,
       status: "approved",
       payoutCents: basePayoutCents,
-      approvedAt,
+      approvedAt: payload.approved_at,
     });
   } else if (["pending_qualification", "review_required"].includes(nextStatus)) {
     await updateCreatorCaptureProjection({
@@ -1610,7 +1888,45 @@ export async function upsertCreatorPayoutFromPipeline(params: {
   return payload;
 }
 
+function sortCreatorPayoutsByRecency(entries: CreatorPayoutRecord[]) {
+  return entries.sort((a, b) => {
+    const aTime = new Date(a.paid_at || a.approved_at || a.updated_at).getTime();
+    const bTime = new Date(b.paid_at || b.approved_at || b.updated_at).getTime();
+    return bTime - aTime;
+  });
+}
+
 export async function listCreatorPayouts(
+  creatorId: string,
+  options?: { limit?: number },
+): Promise<CreatorPayoutRecord[]> {
+  if (!db || !creatorId) {
+    return [];
+  }
+
+  let query: FirebaseFirestore.Query = db
+    .collection(CREATOR_PAYOUT_COLLECTION)
+    .where("creator_id", "==", creatorId);
+  const limit = Math.trunc(options?.limit ?? 0);
+  if (limit > 0) {
+    // Bounded recency window (creator_id + updated_at composite index) so the
+    // read stops scaling with creator tenure. Every payout write refreshes
+    // updated_at, so the newest entries always land in the window.
+    query = query.orderBy("updated_at", "desc").limit(limit);
+  }
+  const snapshot = await query.get();
+
+  return sortCreatorPayoutsByRecency(
+    snapshot.docs.map((doc) => copyCreatorPayout(doc.data() as Record<string, unknown>)),
+  );
+}
+
+const PAYABLE_PAYOUT_STATUSES: CreatorPayoutStatus[] = [
+  "approved",
+  "disbursement_failed",
+];
+
+async function listPayableCreatorPayouts(
   creatorId: string,
 ): Promise<CreatorPayoutRecord[]> {
   if (!db || !creatorId) {
@@ -1620,15 +1936,12 @@ export async function listCreatorPayouts(
   const snapshot = await db
     .collection(CREATOR_PAYOUT_COLLECTION)
     .where("creator_id", "==", creatorId)
+    .where("status", "in", PAYABLE_PAYOUT_STATUSES)
     .get();
 
-  return snapshot.docs
-    .map((doc) => copyCreatorPayout(doc.data() as Record<string, unknown>))
-    .sort((a, b) => {
-      const aTime = new Date(a.paid_at || a.approved_at || a.updated_at).getTime();
-      const bTime = new Date(b.paid_at || b.approved_at || b.updated_at).getTime();
-      return bTime - aTime;
-    });
+  return sortCreatorPayoutsByRecency(
+    snapshot.docs.map((doc) => copyCreatorPayout(doc.data() as Record<string, unknown>)),
+  );
 }
 
 export function mapCreatorPayoutStatusForLedger(
@@ -1662,6 +1975,7 @@ export async function beginCreatorPayoutDisbursement(params: {
   const existingDisbursementSnapshot = await firestore
     .collection(CREATOR_PAYOUT_DISBURSEMENT_COLLECTION)
     .where("creator_id", "==", params.creatorId)
+    .where("status", "==", "failed")
     .get();
   const retryableDisbursement = existingDisbursementSnapshot.docs
     .map((doc) => copyCreatorPayoutDisbursement(doc.data() as Record<string, unknown>))
@@ -1700,13 +2014,10 @@ export async function beginCreatorPayoutDisbursement(params: {
   // cannot run the collection query itself). Every entry's status is then
   // re-read *inside* the transaction and re-checked before any write, so the
   // read-then-write double-pay race (WEB-01) cannot open a window between
-  // selection and the in_transit flip.
-  const candidateEntryIds = (await listCreatorPayouts(params.creatorId))
-    .filter(
-      (entry) =>
-        ["approved", "disbursement_failed"].includes(entry.status) &&
-        payoutFundingEligibleForDisbursement(entry),
-    )
+  // selection and the in_transit flip. The candidate query is bounded to
+  // payable statuses instead of scanning the creator's full payout history.
+  const candidateEntryIds = (await listPayableCreatorPayouts(params.creatorId))
+    .filter((entry) => payoutFundingEligibleForDisbursement(entry))
     .map((entry) => entry.id);
   if (candidateEntryIds.length === 0) {
     return null;
@@ -1743,6 +2054,8 @@ export async function beginCreatorPayoutDisbursement(params: {
       firestore.collection(CREATOR_PAYOUT_COLLECTION).doc(entryId),
     );
     const snapshots = await Promise.all(refs.map((ref) => tx.get(ref)));
+    const aggregateRef = earningsAggregateRef(firestore, params.creatorId);
+    const aggregateSnapshot = await tx.get(aggregateRef);
 
     const selectedEntries: CreatorPayoutRecord[] = [];
     let runningTotal = 0;
@@ -1822,6 +2135,20 @@ export async function beginCreatorPayoutDisbursement(params: {
         { merge: true },
       );
     }
+
+    updateEarningsAggregateInTx({
+      tx,
+      ref: aggregateRef,
+      snapshot: aggregateSnapshot,
+      creatorId: params.creatorId,
+      changes: selectedEntries.map((entry) => ({
+        previous: payoutAggregateSlice(entry),
+        next: {
+          status: "in_transit" as CreatorPayoutStatus,
+          approvedAmountCents: entry.approved_amount_cents,
+        },
+      })),
+    });
 
     return { disbursement, entries: selectedEntries };
   });
@@ -1952,21 +2279,48 @@ export async function failCreatorPayoutDisbursement(params: {
       { merge: true },
     );
 
-  await Promise.all(
-    disbursement.payout_entry_ids.map((entryId) =>
-      firestore
-        .collection(CREATOR_PAYOUT_COLLECTION)
-        .doc(entryId)
-        .set(
-          {
+  await firestore.runTransaction(async (tx) => {
+    const entryRefs = disbursement.payout_entry_ids.map((entryId) =>
+      firestore.collection(CREATOR_PAYOUT_COLLECTION).doc(entryId),
+    );
+    const entrySnapshots = await Promise.all(entryRefs.map((ref) => tx.get(ref)));
+    const aggregateRef = earningsAggregateRef(firestore, disbursement.creator_id);
+    const aggregateSnapshot = await tx.get(aggregateRef);
+
+    const changes: Array<{
+      previous: PayoutAggregateSlice | null;
+      next: PayoutAggregateSlice | null;
+    }> = [];
+    entrySnapshots.forEach((snapshot, index) => {
+      tx.set(
+        entryRefs[index],
+        {
+          status: "disbursement_failed",
+          updated_at: failedAt,
+          failure_reason: params.reason,
+        },
+        { merge: true },
+      );
+      if (snapshot.exists) {
+        const entry = copyCreatorPayout(snapshot.data() as Record<string, unknown>);
+        changes.push({
+          previous: payoutAggregateSlice(entry),
+          next: {
             status: "disbursement_failed",
-            updated_at: failedAt,
-            failure_reason: params.reason,
+            approvedAmountCents: entry.approved_amount_cents,
           },
-          { merge: true },
-        ),
-    ),
-  );
+        });
+      }
+    });
+
+    updateEarningsAggregateInTx({
+      tx,
+      ref: aggregateRef,
+      snapshot: aggregateSnapshot,
+      creatorId: disbursement.creator_id,
+      changes,
+    });
+  });
 }
 
 export async function findCreatorPayoutDisbursementByStripePayoutId(
@@ -2041,25 +2395,32 @@ export async function applyCreatorPayoutWebhook(params: {
       { merge: true },
     );
 
-  await Promise.all(
-    disbursement.payout_entry_ids.map(async (entryId) => {
-      const payoutSnapshot = await firestore
-        .collection(CREATOR_PAYOUT_COLLECTION)
-        .doc(entryId)
-        .get();
-      if (!payoutSnapshot.exists) {
-        return;
-      }
-      const payout = copyCreatorPayout(
-        payoutSnapshot.data() as Record<string, unknown>,
+  const settledPayouts = await firestore.runTransaction<CreatorPayoutRecord[]>(
+    async (tx) => {
+      const entryRefs = disbursement.payout_entry_ids.map((entryId) =>
+        firestore.collection(CREATOR_PAYOUT_COLLECTION).doc(entryId),
       );
-      const nextStatus: CreatorPayoutStatus =
-        params.status === "paid" ? "paid" : "disbursement_failed";
+      const entrySnapshots = await Promise.all(entryRefs.map((ref) => tx.get(ref)));
+      const aggregateRef = earningsAggregateRef(firestore, disbursement.creator_id);
+      const aggregateSnapshot = await tx.get(aggregateRef);
 
-      await firestore
-        .collection(CREATOR_PAYOUT_COLLECTION)
-        .doc(entryId)
-        .set(
+      const updated: CreatorPayoutRecord[] = [];
+      const changes: Array<{
+        previous: PayoutAggregateSlice | null;
+        next: PayoutAggregateSlice | null;
+      }> = [];
+      entrySnapshots.forEach((payoutSnapshot, index) => {
+        if (!payoutSnapshot.exists) {
+          return;
+        }
+        const payout = copyCreatorPayout(
+          payoutSnapshot.data() as Record<string, unknown>,
+        );
+        const nextStatus: CreatorPayoutStatus =
+          params.status === "paid" ? "paid" : "disbursement_failed";
+
+        tx.set(
+          entryRefs[index],
           {
             status: nextStatus,
             paid_at: params.status === "paid" ? updatedAt : null,
@@ -2071,25 +2432,46 @@ export async function applyCreatorPayoutWebhook(params: {
           },
           { merge: true },
         );
+        changes.push({
+          previous: payoutAggregateSlice(payout),
+          next: {
+            status: nextStatus,
+            approvedAmountCents: payout.approved_amount_cents,
+          },
+        });
+        updated.push(payout);
+      });
 
-      if (params.status === "paid") {
-        await updateCreatorCaptureProjection({
-          captureId: payout.capture_id,
-          creatorId: payout.creator_id,
-          status: "paid",
-          estimatedPayoutCents: payout.approved_amount_cents,
-        });
-        await updateCaptureSubmissionProjection({
-          captureId: payout.capture_id,
-          creatorId: payout.creator_id,
-          status: "paid",
-          payoutCents: payout.approved_amount_cents,
-          approvedAt: payout.approved_at,
-          paidAt: updatedAt,
-        });
-      }
-    }),
+      updateEarningsAggregateInTx({
+        tx,
+        ref: aggregateRef,
+        snapshot: aggregateSnapshot,
+        creatorId: disbursement.creator_id,
+        changes,
+      });
+
+      return updated;
+    },
   );
+
+  if (params.status === "paid") {
+    for (const payout of settledPayouts) {
+      await updateCreatorCaptureProjection({
+        captureId: payout.capture_id,
+        creatorId: payout.creator_id,
+        status: "paid",
+        estimatedPayoutCents: payout.approved_amount_cents,
+      });
+      await updateCaptureSubmissionProjection({
+        captureId: payout.capture_id,
+        creatorId: payout.creator_id,
+        status: "paid",
+        payoutCents: payout.approved_amount_cents,
+        approvedAt: payout.approved_at,
+        paidAt: updatedAt,
+      });
+    }
+  }
 
   return disbursement.id;
 }

--- a/server/utils/accounting.ts
+++ b/server/utils/accounting.ts
@@ -1161,6 +1161,18 @@ export async function markBuyerOrderDisputedFromCharge(params: {
   };
 }
 
+const STRIPE_WEBHOOK_EVENT_RETENTION_DAYS_DEFAULT = 180;
+
+// Dedupe records only (Stripe retries span days, not months); the payout
+// ledger collections are permanent. expires_at feeds the Firestore TTL policy
+// enabled by scripts/apply_firestore_ttl_policies.sh.
+function stripeWebhookEventExpiresAt(): Date {
+  const raw = Number(process.env.BLUEPRINT_STRIPE_WEBHOOK_EVENT_RETENTION_DAYS);
+  const days =
+    Number.isFinite(raw) && raw > 0 ? raw : STRIPE_WEBHOOK_EVENT_RETENTION_DAYS_DEFAULT;
+  return new Date(Date.now() + days * 24 * 60 * 60 * 1000);
+}
+
 export async function beginStripeWebhookEvent(
   eventId: string,
   payload: Record<string, unknown>,
@@ -1176,6 +1188,7 @@ export async function beginStripeWebhookEvent(
       status: "processing",
       created_at: nowIso(),
       updated_at: nowIso(),
+      expires_at: stripeWebhookEventExpiresAt(),
     });
     return "new";
   } catch (error) {

--- a/server/utils/automationLeaderLease.ts
+++ b/server/utils/automationLeaderLease.ts
@@ -1,0 +1,270 @@
+import { randomUUID } from "crypto";
+
+import { dbAdmin } from "../../client/src/lib/firebaseAdmin";
+import { logger } from "../logger";
+import { getRateLimitRedisClient } from "./rate-limit-redis";
+
+/**
+ * Single-writer lease for the ops automation scheduler. Exactly one instance
+ * may run automation lanes at a time; every other instance keeps trying to
+ * acquire the lease so failover happens within one lease TTL. Redis
+ * (SET NX PX + compare-and-renew) is preferred when configured; otherwise a
+ * Firestore transaction lease is used. With neither store available the lease
+ * grants leadership, preserving today's single-instance behavior.
+ */
+
+const LEASE_NAME = "ops-automation-leader";
+const LEASE_COLLECTION = "opsAutomationLeases";
+const DEFAULT_LEASE_TTL_MS = 60_000;
+
+const RENEW_IF_HOLDER_SCRIPT =
+  'if redis.call("get", KEYS[1]) == ARGV[1] then return redis.call("pexpire", KEYS[1], ARGV[2]) else return 0 end';
+const RELEASE_IF_HOLDER_SCRIPT =
+  'if redis.call("get", KEYS[1]) == ARGV[1] then return redis.call("del", KEYS[1]) else return 0 end';
+
+export type LeaseRedisClient = {
+  set: (
+    key: string,
+    value: string,
+    options: { NX: true; PX: number },
+  ) => Promise<string | null>;
+  eval: (
+    script: string,
+    options: { keys: string[]; arguments: string[] },
+  ) => Promise<unknown>;
+};
+
+export type LeaseFirestoreClient = {
+  collection: (name: string) => {
+    doc: (id: string) => FirebaseFirestore.DocumentReference;
+  };
+  runTransaction: <T>(
+    updateFunction: (tx: FirebaseFirestore.Transaction) => Promise<T>,
+  ) => Promise<T>;
+};
+
+export type AutomationLeaderLeaseOptions = {
+  leaseName?: string;
+  instanceId?: string;
+  ttlMs?: number;
+  now?: () => number;
+  getRedisClient?: () => LeaseRedisClient | null;
+  getFirestore?: () => LeaseFirestoreClient | null;
+  isForced?: () => boolean;
+};
+
+export type AutomationLeaderLease = {
+  instanceId: string;
+  isLeader: () => boolean;
+  tick: () => Promise<boolean>;
+  start: () => void;
+  stop: () => Promise<void>;
+};
+
+function envForcedLeader() {
+  return ["1", "true", "yes"].includes(
+    String(process.env.BLUEPRINT_OPS_AUTOMATION_FORCE_LEADER || "")
+      .trim()
+      .toLowerCase(),
+  );
+}
+
+function defaultFirestoreClient(): LeaseFirestoreClient | null {
+  // Some test harnesses mock dbAdmin without transaction support; a lease
+  // backend that cannot run transactions is treated as absent.
+  if (!dbAdmin || typeof dbAdmin.runTransaction !== "function") {
+    return null;
+  }
+  return dbAdmin as unknown as LeaseFirestoreClient;
+}
+
+export function createAutomationLeaderLease(
+  options: AutomationLeaderLeaseOptions = {},
+): AutomationLeaderLease {
+  const leaseName = options.leaseName || LEASE_NAME;
+  const instanceId = options.instanceId || randomUUID();
+  const ttlMs = Math.max(5_000, options.ttlMs ?? DEFAULT_LEASE_TTL_MS);
+  const now = options.now || Date.now;
+  const getRedis =
+    options.getRedisClient
+    || (() => getRateLimitRedisClient() as LeaseRedisClient | null);
+  const getFirestore = options.getFirestore || defaultFirestoreClient;
+  const isForced = options.isForced || envForcedLeader;
+
+  let leader = false;
+  let stopped = false;
+  let intervalId: NodeJS.Timeout | null = null;
+
+  const acquireOrRenewViaRedis = async (redis: LeaseRedisClient) => {
+    const acquired = await redis.set(leaseName, instanceId, {
+      NX: true,
+      PX: ttlMs,
+    });
+    if (acquired) {
+      return true;
+    }
+    const renewed = await redis.eval(RENEW_IF_HOLDER_SCRIPT, {
+      keys: [leaseName],
+      arguments: [instanceId, String(ttlMs)],
+    });
+    return Number(renewed) === 1;
+  };
+
+  const acquireOrRenewViaFirestore = async (firestore: LeaseFirestoreClient) => {
+    const ref = firestore.collection(LEASE_COLLECTION).doc(leaseName);
+    return firestore.runTransaction(async (tx) => {
+      const snapshot = await tx.get(ref);
+      const data = (snapshot.data() || {}) as Record<string, unknown>;
+      const holderId = typeof data.holder_id === "string" ? data.holder_id : null;
+      const expiresAtMs = Number(data.expires_at_ms);
+      const currentMs = now();
+      const holdable =
+        !snapshot.exists
+        || holderId === instanceId
+        || !Number.isFinite(expiresAtMs)
+        || expiresAtMs <= currentMs;
+      if (!holdable) {
+        return false;
+      }
+      tx.set(
+        ref,
+        {
+          lease: leaseName,
+          holder_id: instanceId,
+          expires_at_ms: currentMs + ttlMs,
+          updated_at_iso: new Date(currentMs).toISOString(),
+        },
+        { merge: true },
+      );
+      return true;
+    });
+  };
+
+  const tick = async (): Promise<boolean> => {
+    if (isForced()) {
+      leader = true;
+      return leader;
+    }
+    const redis = getRedis();
+    const firestore = getFirestore();
+    if (!redis && !firestore) {
+      // No coordination store: single-instance deployment behavior.
+      leader = true;
+      return leader;
+    }
+    try {
+      if (redis) {
+        leader = await acquireOrRenewViaRedis(redis);
+        return leader;
+      }
+    } catch (error) {
+      logger.warn(
+        { err: error, lease: leaseName, instanceId },
+        "Automation leader lease Redis error; falling back to Firestore",
+      );
+      if (!firestore) {
+        leader = false;
+        return leader;
+      }
+    }
+    try {
+      leader = await acquireOrRenewViaFirestore(firestore!);
+    } catch (error) {
+      // Fail closed: never risk two instances running automation lanes.
+      logger.warn(
+        { err: error, lease: leaseName, instanceId },
+        "Automation leader lease Firestore error; treating instance as non-leader",
+      );
+      leader = false;
+    }
+    return leader;
+  };
+
+  const release = async () => {
+    if (!leader || isForced()) {
+      leader = false;
+      return;
+    }
+    leader = false;
+    const redis = getRedis();
+    if (redis) {
+      try {
+        await redis.eval(RELEASE_IF_HOLDER_SCRIPT, {
+          keys: [leaseName],
+          arguments: [instanceId],
+        });
+        return;
+      } catch (error) {
+        logger.warn(
+          { err: error, lease: leaseName, instanceId },
+          "Automation leader lease Redis release failed",
+        );
+      }
+    }
+    const firestore = getFirestore();
+    if (!firestore) {
+      return;
+    }
+    try {
+      const ref = firestore.collection(LEASE_COLLECTION).doc(leaseName);
+      await firestore.runTransaction(async (tx) => {
+        const snapshot = await tx.get(ref);
+        const data = (snapshot.data() || {}) as Record<string, unknown>;
+        if (data.holder_id !== instanceId) {
+          return;
+        }
+        tx.set(
+          ref,
+          {
+            holder_id: null,
+            expires_at_ms: 0,
+            updated_at_iso: new Date(now()).toISOString(),
+          },
+          { merge: true },
+        );
+      });
+    } catch (error) {
+      logger.warn(
+        { err: error, lease: leaseName, instanceId },
+        "Automation leader lease Firestore release failed",
+      );
+    }
+  };
+
+  return {
+    instanceId,
+    isLeader: () => (isForced() ? true : leader),
+    tick,
+    start: () => {
+      if (stopped || intervalId) {
+        return;
+      }
+      void tick();
+      intervalId = setInterval(() => {
+        void tick();
+      }, Math.max(1_000, Math.floor(ttlMs / 3)));
+      intervalId.unref?.();
+    },
+    stop: async () => {
+      stopped = true;
+      if (intervalId) {
+        clearInterval(intervalId);
+        intervalId = null;
+      }
+      await release();
+    },
+  };
+}
+
+let sharedLease: AutomationLeaderLease | null = null;
+
+export function getOpsAutomationLeaderLease(): AutomationLeaderLease {
+  if (!sharedLease) {
+    sharedLease = createAutomationLeaderLease();
+  }
+  return sharedLease;
+}
+
+export function __resetOpsAutomationLeaderLeaseForTests() {
+  sharedLease = null;
+}

--- a/server/utils/captureShard.ts
+++ b/server/utils/captureShard.ts
@@ -1,0 +1,35 @@
+import { createHash } from "node:crypto";
+
+/**
+ * Firestore createdAt hotspot guard: capture records carry a deterministic
+ * `createdAtShard` so high-volume createdAt queries can route through the
+ * sharded composite indexes declared in
+ * BlueprintCapturePipeline/deploy/terraform/main.tf
+ * (captures_status_created_at_shard / captures_user_created_at_shard) instead
+ * of a monotonically increasing createdAt index.
+ *
+ * Neither the Terraform indexes nor the capacity docs pinned a shard count, so
+ * 16 is the canonical choice — pinned alongside the derivation in
+ * BlueprintCapturePipeline/docs/BETA_CAPACITY_COST_STORAGE_MODEL_2026-07-08.md
+ * ("Firestore CreatedAt Hotspot Guard"). Keep both in sync if this changes.
+ */
+export const CREATED_AT_SHARD_COUNT = 16;
+
+/**
+ * Deterministic shard for a capture id: sha256(capture_id) mod shardCount.
+ *
+ * Matches the cross-language reference derivation
+ * `int(hashlib.sha256(capture_id.encode()).hexdigest(), 16) % shard_count`
+ * exactly (full-digest big-integer modulo), so any backfill or reader written
+ * in Python produces identical shard values.
+ */
+export function deriveCreatedAtShard(
+  captureId: string,
+  shardCount: number = CREATED_AT_SHARD_COUNT,
+): number {
+  if (!Number.isInteger(shardCount) || shardCount < 1) {
+    throw new Error(`Invalid createdAtShard shard count: ${shardCount}`);
+  }
+  const digestHex = createHash("sha256").update(captureId, "utf8").digest("hex");
+  return Number(BigInt(`0x${digestHex}`) % BigInt(shardCount));
+}

--- a/server/utils/cityLaunchCaptureTargets.ts
+++ b/server/utils/cityLaunchCaptureTargets.ts
@@ -1,4 +1,4 @@
-import { listCityLaunchActivations, listCityLaunchCandidateSignals, listCityLaunchProspects } from "./cityLaunchLedgers";
+import { getCityLaunchSnapshot } from "./cityLaunchSnapshot";
 
 const ACTIVE_ACTIVATION_STATUSES = new Set<string>([
   "activation_ready",
@@ -184,54 +184,48 @@ export async function buildCreatorLaunchStatus(input: {
   resolvedCity?: { city: string; stateCode?: string | null } | null;
 }): Promise<CreatorLaunchStatus> {
   const sourceWarnings: string[] = [];
-  let activations: Awaited<ReturnType<typeof listCityLaunchActivations>> = [];
   let cityLaunchActivations: CreatorLaunchStatus["sourceStatus"]["cityLaunchActivations"] = "available";
   let cityLaunchProspects: CreatorLaunchStatus["sourceStatus"]["cityLaunchProspects"] = "available";
   let cityLaunchCandidateSignals: CreatorLaunchStatus["sourceStatus"]["cityLaunchCandidateSignals"] = "available";
 
-  try {
-    activations = await listCityLaunchActivations();
-  } catch (error) {
+  const snapshot = await getCityLaunchSnapshot();
+  const activations = snapshot.activations;
+  if (snapshot.activationsError) {
     cityLaunchActivations = "unavailable";
     cityLaunchProspects = "unavailable";
-    sourceWarnings.push(ledgerErrorWarning("cityLaunchActivations", error));
+    sourceWarnings.push(ledgerErrorWarning("cityLaunchActivations", snapshot.activationsError));
   }
 
   const activationCoordinates = new Map<string, { latitude: number | null; longitude: number | null }>();
-  await Promise.all(
-    activations.map(async (activation) => {
-      let prospects: Awaited<ReturnType<typeof listCityLaunchProspects>> = [];
-      try {
-        prospects = await listCityLaunchProspects(activation.city);
-      } catch (error) {
-        cityLaunchProspects = cityLaunchProspects === "unavailable" ? "unavailable" : "partial";
-        sourceWarnings.push(ledgerErrorWarning(`cityLaunchProspects:${activation.citySlug}`, error));
-      }
-      activationCoordinates.set(
-        activation.citySlug,
-        averageCoordinates(
-          prospects.map((prospect) => ({
-            lat: prospect.lat,
-            lng: prospect.lng,
-          })),
-        ),
-      );
-    }),
-  );
+  for (const activation of activations) {
+    const prospects = snapshot.prospectsByCitySlug.get(activation.citySlug) || [];
+    const prospectError = snapshot.prospectErrorsByCitySlug.get(activation.citySlug);
+    if (prospectError) {
+      cityLaunchProspects = cityLaunchProspects === "unavailable" ? "unavailable" : "partial";
+      sourceWarnings.push(ledgerErrorWarning(`cityLaunchProspects:${activation.citySlug}`, prospectError));
+    }
+    activationCoordinates.set(
+      activation.citySlug,
+      averageCoordinates(
+        prospects.map((prospect) => ({
+          lat: prospect.lat,
+          lng: prospect.lng,
+        })),
+      ),
+    );
+  }
 
   let underReviewSignals: Array<{
     city: string;
     citySlug: string;
     lat: number;
     lng: number;
-  }> = [];
-  try {
-    underReviewSignals = await listCityLaunchCandidateSignals({
-      statuses: ["queued", "in_review"],
-    });
-  } catch (error) {
+  }> = snapshot.candidateSignals;
+  if (snapshot.candidateSignalsError) {
     cityLaunchCandidateSignals = "unavailable";
-    sourceWarnings.push(ledgerErrorWarning("cityLaunchCandidateSignals", error));
+    sourceWarnings.push(
+      ledgerErrorWarning("cityLaunchCandidateSignals", snapshot.candidateSignalsError),
+    );
     underReviewSignals = [];
   }
 
@@ -369,20 +363,25 @@ export async function buildCityLaunchCaptureTargetFeed(input: {
   radiusMeters: number;
   limit: number;
 }) {
-  const activations = await listCityLaunchActivations();
-  const activeCities = activations.filter((activation) =>
+  const snapshot = await getCityLaunchSnapshot();
+  if (snapshot.activationsError) {
+    throw snapshot.activationsError;
+  }
+  const activeCities = snapshot.activations.filter((activation) =>
     activation.founderApproved
     || ACTIVE_ACTIVATION_STATUSES.has(activation.status),
   );
 
-  const cityResults = await Promise.all(
-    activeCities.map(async (activation) => {
-      const prospects = await listCityLaunchProspects(activation.city, {
-        statuses: ["approved", "onboarded", "capturing"],
-      });
-      return { activation, prospects };
-    }),
-  );
+  const cityResults = activeCities.map((activation) => {
+    const prospectError = snapshot.prospectErrorsByCitySlug.get(activation.citySlug);
+    if (prospectError) {
+      throw prospectError;
+    }
+    return {
+      activation,
+      prospects: snapshot.prospectsByCitySlug.get(activation.citySlug) || [],
+    };
+  });
 
   const targets = cityResults
     .flatMap(({ activation, prospects }) =>
@@ -444,9 +443,11 @@ export async function buildCityLaunchUnderReviewFeed(input: {
   limit: number;
 }) {
   const allowedStatuses = new Set(["queued", "in_review"]);
-  const candidates = await listCityLaunchCandidateSignals({
-    statuses: ["queued", "in_review"],
-  });
+  const snapshot = await getCityLaunchSnapshot();
+  if (snapshot.candidateSignalsError) {
+    throw snapshot.candidateSignalsError;
+  }
+  const candidates = snapshot.candidateSignals;
 
   return {
     generatedAt: new Date().toISOString(),

--- a/server/utils/cityLaunchSnapshot.ts
+++ b/server/utils/cityLaunchSnapshot.ts
@@ -1,0 +1,118 @@
+import {
+  listCityLaunchActivations,
+  listCityLaunchCandidateSignals,
+  listCityLaunchProspects,
+  type CityLaunchActivationRecord,
+  type CityLaunchCandidateSignalRecord,
+  type CityLaunchProspectRecord,
+} from "./cityLaunchLedgers";
+
+/**
+ * Short-TTL in-process snapshot of the city-shared launch inputs (activations,
+ * per-city prospects, under-review candidate signals). These feeds are read on
+ * every creator app open; without the snapshot each request fans out one
+ * Firestore prospects query per active city. Opportunity data tolerates ~90s
+ * staleness, and only city-shared data lives here — never creator-specific
+ * state. Errors are captured per source so callers keep their existing
+ * partial/unavailable semantics.
+ */
+
+const DEFAULT_SNAPSHOT_TTL_MS = 90_000;
+
+export type CityLaunchSnapshot = {
+  fetchedAtMs: number;
+  activations: CityLaunchActivationRecord[];
+  activationsError: unknown;
+  prospectsByCitySlug: Map<string, CityLaunchProspectRecord[]>;
+  prospectErrorsByCitySlug: Map<string, unknown>;
+  candidateSignals: CityLaunchCandidateSignalRecord[];
+  candidateSignalsError: unknown;
+};
+
+function snapshotTtlMs() {
+  const raw = Number(process.env.BLUEPRINT_CITY_LAUNCH_SNAPSHOT_TTL_MS);
+  if (Number.isFinite(raw)) {
+    return Math.max(0, raw);
+  }
+  // Tests mutate ledger fixtures between calls; default to no caching there.
+  if (process.env.NODE_ENV === "test" || process.env.VITEST) {
+    return 0;
+  }
+  return DEFAULT_SNAPSHOT_TTL_MS;
+}
+
+let cachedSnapshot: CityLaunchSnapshot | null = null;
+let inflightLoad: Promise<CityLaunchSnapshot> | null = null;
+
+async function loadCityLaunchSnapshot(): Promise<CityLaunchSnapshot> {
+  let activations: CityLaunchActivationRecord[] = [];
+  let activationsError: unknown = null;
+  try {
+    activations = await listCityLaunchActivations();
+  } catch (error) {
+    activationsError = error;
+  }
+
+  const prospectsByCitySlug = new Map<string, CityLaunchProspectRecord[]>();
+  const prospectErrorsByCitySlug = new Map<string, unknown>();
+  await Promise.all(
+    activations.map(async (activation) => {
+      try {
+        prospectsByCitySlug.set(
+          activation.citySlug,
+          await listCityLaunchProspects(activation.city),
+        );
+      } catch (error) {
+        prospectErrorsByCitySlug.set(activation.citySlug, error);
+      }
+    }),
+  );
+
+  let candidateSignals: CityLaunchCandidateSignalRecord[] = [];
+  let candidateSignalsError: unknown = null;
+  try {
+    candidateSignals = await listCityLaunchCandidateSignals({
+      statuses: ["queued", "in_review"],
+    });
+  } catch (error) {
+    candidateSignalsError = error;
+  }
+
+  return {
+    fetchedAtMs: Date.now(),
+    activations,
+    activationsError,
+    prospectsByCitySlug,
+    prospectErrorsByCitySlug,
+    candidateSignals,
+    candidateSignalsError,
+  };
+}
+
+export async function getCityLaunchSnapshot(): Promise<CityLaunchSnapshot> {
+  const ttlMs = snapshotTtlMs();
+  if (
+    ttlMs > 0
+    && cachedSnapshot
+    && Date.now() - cachedSnapshot.fetchedAtMs < ttlMs
+  ) {
+    return cachedSnapshot;
+  }
+  // Single-flight: concurrent requests during a refresh share one loader.
+  if (!inflightLoad) {
+    inflightLoad = loadCityLaunchSnapshot()
+      .then((snapshot) => {
+        cachedSnapshot = snapshot;
+        return snapshot;
+      })
+      .finally(() => {
+        inflightLoad = null;
+      });
+  }
+  return inflightLoad;
+}
+
+export function __resetCityLaunchSnapshotForTests() {
+  cachedSnapshot = null;
+  inflightLoad = null;
+}

--- a/server/utils/inboundRequestStats.ts
+++ b/server/utils/inboundRequestStats.ts
@@ -1,0 +1,94 @@
+import admin from "../../client/src/lib/firebaseAdmin";
+
+/**
+ * Sharded counters for the stats/inboundRequests summary document.
+ *
+ * Every inbound-lead submission and status transition previously incremented
+ * fields on the single stats/inboundRequests doc, which contends at
+ * Firestore's ~1 sustained write/sec/doc ceiling under lead bursts. Writes now
+ * land on a random shard under stats/inboundRequests/shards/{0..N-1}; reads
+ * sum the legacy base doc (which keeps its historic totals) plus all shards.
+ */
+export const INBOUND_REQUEST_STATS_SHARD_COUNT = 8;
+
+const STATS_COLLECTION = "stats";
+const BASE_DOC_ID = "inboundRequests";
+const SHARDS_SUBCOLLECTION = "shards";
+
+type Db = FirebaseFirestore.Firestore;
+
+function shardsCollection(db: Db) {
+  return db
+    .collection(STATS_COLLECTION)
+    .doc(BASE_DOC_ID)
+    .collection(SHARDS_SUBCOLLECTION);
+}
+
+export function pickInboundRequestStatsShard(random: () => number = Math.random): string {
+  return String(Math.floor(random() * INBOUND_REQUEST_STATS_SHARD_COUNT));
+}
+
+/**
+ * Apply numeric field deltas (dot-path keys, e.g. "byStatus.submitted") to a
+ * random shard. Mirrors the set(..., { merge: true }) + FieldValue.increment
+ * shape the base doc previously used, so nested map layout is unchanged.
+ */
+export async function incrementInboundRequestStats(
+  db: Db,
+  deltas: Record<string, number>,
+  random: () => number = Math.random,
+): Promise<void> {
+  const payload: Record<string, unknown> = {
+    updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+  };
+  for (const [field, delta] of Object.entries(deltas)) {
+    payload[field] = admin.firestore.FieldValue.increment(delta);
+  }
+  await shardsCollection(db)
+    .doc(pickInboundRequestStatsShard(random))
+    .set(payload, { merge: true });
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const proto = Object.getPrototypeOf(value);
+  // Excludes Timestamp/GeoPoint/etc. class instances, whose own numeric
+  // fields must not be summed as counters.
+  return proto === Object.prototype || proto === null;
+}
+
+function addNumericLeaves(target: Record<string, unknown>, source: unknown): void {
+  if (!isPlainObject(source)) return;
+  for (const [key, value] of Object.entries(source)) {
+    if (typeof value === "number" && Number.isFinite(value)) {
+      const current = target[key];
+      target[key] = (typeof current === "number" ? current : 0) + value;
+    } else if (isPlainObject(value)) {
+      const nested = isPlainObject(target[key])
+        ? (target[key] as Record<string, unknown>)
+        : {};
+      target[key] = nested;
+      addNumericLeaves(nested, value);
+    }
+  }
+}
+
+/**
+ * Read the summed stats view: legacy base doc totals plus every shard.
+ * Non-numeric fields (e.g. updatedAt) are kept from the base doc only.
+ */
+export async function readInboundRequestStats(db: Db): Promise<Record<string, unknown>> {
+  const [baseSnapshot, shardsSnapshot] = await Promise.all([
+    db.collection(STATS_COLLECTION).doc(BASE_DOC_ID).get(),
+    shardsCollection(db).get(),
+  ]);
+  const totals: Record<string, unknown> = baseSnapshot.exists
+    ? { ...(baseSnapshot.data() ?? {}) }
+    : {};
+  const summed: Record<string, unknown> = {};
+  addNumericLeaves(summed, totals);
+  for (const shard of shardsSnapshot.docs) {
+    addNumericLeaves(summed, shard.data());
+  }
+  return { ...totals, ...summed };
+}

--- a/server/utils/opsAutomationScheduler.ts
+++ b/server/utils/opsAutomationScheduler.ts
@@ -26,6 +26,7 @@ import { runLifecycleCadenceWorker } from "./lifecycle-cadence";
 import { runGapClosureLoop } from "./gap-closure";
 import { runHumanReplyEmailWatcher } from "./human-reply-worker";
 import { runOperatingGraphProjectionLoop } from "./operatingGraphEvidenceProjectors";
+import { getOpsAutomationLeaderLease } from "./automationLeaderLease";
 
 const WORKER_STATUS_COLLECTION = "opsAutomationWorkerStatus";
 
@@ -363,6 +364,16 @@ const workers: WorkerDefinition[] = [
 export function startOpsAutomationScheduler() {
   const disposers: Array<() => void> = [];
 
+  // Leader election: on multi-instance deployments only the lease holder runs
+  // automation lanes; standby instances keep re-checking so they take over
+  // within one lease TTL. Set BLUEPRINT_OPS_AUTOMATION_FORCE_LEADER=1 to pin
+  // an instance as leader (single-instance escape hatch).
+  const leaderLease = getOpsAutomationLeaderLease();
+  leaderLease.start();
+  disposers.push(() => {
+    void leaderLease.stop();
+  });
+
   for (const worker of workers) {
     if (!isAutomationLaneEnabled(worker.enabledEnv)) {
       void persistWorkerStatus(worker.key, {
@@ -415,6 +426,18 @@ export function startOpsAutomationScheduler() {
         return;
       }
       timeoutId = setTimeout(async () => {
+        if (!leaderLease.isLeader()) {
+          logger.info(
+            attachRequestMeta({
+              route: "ops-automation-scheduler",
+              worker: worker.key,
+              leaseInstanceId: leaderLease.instanceId,
+            }),
+            `Skipping ${worker.key} automation run on non-leader instance`,
+          );
+          scheduleNext(intervalMs);
+          return;
+        }
         runNumber += 1;
         const runStartedAt = Date.now();
         const runStartedAtIso = new Date(runStartedAt).toISOString();


### PR DESCRIPTION
Part of a cross-repo backend scaling pass for the first 1k–10k locations. The full audit and target design ship in this PR as `docs/backend-scaling-architecture-2026-07-20.md`. Companion PRs: `BlueprintCapture#57`, `BlueprintCapturePipeline` (same branch name).

## What changed

**Leader election for the ops automation scheduler** (`server/utils/automationLeaderLease.ts`)
The ~20 in-process automation workers previously assumed a single instance — a second Render instance would have duplicated payout-exception triage, lifecycle emails, and Notion writes. A leased leader (Redis `SET NX PX` with compare-and-renew/release, Firestore transaction lease fallback, `BLUEPRINT_OPS_AUTOMATION_FORCE_LEADER` kill-switch) now gates every worker tick; non-leaders idle and take over within one lease TTL on failover. This unblocks horizontal scale-out.

**City-launch snapshot cache** (`server/utils/cityLaunchSnapshot.ts`)
`/v1/creator/city-launch/targets`, launch-status, and under-review feeds previously ran one prospects query per active city (up to 1000 docs each) per creator app-open. They now read a 90s-TTL single-flight snapshot of city-shared data (activations, prospects, queued candidate signals); creator-specific reads stay live and uncached. Per-source error semantics preserved.

**Composite indexes: 2 → 16** (`firestore.indexes.json`)
Every `where().orderBy()` query in the server was verified in code and now has a declared composite (inboundRequests, action_ledger, growth campaigns/events, city-launch coverage/ads evidence, plus the new bounded creator queries below). Previously these existed only as console-created indexes (or would `FAILED_PRECONDITION` in a fresh environment).

**Bounded money-path reads + earnings aggregate** (`server/utils/accounting.ts`, `server/routes/creator.ts`)
- New `creatorEarningsAggregates/{creatorId}` doc (per-status count/amount buckets) maintained inside the *same transactions* as every `creatorPayouts` write — pipeline upsert, dispute hold, disbursement begin/fail, payout-webhook settle — with lazy transactional backfill from a one-time scan, so there is no drift window. `/earnings` reads the aggregate instead of scanning the creator's full payout history per request.
- `/captures` and `/qc` gain `orderBy(created_at desc)` + limits; `/payouts/ledger` reads a bounded recency window; disbursement candidates come from an indexed `status in [approved, disbursement_failed]` query instead of a full history scan.
- The WEB-01 double-pay transaction guard is preserved byte-for-byte; dispute holds actually became fully transactional as a side effect.

**Firestore write-hotspot shard** (`server/utils/captureShard.ts`)
Capture registrations now write `createdAtShard` (`sha256(capture_id) mod 16`, pinned cross-language) next to `created_at`. Investigation confirmed this repo is the only writer of capture records — the pipeline repo's Terraform sharded indexes referenced a collection nothing writes (flagged there for reconciliation).

**Operational-exhaust TTLs**
`creatorClientTelemetry` writes stamp `expires_at` (90d default); `scripts/apply_firestore_ttl_policies.sh` (idempotent, gcloud) enables TTL on telemetry + idempotency collections.

## Contracts preserved
Route paths and response shapes unchanged; pipeline HMAC sync untouched; caches serve advisory read surfaces only — payout correctness paths never read from cache.

## Testing
- `npm run check` (full tsc): clean
- Full server suite: **199 files, 989 tests, all passing**, including new suites for the leader lease (9), snapshot cache (5), earnings aggregate (5), and shard derivation; existing double-pay and accounting-ledger assertions untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QmqevSVjf1hPBq4SjPNQNw

---
_Generated by [Claude Code](https://claude.ai/code/session_01QmqevSVjf1hPBq4SjPNQNw)_