### PR TITLE
Backend scaling round 2: dedicated worker service, queued Stripe webhooks + append-only ledger journal, creatorCaptures shard indexes

### DIFF
--- a/docs/backend-scaling-architecture-2026-07-20.md
+++ b/docs/backend-scaling-architecture-2026-07-20.md
@@ -148,21 +148,69 @@ BlueprintCapturePipeline:
 - Canonical bucket lifecycle updated: raw archived at 365d instead of deleted at 180d;
   cost note updated.
 
-## 5. Deliberate follow-ups (not in this change set)
+## 5. Round 2 (2026-07-20, branch `claude/blueprint-scaling-round-2-ii8aik`)
 
-- Move Stripe webhook processing onto a queue with DLQ + append-only journal/BigQuery
-  export for reconciliation (operational shape change — needs ops review).
-- Split automation workers into a dedicated Render background worker service.
-- Frame packing (tar/composite objects) for `extractFrames` output — requires a
-  coordinated pipeline contract rev; per-frame objects are the current contract.
-- CDN in front of buyer delivery downloads (egress $0.12/GiB today).
-- Retire the legacy iOS Backblaze `StorageManager` path and rotate the exposed B2 key
-  (credentials currently hardcoded in the binary — key rotation is an ops action).
-- Warm-pool strategy for GPU privacy services (min-instances vs cold model loads) once
-  sustained load justifies idle spend.
+The seven deferred items from §5 of round 1 landed as follows:
+
+**Dedicated Render worker service (SCALE2-02).** `render.yaml` now declares
+`blueprint-webapp-worker` (`type: worker`, `npm run start:worker` →
+`server/worker.ts`). The worker boots the ops automation scheduler and the
+Stripe webhook queue processor; the web process serves HTTP only and no longer
+starts the scheduler (escape hatch: `BLUEPRINT_RUN_OPS_AUTOMATION_IN_WEB=1`).
+The round-1 leader lease stays active in every configuration, so no rollout
+state can double-run automation. Both services need the same env (see
+render.*.env.example headers).
+
+**Queue-based Stripe webhooks + append-only journal (SCALE2-01).** The webhook
+handler's synchronous job is now: verify signature, dedupe via
+`stripeWebhookEvents` (both unchanged), enqueue to `stripeWebhookQueue`
+(doc id = event id, full verified payload), return 200. The worker drains the
+queue behind the leader lease with transactional claims, bounded exponential
+retry, and a `stripeWebhookDeadLetters` collection + `payment_webhook_dead_letter`
+ops failure signal on exhaustion. `BLUEPRINT_STRIPE_WEBHOOK_INLINE=1` restores
+the synchronous path.
+  Queue-backend evaluation: a Firestore-backed queue (chosen) needs no new
+provider, reuses the lease/alerting patterns, and at 10k payouts/month peaks
+of a few events/second is far below Firestore's limits; Cloud Tasks would add
+managed backoff and per-queue rate limits but introduces a new runtime
+dependency into this repo, per-task payload limits, and push-endpoint auth
+surface. Revisit Cloud Tasks only if sustained event rates approach hundreds
+per second — flagged as a recommendation, not wired up.
+  Every financial state transition (checkout completed, refund, dispute
+opened/resolved, payout approved, disbursement initiated/settled/failed) now
+also writes one immutable `stripeLedgerJournal` document in the same Firestore
+transaction as the corresponding ledger write (additive; the WEB-01 double-pay
+guard is untouched). `npm run stripe:reconcile`
+(scripts/stripe-ledger-reconcile.ts) sums the journal for a period and
+cross-checks creator settlement totals against `creatorEarningsAggregates`,
+flagging drift instead of trusting either source. A BigQuery export stays
+deferred: the journal is the export-ready source when reconciliation needs
+SQL. Note: the journal covers transitions from round 2 onward; pre-journal
+paid history shows as negative drift until a one-time backfill entry is
+recorded.
+
+**Other round-2 items (sibling repos).** BlueprintCapture: deleted the dead
+Backblaze `StorageManager` path with embedded credentials (key rotation is a
+human ops action) + a CI validator preventing recurrence; frame packing for
+`extractFrames` shipped as a `frames_index.v2` contract revision coordinated
+with the pipeline. BlueprintCapturePipeline: phantom `captures` Firestore
+indexes deleted (real `creatorCaptures` shard composites now live in this
+repo's firestore.indexes.json — see §4); GPU warm-pool economics analysis
+(stay scale-to-zero, in-process model cache instead) in
+`docs/GPU_WARM_POOL_ECONOMICS_2026-07-20.md`; CDN-for-delivery design in
+`docs/BUYER_DELIVERY_CDN_DESIGN_2026-07-20.md`.
+
+## 6. Deliberate follow-ups (not in round 2)
+
+- BigQuery export of `stripeLedgerJournal` once reconciliation needs SQL-scale
+  analysis (the journal is already the export-ready source of truth).
+- One-time journal backfill entries for pre-round-2 paid history, so
+  reconciliation drift reads clean without the claim-boundary caveat.
+- Cloud Tasks migration for the webhook queue if sustained event rates ever
+  approach hundreds/second (see evaluation above).
 - k6 load test of the gateway (BLR-041) once leader election lands.
 
-## 6. Invariants preserved
+## 7. Invariants preserved
 
 - Raw capture bundle structure, provenance/rights metadata, `capture_bridge_handoff.v1`,
   webapp sync payload `v1`, robot-eval status projection `v1`, canonical package layout:

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -255,6 +255,20 @@
       ]
     },
     {
+      "collectionGroup": "stripeWebhookQueue",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "processing_started_at",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
       "collectionGroup": "creatorPayouts",
       "queryScope": "COLLECTION",
       "fields": [

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -205,6 +205,42 @@
       ]
     },
     {
+      "collectionGroup": "creatorCaptures",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "creator_id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAtShard",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "created_at",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "creatorCaptures",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAtShard",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "created_at",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
       "collectionGroup": "creatorPayouts",
       "queryScope": "COLLECTION",
       "fields": [

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -241,6 +241,20 @@
       ]
     },
     {
+      "collectionGroup": "stripeWebhookQueue",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "next_attempt_at",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
       "collectionGroup": "creatorPayouts",
       "queryScope": "COLLECTION",
       "fields": [

--- a/package.json
+++ b/package.json
@@ -5,11 +5,12 @@
   "license": "MIT",
   "scripts": {
     "dev": "tsx watch --clear-screen=false --exclude vite.config.ts.* server/index.ts",
-    "build": "vite build && tsx --tsconfig tsconfig.prerender.json scripts/prerender.tsx && tsx scripts/generate-sitemap.ts && node scripts/generate-build-info.mjs && npx esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
+    "build": "vite build && tsx --tsconfig tsconfig.prerender.json scripts/prerender.tsx && tsx scripts/generate-sitemap.ts && node scripts/generate-build-info.mjs && npx esbuild server/index.ts server/worker.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "render:proof-reel": "npm exec --package=@remotion/cli@4.0.438 remotion render proof-reel/index.ts BlueprintProofReel client/public/proof/blueprint-proof-reel.mp4 --public-dir client/public",
     "render:site-motion-loop": "mkdir -p tmp/remotion && npm exec --package=@remotion/cli@4.0.438 -- remotion render proof-reel/index.ts BlueprintSiteMotionLoop --output tmp/remotion/blueprint-site-motion-loop.raw.mp4 --public-dir client/public && npm exec --package=@remotion/cli@4.0.438 -- remotion ffmpeg -y -i tmp/remotion/blueprint-site-motion-loop.raw.mp4 -an -c:v libx264 -preset medium -crf 28 -movflags +faststart client/public/proof/blueprint-site-motion-loop.mp4 && rm tmp/remotion/blueprint-site-motion-loop.raw.mp4",
     "render:site-motion-loop:poster": "npm exec --package=@remotion/cli@4.0.438 -- remotion still proof-reel/index.ts BlueprintSiteMotionLoop --output client/public/proof/blueprint-site-motion-loop-poster.png --frame=42 --public-dir client/public",
     "start": "NODE_ENV=production node dist/index.js",
+    "start:worker": "NODE_ENV=production node dist/worker.js",
     "check": "tsc -p tsconfig.full.json --noEmit",
     "rules:firestore-parity": "bash scripts/check-firestore-rules-parity.sh",
     "rules:storage-parity": "bash scripts/check-storage-rules-parity.sh",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "render:site-motion-loop:poster": "npm exec --package=@remotion/cli@4.0.438 -- remotion still proof-reel/index.ts BlueprintSiteMotionLoop --output client/public/proof/blueprint-site-motion-loop-poster.png --frame=42 --public-dir client/public",
     "start": "NODE_ENV=production node dist/index.js",
     "start:worker": "NODE_ENV=production node dist/worker.js",
+    "stripe:reconcile": "tsx scripts/stripe-ledger-reconcile.ts",
     "check": "tsc -p tsconfig.full.json --noEmit",
     "rules:firestore-parity": "bash scripts/check-firestore-rules-parity.sh",
     "rules:storage-parity": "bash scripts/check-storage-rules-parity.sh",

--- a/render.optional.env.example
+++ b/render.optional.env.example
@@ -9,6 +9,11 @@
 # This file is permissive:
 # - empty values are allowed during import
 #
+# SCALE2-02: import this manifest into BOTH Render services —
+# blueprint-webapp (web) AND blueprint-webapp-worker (background worker).
+# The worker runs the ops automation scheduler and the Stripe webhook
+# queue processor and needs the same Firebase/Stripe/Redis/Notion env.
+#
 # Import with:
 #   RENDER_API_KEY=... RENDER_SERVICE_ID=... npm run render:import-env -- render.optional.env.example
 

--- a/render.required.env.example
+++ b/render.required.env.example
@@ -14,6 +14,11 @@
 # This file is strict:
 # - the import script will fail if any value is empty
 #
+# SCALE2-02: import this manifest into BOTH Render services —
+# blueprint-webapp (web) AND blueprint-webapp-worker (background worker).
+# The worker runs the ops automation scheduler and the Stripe webhook
+# queue processor and needs the same Firebase/Stripe/Redis/Notion env.
+#
 # Import with:
 #   RENDER_API_KEY=... RENDER_SERVICE_ID=... npm run render:import-env -- render.required.env.example
 # Dry run:

--- a/render.yaml
+++ b/render.yaml
@@ -12,3 +12,25 @@ services:
     buildCommand: npm ci && npm run build
     startCommand: npm start
     healthCheckPath: /health/ready
+
+  # Dedicated background worker (SCALE2-02): runs the ops automation
+  # scheduler (and the Stripe webhook queue processor) out of the web
+  # process so batch work never shares an event loop with live HTTP traffic.
+  # The ops automation leader lease stays active inside the worker, so
+  # scaling this service beyond one instance (or temporarily opting the web
+  # process back in with BLUEPRINT_RUN_OPS_AUTOMATION_IN_WEB=1) can never
+  # double-run automation lanes.
+  #
+  # Env vars: this service needs the same environment as blueprint-webapp
+  # (Firebase service account, Stripe keys, Redis URL, Notion/SendGrid/Slack
+  # tokens — see render.required.env.example / render.optional.env.example).
+  # Env is dashboard-managed for this blueprint; import the same env group
+  # into both services.
+  - type: worker
+    name: blueprint-webapp-worker
+    runtime: node
+    plan: starter
+    region: oregon
+    autoDeploy: false
+    buildCommand: npm ci && npm run build
+    startCommand: npm run start:worker

--- a/scripts/apply_firestore_ttl_policies.sh
+++ b/scripts/apply_firestore_ttl_policies.sh
@@ -57,6 +57,9 @@ apply_ttl() {
 apply_ttl "creatorClientTelemetry" "expires_at"
 apply_ttl "idempotencyKeys" "expiresAt"
 apply_ttl "stripeWebhookEvents" "expires_at"
+# Queue transport docs only (SCALE2-01): the append-only stripeLedgerJournal
+# and the dead-letter collection are money-plane records and get NO TTL.
+apply_ttl "stripeWebhookQueue" "expires_at"
 
 echo "Done. Verify with:"
 echo "  gcloud firestore fields ttls list --project=${PROJECT_ID}"

--- a/scripts/stripe-ledger-reconcile.ts
+++ b/scripts/stripe-ledger-reconcile.ts
@@ -1,0 +1,43 @@
+/**
+ * CLI reconciliation report over the append-only Stripe ledger journal
+ * (SCALE2-01). Sums the journal for a period and cross-checks creator
+ * settlement totals against creatorEarningsAggregates, flagging drift.
+ *
+ * Usage:
+ *   npm run stripe:reconcile                      # last 30 days
+ *   npm run stripe:reconcile -- --from 2026-06-01T00:00:00Z --to 2026-07-01T00:00:00Z
+ *
+ * Exit code 1 when drift is detected so this can run in a cron/ops lane and
+ * page through the usual failure path.
+ */
+import { buildStripeLedgerReconciliationReport } from "../server/utils/stripeLedgerReconciliation";
+
+function argValue(flag: string): string | null {
+  const index = process.argv.indexOf(flag);
+  if (index < 0 || index + 1 >= process.argv.length) {
+    return null;
+  }
+  return process.argv[index + 1];
+}
+
+async function main() {
+  const toIso = argValue("--to") || new Date().toISOString();
+  const fromIso =
+    argValue("--from") ||
+    new Date(new Date(toIso).getTime() - 30 * 24 * 60 * 60 * 1000).toISOString();
+
+  const report = await buildStripeLedgerReconciliationReport({ fromIso, toIso });
+  console.log(JSON.stringify(report, null, 2));
+
+  if (report.drift_creator_count > 0) {
+    console.error(
+      `DRIFT: ${report.drift_creator_count}/${report.checked_creator_count} creators show journal/aggregate drift — investigate before trusting either source.`,
+    );
+    process.exit(1);
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(2);
+});

--- a/server/index.ts
+++ b/server/index.ts
@@ -42,6 +42,13 @@ const isProduction = process.env.NODE_ENV === "production";
 const disableOpsAutomationScheduler =
   process.env.BLUEPRINT_DISABLE_OPS_AUTOMATION_SCHEDULER === "1" ||
   process.env.VITE_BLUEPRINT_OPERATOR_QA_FAKE_AUTH === "1";
+// SCALE2-02: automation lanes run in the dedicated Render worker service
+// (server/worker.ts, `npm run start:worker`); the web process serves HTTP
+// only. This flag is a transition escape hatch for single-service deploys —
+// the ops automation leader lease still guarantees only one runner even if
+// both the worker service and an opted-in web instance are up.
+const runOpsAutomationInWebProcess =
+  process.env.BLUEPRINT_RUN_OPS_AUTOMATION_IN_WEB === "1";
 
 const noIndexPathPatterns = [
   /^\/admin(?:\/|$)/,
@@ -434,10 +441,16 @@ app.use((req, res, next) => {
   }
 
   const PORT = env.PORT;
-  const stopOpsAutomationScheduler = disableOpsAutomationScheduler
-    ? () => undefined
-    : startOpsAutomationScheduler();
-  if (disableOpsAutomationScheduler) {
+  const stopOpsAutomationScheduler =
+    runOpsAutomationInWebProcess && !disableOpsAutomationScheduler
+      ? startOpsAutomationScheduler()
+      : () => undefined;
+  if (!runOpsAutomationInWebProcess) {
+    logger.info(
+      attachRequestMeta({ route: "ops-automation-scheduler" }),
+      "Ops automation scheduler not started in web process; it runs in the blueprint-webapp-worker service (set BLUEPRINT_RUN_OPS_AUTOMATION_IN_WEB=1 to opt this process in)",
+    );
+  } else if (disableOpsAutomationScheduler) {
     logger.info(
       attachRequestMeta({ route: "ops-automation-scheduler" }),
       "Ops automation scheduler disabled for local QA",

--- a/server/routes/stripe-webhooks.ts
+++ b/server/routes/stripe-webhooks.ts
@@ -1,21 +1,30 @@
+/**
+ * Stripe webhook receipt (SCALE2-01).
+ *
+ * The synchronous job of this handler is deliberately tiny: verify the
+ * signature, dedupe via stripeWebhookEvents (both unchanged, load-bearing
+ * round-1 correctness guarantees), persist the event to the durable
+ * stripeWebhookQueue, and return 200. Processing runs on the worker service
+ * (server/utils/stripeWebhookQueue.ts -> stripeEventProcessor.ts), so payout
+ * batches and dispute waves never compete with live buyer/creator HTTP
+ * traffic for web event-loop time.
+ *
+ * BLUEPRINT_STRIPE_WEBHOOK_INLINE=1 restores the round-1 synchronous path
+ * (verify -> dedupe -> process in-request) for single-service deploys.
+ */
 import type { Request, Response } from "express";
 import type Stripe from "stripe";
 
 import {
-  applyCreatorPayoutWebhook,
   beginStripeWebhookEvent,
   completeStripeWebhookEvent,
   failStripeWebhookEvent,
-  fetchBuyerOrder,
-  findBuyerOrderByCheckoutSessionId,
-  findBuyerOrderByPaymentIntentId,
-  markBuyerOrderPaidFromCheckout,
-  markBuyerOrderDisputedFromCharge,
-  markBuyerOrderPaymentFailure,
 } from "../utils/accounting";
-import { createOnboardingSequence } from "../utils/buyer-onboarding";
-import { initRenewalTracking } from "../utils/growth-ops";
-import { recordBetaOpsFailureSignal } from "../utils/ops-alerts";
+import { processStripeWebhookEvent } from "../utils/stripeEventProcessor";
+import {
+  enqueueStripeWebhookEvent,
+  stripeWebhookInlineMode,
+} from "../utils/stripeWebhookQueue";
 import { stripeClient } from "../constants/stripe";
 
 const stripeWebhookSecret = (process.env.STRIPE_WEBHOOK_SECRET || "").trim();
@@ -46,215 +55,6 @@ function requireStripeWebhookContext(req: Request, res: Response) {
     stripe: stripeClient,
     signature,
   };
-}
-
-async function handleCheckoutSessionCompleted(
-  session: Stripe.Checkout.Session,
-  event: Stripe.Event,
-) {
-  const checkoutSessionId = session.id;
-  const order =
-    (await findBuyerOrderByCheckoutSessionId(checkoutSessionId)) ||
-    (session.client_reference_id
-      ? await fetchBuyerOrder(session.client_reference_id)
-      : null);
-  if (!order) {
-    return null;
-  }
-
-  if (session.payment_status === "paid") {
-    const paidOrder = await markBuyerOrderPaidFromCheckout({
-      orderId: order.id,
-      checkoutSessionId,
-      paymentIntentId:
-        typeof session.payment_intent === "string" ? session.payment_intent : null,
-      customerId: typeof session.customer === "string" ? session.customer : null,
-      livemode: session.livemode,
-      eventId: event.id,
-      eventType: event.type,
-    });
-
-    if (paidOrder?.id && paidOrder.buyer_email) {
-      void createOnboardingSequence({
-        orderId: paidOrder.id,
-        buyerEmail: paidOrder.buyer_email,
-        skuName: paidOrder.item.title || paidOrder.item.sku,
-        licenseTier: paidOrder.item.license_tier || "standard",
-      });
-
-      if (paidOrder.entitlement_id && paidOrder.paid_at) {
-        void initRenewalTracking({
-          entitlementId: paidOrder.entitlement_id,
-          orderId: paidOrder.id,
-          buyerEmail: paidOrder.buyer_email,
-          skuName: paidOrder.item.title || paidOrder.item.sku,
-          licenseTier: paidOrder.item.license_tier || "standard",
-          grantedAt: paidOrder.paid_at,
-        });
-      }
-    }
-
-    return paidOrder;
-  }
-
-  return null;
-}
-
-async function handleCheckoutSessionAsyncFailure(
-  session: Stripe.Checkout.Session,
-  event: Stripe.Event,
-) {
-  const order = await findBuyerOrderByCheckoutSessionId(session.id);
-  if (!order) {
-    return null;
-  }
-
-  await markBuyerOrderPaymentFailure({
-    orderId: order.id,
-    eventId: event.id,
-    eventType: event.type,
-    reason: "Stripe reported an asynchronous payment failure.",
-  });
-  return order.id;
-}
-
-async function handleCheckoutSessionExpired(
-  session: Stripe.Checkout.Session,
-  event: Stripe.Event,
-) {
-  const order = await findBuyerOrderByCheckoutSessionId(session.id);
-  if (!order) {
-    return null;
-  }
-
-  await markBuyerOrderPaymentFailure({
-    orderId: order.id,
-    eventId: event.id,
-    eventType: event.type,
-    reason: "Checkout session expired before payment completed.",
-    expired: true,
-  });
-  return order.id;
-}
-
-async function handleChargeRefunded(charge: Stripe.Charge, event: Stripe.Event) {
-  const paymentIntentId =
-    typeof charge.payment_intent === "string" ? charge.payment_intent : null;
-  const order = paymentIntentId
-    ? await findBuyerOrderByPaymentIntentId(paymentIntentId)
-    : null;
-  if (!order) {
-    return null;
-  }
-
-  await markBuyerOrderPaymentFailure({
-    orderId: order.id,
-    eventId: event.id,
-    eventType: event.type,
-    reason: "Stripe reported a refund for the marketplace order.",
-    refunded: true,
-  });
-  return order.id;
-}
-
-async function handleChargeDispute(dispute: Stripe.Dispute, event: Stripe.Event) {
-  const paymentIntentId =
-    typeof dispute.payment_intent === "string"
-      ? dispute.payment_intent
-      : dispute.payment_intent?.id || null;
-  const chargeId =
-    typeof dispute.charge === "string" ? dispute.charge : dispute.charge?.id || null;
-  const result = await markBuyerOrderDisputedFromCharge({
-    paymentIntentId,
-    chargeId,
-    disputeId: dispute.id,
-    disputeStatus: dispute.status || null,
-    disputeReason: dispute.reason || null,
-    amountCents: typeof dispute.amount === "number" ? dispute.amount : null,
-    currency: dispute.currency || null,
-    evidenceDueBy:
-      typeof dispute.evidence_details?.due_by === "number"
-        ? dispute.evidence_details.due_by
-        : null,
-    eventId: event.id,
-    eventType: event.type,
-  });
-  await recordBetaOpsFailureSignal({
-    kind: "payment_dispute",
-    scopeId: result.orderId || dispute.id,
-    severity: "critical",
-    summary: `Stripe reported ${event.type} for buyer payment ${paymentIntentId || "unknown"}.`,
-    details: {
-      order_id: result.orderId,
-      dispute_id: dispute.id,
-      dispute_status: dispute.status || null,
-      dispute_reason: dispute.reason || null,
-      payment_intent_id: paymentIntentId,
-      charge_id: chargeId,
-      held_payout_ids: result.heldPayoutIds,
-      unresolved_payout_ids: result.unresolvedPayoutIds,
-    },
-  });
-  return result.orderId;
-}
-
-async function handlePayoutEvent(
-  payout: Stripe.Payout,
-  event: Stripe.Event,
-): Promise<string | null> {
-  if (event.type === "payout.paid") {
-    return applyCreatorPayoutWebhook({
-      stripePayoutId: payout.id,
-      eventId: event.id,
-      eventType: event.type,
-      status: "paid",
-    });
-  }
-
-  if (event.type === "payout.failed") {
-    const disbursementId = await applyCreatorPayoutWebhook({
-      stripePayoutId: payout.id,
-      eventId: event.id,
-      eventType: event.type,
-      status: "failed",
-      failureReason: payout.failure_message || "Stripe payout failed.",
-    });
-    await recordBetaOpsFailureSignal({
-      kind: "payout_exception",
-      scopeId: disbursementId || payout.id,
-      severity: "critical",
-      summary: `Stripe payout failed for ${payout.id}.`,
-      details: {
-        stripe_payout_id: payout.id,
-        disbursement_id: disbursementId,
-        failure_message: payout.failure_message || null,
-      },
-    });
-    return disbursementId;
-  }
-
-  if (event.type === "payout.canceled") {
-    const disbursementId = await applyCreatorPayoutWebhook({
-      stripePayoutId: payout.id,
-      eventId: event.id,
-      eventType: event.type,
-      status: "canceled",
-      failureReason: "Stripe payout was canceled.",
-    });
-    await recordBetaOpsFailureSignal({
-      kind: "payout_exception",
-      scopeId: disbursementId || payout.id,
-      severity: "critical",
-      summary: `Stripe payout was canceled for ${payout.id}.`,
-      details: {
-        stripe_payout_id: payout.id,
-        disbursement_id: disbursementId,
-      },
-    });
-    return disbursementId;
-  }
-
-  return null;
 }
 
 /**
@@ -325,62 +125,27 @@ export async function stripeWebhookHandler(req: Request, res: Response) {
   // Fire-and-forget relay to Paperclip ops
   relayToPaperclipOps(event);
 
-  try {
-    let orderId: string | null = null;
-    let disbursementId: string | null = null;
-
-    switch (event.type) {
-      case "checkout.session.completed":
-      case "checkout.session.async_payment_succeeded": {
-        const order = await handleCheckoutSessionCompleted(
-          event.data.object as Stripe.Checkout.Session,
-          event,
-        );
-        orderId = order?.id || null;
-        break;
-      }
-      case "checkout.session.async_payment_failed": {
-        orderId = await handleCheckoutSessionAsyncFailure(
-          event.data.object as Stripe.Checkout.Session,
-          event,
-        );
-        break;
-      }
-      case "checkout.session.expired": {
-        orderId = await handleCheckoutSessionExpired(
-          event.data.object as Stripe.Checkout.Session,
-          event,
-        );
-        break;
-      }
-      case "charge.refunded": {
-        orderId = await handleChargeRefunded(
-          event.data.object as Stripe.Charge,
-          event,
-        );
-        break;
-      }
-      case "charge.dispute.created":
-      case "charge.dispute.closed": {
-        orderId = await handleChargeDispute(
-          event.data.object as Stripe.Dispute,
-          event,
-        );
-        break;
-      }
-      case "payout.paid":
-      case "payout.failed":
-      case "payout.canceled": {
-        disbursementId = await handlePayoutEvent(
-          event.data.object as Stripe.Payout,
-          event,
-        );
-        break;
-      }
-      default:
-        break;
+  if (!stripeWebhookInlineMode()) {
+    // Durable receipt: enqueue and acknowledge. The queue doc id is the
+    // Stripe event id, so a "retry" delivery whose queue doc already exists
+    // is acknowledged without a second enqueue.
+    try {
+      await enqueueStripeWebhookEvent(event);
+      return res.status(200).json({ received: true, queued: true });
+    } catch (error) {
+      // If the event can't be persisted we must NOT ack: report failure so
+      // Stripe redelivers, and roll the dedupe record back to retryable.
+      await failStripeWebhookEvent({
+        eventId: event.id,
+        eventType: event.type,
+        reason: `Webhook enqueue failed: ${(error as Error).message}`,
+      });
+      return res.status(500).json({ error: "Webhook enqueue failed." });
     }
+  }
 
+  try {
+    const { orderId, disbursementId } = await processStripeWebhookEvent(event);
     await completeStripeWebhookEvent({
       eventId: event.id,
       orderId,

--- a/server/tests/accounting-ledgers.test.ts
+++ b/server/tests/accounting-ledgers.test.ts
@@ -239,10 +239,15 @@ beforeEach(() => {
   state.docs.clear();
   state.constructEvent.mockReset();
   process.env.STRIPE_WEBHOOK_SECRET = "whsec_test";
+  // These tests exercise the synchronous processing path end-to-end; the
+  // queue transport (SCALE2-01) has its own tests in
+  // stripe-webhook-queue.test.ts.
+  process.env.BLUEPRINT_STRIPE_WEBHOOK_INLINE = "1";
 });
 
 afterEach(() => {
   delete process.env.STRIPE_WEBHOOK_SECRET;
+  delete process.env.BLUEPRINT_STRIPE_WEBHOOK_INLINE;
 });
 
 describe("accounting ledgers", () => {

--- a/server/tests/firestore-indexes-capture-shard.test.ts
+++ b/server/tests/firestore-indexes-capture-shard.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment node
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * SCALE2-07: the round-1 `createdAtShard` write on `creatorCaptures`
+ * (server/routes/creator.ts + utils/captureShard.ts) is only useful if this
+ * repo — the owner of the webapp Firestore database's index manifest —
+ * actually declares the sharded composite indexes readers will fan out
+ * through. Round 1 shipped the write but the matching composites lived (as
+ * phantoms) in BlueprintCapturePipeline Terraform against a nonexistent
+ * `captures` collection. These assertions keep the real indexes pinned here.
+ */
+
+type IndexField = { fieldPath: string; order?: string; arrayConfig?: string };
+type IndexEntry = { collectionGroup: string; queryScope: string; fields: IndexField[] };
+
+const manifest = JSON.parse(
+  readFileSync(join(__dirname, "..", "..", "firestore.indexes.json"), "utf8"),
+) as { indexes: IndexEntry[] };
+
+function hasIndex(collection: string, fields: Array<[string, string]>): boolean {
+  return manifest.indexes.some(
+    (index) =>
+      index.collectionGroup === collection &&
+      index.fields.length === fields.length &&
+      index.fields.every(
+        (field, i) => field.fieldPath === fields[i][0] && field.order === fields[i][1],
+      ),
+  );
+}
+
+describe("firestore.indexes.json creatorCaptures shard composites", () => {
+  it("keeps the base creator_id + created_at composite", () => {
+    expect(
+      hasIndex("creatorCaptures", [
+        ["creator_id", "ASCENDING"],
+        ["created_at", "DESCENDING"],
+      ]),
+    ).toBe(true);
+  });
+
+  it("declares the per-creator sharded composite (creator_id + createdAtShard + created_at)", () => {
+    expect(
+      hasIndex("creatorCaptures", [
+        ["creator_id", "ASCENDING"],
+        ["createdAtShard", "ASCENDING"],
+        ["created_at", "DESCENDING"],
+      ]),
+    ).toBe(true);
+  });
+
+  it("declares the status-scan sharded composite (status + createdAtShard + created_at)", () => {
+    expect(
+      hasIndex("creatorCaptures", [
+        ["status", "ASCENDING"],
+        ["createdAtShard", "ASCENDING"],
+        ["created_at", "ASCENDING"],
+      ]),
+    ).toBe(true);
+  });
+
+  it("declares no indexes for a literal `captures` collection (nothing writes one)", () => {
+    expect(manifest.indexes.filter((index) => index.collectionGroup === "captures")).toEqual([]);
+  });
+});

--- a/server/tests/helpers/fake-firestore.ts
+++ b/server/tests/helpers/fake-firestore.ts
@@ -1,0 +1,225 @@
+/**
+ * In-memory Firestore fake for SCALE2-01 queue/journal tests.
+ *
+ * Extends the pattern used by accounting-ledgers.test.ts with the query
+ * features the webhook queue and reconciliation report need: range operators
+ * (<=, >=), orderBy, and limit. Transactions buffer writes and commit
+ * atomically after the callback resolves, mirroring Firestore semantics
+ * closely enough to exercise reads-before-writes journal logic.
+ */
+
+export type StoredDoc = Record<string, unknown>;
+
+export type FakeFirestoreState = {
+  docs: Map<string, StoredDoc>;
+};
+
+export function createFakeFirestoreState(): FakeFirestoreState {
+  return { docs: new Map() };
+}
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function deepMerge(
+  target: Record<string, unknown>,
+  source: Record<string, unknown>,
+): Record<string, unknown> {
+  const merged: Record<string, unknown> = { ...target };
+  for (const [key, value] of Object.entries(source)) {
+    const existing = merged[key];
+    if (isPlainObject(existing) && isPlainObject(value)) {
+      merged[key] = deepMerge(existing, value);
+      continue;
+    }
+    merged[key] = clone(value);
+  }
+  return merged;
+}
+
+type QueryFilter = { field: string; op: string; value: unknown };
+type QueryOrder = { field: string; direction: "asc" | "desc" };
+
+function compareValues(a: unknown, b: unknown): number {
+  if (typeof a === "number" && typeof b === "number") {
+    return a - b;
+  }
+  return String(a).localeCompare(String(b));
+}
+
+function queryMatches(data: StoredDoc, filter: QueryFilter): boolean {
+  const actual = data[filter.field];
+  switch (filter.op) {
+    case "==":
+      return actual === filter.value;
+    case "in":
+      return Array.isArray(filter.value) && (filter.value as unknown[]).includes(actual);
+    case "<=":
+      return compareValues(actual, filter.value) <= 0;
+    case ">=":
+      return compareValues(actual, filter.value) >= 0;
+    case "<":
+      return compareValues(actual, filter.value) < 0;
+    case ">":
+      return compareValues(actual, filter.value) > 0;
+    default:
+      throw new Error(`Unsupported operator ${filter.op}`);
+  }
+}
+
+export function createFakeFirestore(state: FakeFirestoreState) {
+  const docKey = (collection: string, id: string) => `${collection}/${id}`;
+
+  const readDoc = (collection: string, id: string): StoredDoc | undefined => {
+    const stored = state.docs.get(docKey(collection, id));
+    return stored ? clone(stored) : undefined;
+  };
+
+  function makeDocRef(collectionName: string, id: string) {
+    return {
+      id,
+      __collection: collectionName,
+      get: async () => ({
+        id,
+        exists: Boolean(readDoc(collectionName, id)),
+        data: () => readDoc(collectionName, id),
+      }),
+      set: async (payload: StoredDoc, options?: { merge?: boolean }) => {
+        const existing = readDoc(collectionName, id) || {};
+        state.docs.set(
+          docKey(collectionName, id),
+          options?.merge ? deepMerge(existing, payload) : clone(payload),
+        );
+      },
+      update: async (payload: StoredDoc) => {
+        const existing = readDoc(collectionName, id) || {};
+        state.docs.set(docKey(collectionName, id), deepMerge(existing, payload));
+      },
+      create: async (payload: StoredDoc) => {
+        const key = docKey(collectionName, id);
+        if (state.docs.has(key)) {
+          const error = new Error("already exists") as Error & { code?: string };
+          error.code = "already-exists";
+          throw error;
+        }
+        state.docs.set(key, clone(payload));
+      },
+    };
+  }
+
+  type MockDocRef = ReturnType<typeof makeDocRef>;
+
+  function makeQuery(
+    collectionName: string,
+    filters: QueryFilter[],
+    orders: QueryOrder[] = [],
+    limitCount: number | null = null,
+  ) {
+    return {
+      where: (field: string, op: string, value: unknown) =>
+        makeQuery(collectionName, [...filters, { field, op, value }], orders, limitCount),
+      orderBy: (field: string, direction: "asc" | "desc" = "asc") =>
+        makeQuery(collectionName, filters, [...orders, { field, direction }], limitCount),
+      limit: (count: number) => makeQuery(collectionName, filters, orders, count),
+      get: async () => {
+        let entries = Array.from(state.docs.entries())
+          .filter(([key, data]) => {
+            if (!key.startsWith(`${collectionName}/`)) {
+              return false;
+            }
+            return filters.every((filter) => queryMatches(data, filter));
+          })
+          .map(([key, data]) => ({
+            id: key.slice(collectionName.length + 1),
+            data: clone(data),
+          }));
+        for (const order of [...orders].reverse()) {
+          entries = entries.sort((a, b) => {
+            const comparison = compareValues(a.data[order.field], b.data[order.field]);
+            return order.direction === "desc" ? -comparison : comparison;
+          });
+        }
+        if (limitCount !== null) {
+          entries = entries.slice(0, limitCount);
+        }
+        return {
+          docs: entries.map((entry) => ({
+            id: entry.id,
+            data: () => clone(entry.data),
+            ref: makeDocRef(collectionName, entry.id),
+          })),
+        };
+      },
+    };
+  }
+
+  return {
+    collection: (collectionName: string) => ({
+      doc: (id: string) => makeDocRef(collectionName, id),
+      where: (field: string, op: string, value: unknown) =>
+        makeQuery(collectionName, [{ field, op, value }]),
+      orderBy: (field: string, direction: "asc" | "desc" = "asc") =>
+        makeQuery(collectionName, [], [{ field, direction }]),
+    }),
+    runTransaction: async <T>(
+      updateFn: (tx: {
+        get: (ref: MockDocRef) => Promise<{
+          id: string;
+          exists: boolean;
+          data: () => StoredDoc | undefined;
+        }>;
+        set: (ref: MockDocRef, payload: StoredDoc, options?: { merge?: boolean }) => void;
+        update: (ref: MockDocRef, payload: StoredDoc) => void;
+      }) => Promise<T>,
+    ): Promise<T> => {
+      const writes: Array<() => void> = [];
+      const tx = {
+        // Accepts doc refs and query objects (Firestore transactions allow
+        // tx.get(query), used by the earnings-aggregate lazy backfill).
+        get: async (ref: MockDocRef | { get: () => Promise<unknown>; __collection?: undefined }) => {
+          if (!("__collection" in ref) || ref.__collection === undefined) {
+            return (ref as { get: () => Promise<never> }).get();
+          }
+          const docRef = ref as MockDocRef;
+          return {
+            id: docRef.id,
+            exists: Boolean(readDoc(docRef.__collection, docRef.id)),
+            data: () => readDoc(docRef.__collection, docRef.id),
+          };
+        },
+        set: (ref: MockDocRef, payload: StoredDoc, options?: { merge?: boolean }) => {
+          writes.push(() => {
+            const existing = readDoc(ref.__collection, ref.id) || {};
+            state.docs.set(
+              docKey(ref.__collection, ref.id),
+              options?.merge ? deepMerge(existing, payload) : clone(payload),
+            );
+          });
+        },
+        update: (ref: MockDocRef, payload: StoredDoc) => {
+          writes.push(() => {
+            const existing = readDoc(ref.__collection, ref.id) || {};
+            state.docs.set(docKey(ref.__collection, ref.id), deepMerge(existing, payload));
+          });
+        },
+      };
+      const result = await updateFn(tx);
+      for (const write of writes) {
+        write();
+      }
+      return result;
+    },
+  };
+}
+
+/**
+ * Module-level singleton so a vi.mock factory and the test body observe the
+ * same store. Call `sharedFakeFirestoreState.docs.clear()` in beforeEach.
+ */
+export const sharedFakeFirestoreState = createFakeFirestoreState();
+export const sharedFakeFirestore = createFakeFirestore(sharedFakeFirestoreState);

--- a/server/tests/robot-eval-checkout-session.test.ts
+++ b/server/tests/robot-eval-checkout-session.test.ts
@@ -79,6 +79,48 @@ vi.mock("../../client/src/lib/firebaseAdmin", () => ({
       where: (field: string, _op: string, value: unknown) =>
         buildQuery(name, [{ field, value }]),
     }),
+    // Minimal transaction emulation for the SCALE2-01 journal-atomic money
+    // paths: reads delegate to the ref, writes buffer and commit after the
+    // callback resolves.
+    runTransaction: async <T>(
+      updateFn: (tx: {
+        get: (ref: {
+          get: () => Promise<unknown>;
+        }) => Promise<unknown>;
+        set: (
+          ref: { set: (payload: Record<string, unknown>, options?: Record<string, unknown>) => Promise<void> },
+          payload: Record<string, unknown>,
+          options?: Record<string, unknown>,
+        ) => void;
+        update: (
+          ref: { set: (payload: Record<string, unknown>, options?: Record<string, unknown>) => Promise<void> },
+          payload: Record<string, unknown>,
+        ) => void;
+      }) => Promise<T>,
+    ): Promise<T> => {
+      const writes: Array<() => Promise<void>> = [];
+      const tx = {
+        get: async (ref: { get: () => Promise<unknown> }) => ref.get(),
+        set: (
+          ref: { set: (payload: Record<string, unknown>, options?: Record<string, unknown>) => Promise<void> },
+          payload: Record<string, unknown>,
+          options?: Record<string, unknown>,
+        ) => {
+          writes.push(() => ref.set(payload, options));
+        },
+        update: (
+          ref: { set: (payload: Record<string, unknown>, options?: Record<string, unknown>) => Promise<void> },
+          payload: Record<string, unknown>,
+        ) => {
+          writes.push(() => ref.set(payload, { merge: true }));
+        },
+      };
+      const result = await updateFn(tx);
+      for (const write of writes) {
+        await write();
+      }
+      return result;
+    },
   },
   authAdmin: {
     verifyIdToken: async (token: string) => ({ uid: token, email: `${token}@example.com` }),

--- a/server/tests/stripe-ledger-journal.test.ts
+++ b/server/tests/stripe-ledger-journal.test.ts
@@ -154,6 +154,66 @@ describe("stripe ledger journal", () => {
     expect(JSON.stringify(docs.get(settledKey))).toBe(settledBefore);
   });
 
+  it("journals per-event refund deltas from Stripe's cumulative amount_refunded", async () => {
+    const { markBuyerOrderPaymentFailure } = await import("../utils/accounting");
+    docs.set("buyerOrders/order-1", {
+      id: "order-1",
+      currency: "usd",
+      pricing: { total_amount_cents: 25_000 },
+      status: "paid",
+    });
+
+    // First partial refund: cumulative 10,000 -> delta 10,000.
+    await markBuyerOrderPaymentFailure({
+      orderId: "order-1",
+      eventId: "evt_refund_1",
+      eventType: "charge.refunded",
+      reason: "partial refund",
+      refunded: true,
+      refundedAmountCents: 10_000,
+      refundCurrency: "usd",
+    });
+    expect(docs.get("stripeLedgerJournal/order_refunded:evt_refund_1")).toMatchObject({
+      entry_type: "order_refunded",
+      amount_cents: 10_000,
+    });
+    expect(docs.get("buyerOrders/order-1")).toMatchObject({ refunded_amount_cents: 10_000 });
+
+    // Second partial refund: cumulative 15,000 -> delta 5,000, not the full
+    // order total and not the cumulative again.
+    await markBuyerOrderPaymentFailure({
+      orderId: "order-1",
+      eventId: "evt_refund_2",
+      eventType: "charge.refunded",
+      reason: "second partial refund",
+      refunded: true,
+      refundedAmountCents: 15_000,
+      refundCurrency: "usd",
+    });
+    expect(docs.get("stripeLedgerJournal/order_refunded:evt_refund_2")).toMatchObject({
+      amount_cents: 5_000,
+    });
+    expect(docs.get("buyerOrders/order-1")).toMatchObject({ refunded_amount_cents: 15_000 });
+
+    // Refund event without an amount (defensive): full-order fallback.
+    docs.set("buyerOrders/order-2", {
+      id: "order-2",
+      currency: "usd",
+      pricing: { total_amount_cents: 8_000 },
+      status: "paid",
+    });
+    await markBuyerOrderPaymentFailure({
+      orderId: "order-2",
+      eventId: "evt_refund_3",
+      eventType: "charge.refunded",
+      reason: "full refund",
+      refunded: true,
+    });
+    expect(docs.get("stripeLedgerJournal/order_refunded:evt_refund_3")).toMatchObject({
+      amount_cents: 8_000,
+    });
+  });
+
   it("detects journal/aggregate drift in the reconciliation report", async () => {
     // Full lifecycle: approve -> disburse -> settle, which also maintains the
     // creatorEarningsAggregates doc transactionally. Materialize the

--- a/server/tests/stripe-ledger-journal.test.ts
+++ b/server/tests/stripe-ledger-journal.test.ts
@@ -1,0 +1,217 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { sharedFakeFirestoreState } from "./helpers/fake-firestore";
+
+/**
+ * SCALE2-01 append-only journal: every financial state transition writes one
+ * immutable stripeLedgerJournal document atomically with the corresponding
+ * ledger write; replays never duplicate entries; the reconciliation report
+ * detects journal/aggregate drift instead of trusting either source.
+ */
+
+vi.mock("../../client/src/lib/firebaseAdmin", async () => {
+  const { sharedFakeFirestore } = await import("./helpers/fake-firestore");
+  return { default: {}, dbAdmin: sharedFakeFirestore };
+});
+
+const docs = sharedFakeFirestoreState.docs;
+
+function journalKeys(): string[] {
+  return Array.from(docs.keys())
+    .filter((key) => key.startsWith("stripeLedgerJournal/"))
+    .sort();
+}
+
+const PIPELINE_RECOMMENDATION = {
+  status: "baseline",
+  base_payout_cents: 4500,
+  recommended_payout_cents: 4500,
+  payout_funding_policy: {
+    mode: "buyer_revenue_linked",
+    buyer_order_id: "order-paid-1",
+    realized_buyer_revenue_cents: 10000,
+  },
+  reasons: [],
+};
+
+async function approvePayoutFixture() {
+  const { upsertCreatorPayoutFromPipeline } = await import("../utils/accounting");
+  docs.set("capture_submissions/cap-1", {
+    creator_id: "creator-123",
+    status: "submitted",
+    payout_cents: 0,
+  });
+  return upsertCreatorPayoutFromPipeline({
+    captureId: "cap-1",
+    sceneId: "scene-1",
+    captureJobId: "job-1",
+    buyerRequestId: "req-1",
+    siteSubmissionId: "site-1",
+    qualificationState: "qualified_ready",
+    opportunityState: "handoff_ready",
+    recommendation: PIPELINE_RECOMMENDATION,
+    recommendationUri: "gs://bucket/payout.json",
+    stripeConnectAccountId: "acct_creator_123",
+  });
+}
+
+beforeEach(() => {
+  docs.clear();
+});
+
+describe("stripe ledger journal", () => {
+  it("journals payout approval exactly once across pipeline re-upserts", async () => {
+    const payout = await approvePayoutFixture();
+    expect(payout?.status).toBe("approved");
+
+    expect(journalKeys()).toEqual(["stripeLedgerJournal/payout_approved:cap-1"]);
+    expect(docs.get("stripeLedgerJournal/payout_approved:cap-1")).toMatchObject({
+      entry_type: "payout_approved",
+      amount_cents: 4500,
+      creator_id: "creator-123",
+      direction: "creator_payout_out",
+    });
+
+    // Re-qualification churn re-upserts the payout; the deterministic entry
+    // id + in-transaction existence check keep the journal append-only.
+    const before = JSON.stringify(docs.get("stripeLedgerJournal/payout_approved:cap-1"));
+    const { upsertCreatorPayoutFromPipeline } = await import("../utils/accounting");
+    await upsertCreatorPayoutFromPipeline({
+      captureId: "cap-1",
+      sceneId: "scene-1",
+      captureJobId: "job-1",
+      buyerRequestId: "req-1",
+      siteSubmissionId: "site-1",
+      qualificationState: "qualified_ready",
+      opportunityState: "handoff_ready",
+      recommendation: PIPELINE_RECOMMENDATION,
+      recommendationUri: "gs://bucket/payout.json",
+      stripeConnectAccountId: "acct_creator_123",
+    });
+    expect(journalKeys()).toEqual(["stripeLedgerJournal/payout_approved:cap-1"]);
+    expect(JSON.stringify(docs.get("stripeLedgerJournal/payout_approved:cap-1"))).toBe(
+      before,
+    );
+  });
+
+  it("journals disbursement initiation and settlement atomically with the payout writes", async () => {
+    await approvePayoutFixture();
+    const {
+      applyCreatorPayoutWebhook,
+      beginCreatorPayoutDisbursement,
+      finalizeCreatorPayoutDisbursement,
+    } = await import("../utils/accounting");
+
+    const disbursement = await beginCreatorPayoutDisbursement({
+      creatorId: "creator-123",
+      stripeConnectAccountId: "acct_creator_123",
+    });
+    expect(disbursement).not.toBeNull();
+    const disbursementId = disbursement!.disbursement.id;
+
+    const initiationKey = `stripeLedgerJournal/disbursement_initiated:${disbursementId}`;
+    expect(docs.get(initiationKey)).toMatchObject({
+      entry_type: "disbursement_initiated",
+      amount_cents: 4500,
+      creator_id: "creator-123",
+      disbursement_id: disbursementId,
+      payout_entry_ids: ["cap-1"],
+    });
+
+    await finalizeCreatorPayoutDisbursement({
+      disbursementId,
+      stripePayoutId: "po_test_123",
+    });
+    await applyCreatorPayoutWebhook({
+      stripePayoutId: "po_test_123",
+      eventId: "evt_payout_paid_1",
+      eventType: "payout.paid",
+      status: "paid",
+    });
+
+    const settledKey = "stripeLedgerJournal/disbursement_settled:evt_payout_paid_1";
+    expect(docs.get(settledKey)).toMatchObject({
+      entry_type: "disbursement_settled",
+      amount_cents: 4500,
+      creator_id: "creator-123",
+      disbursement_id: disbursementId,
+      stripe_event_id: "evt_payout_paid_1",
+    });
+    expect(docs.get("creatorPayouts/cap-1")).toMatchObject({ status: "paid" });
+
+    // Replayed webhook (same event id): ledger writes are idempotent merges
+    // and the journal must not grow or mutate.
+    const journalBefore = journalKeys();
+    const settledBefore = JSON.stringify(docs.get(settledKey));
+    await applyCreatorPayoutWebhook({
+      stripePayoutId: "po_test_123",
+      eventId: "evt_payout_paid_1",
+      eventType: "payout.paid",
+      status: "paid",
+    });
+    expect(journalKeys()).toEqual(journalBefore);
+    expect(JSON.stringify(docs.get(settledKey))).toBe(settledBefore);
+  });
+
+  it("detects journal/aggregate drift in the reconciliation report", async () => {
+    // Full lifecycle: approve -> disburse -> settle, which also maintains the
+    // creatorEarningsAggregates doc transactionally. Materialize the
+    // aggregate first so the incremental maintenance path is active.
+    const { readCreatorEarningsAggregate } = await import("../utils/accounting");
+    await approvePayoutFixture();
+    await readCreatorEarningsAggregate("creator-123");
+    const {
+      applyCreatorPayoutWebhook,
+      beginCreatorPayoutDisbursement,
+      finalizeCreatorPayoutDisbursement,
+    } = await import("../utils/accounting");
+    const disbursement = await beginCreatorPayoutDisbursement({
+      creatorId: "creator-123",
+      stripeConnectAccountId: "acct_creator_123",
+    });
+    await finalizeCreatorPayoutDisbursement({
+      disbursementId: disbursement!.disbursement.id,
+      stripePayoutId: "po_test_123",
+    });
+    await applyCreatorPayoutWebhook({
+      stripePayoutId: "po_test_123",
+      eventId: "evt_payout_paid_1",
+      eventType: "payout.paid",
+      status: "paid",
+    });
+
+    const { buildStripeLedgerReconciliationReport } = await import(
+      "../utils/stripeLedgerReconciliation"
+    );
+    const from = "1970-01-01T00:00:00.000Z";
+    const to = "2999-01-01T00:00:00.000Z";
+
+    // Consistent state: journal settled total matches the aggregate paid
+    // bucket -> no drift.
+    const clean = await buildStripeLedgerReconciliationReport({ fromIso: from, toIso: to });
+    expect(clean.totals.disbursements_settled_cents).toBe(4500);
+    expect(clean.totals.payouts_approved_cents).toBe(4500);
+    expect(clean.drift_creator_count).toBe(0);
+    expect(clean.checked_creator_count).toBe(1);
+
+    // Corrupt the aggregate (simulating a missed transactional update):
+    // reconciliation must flag it, not silently trust either source.
+    const aggregate = docs.get("creatorEarningsAggregates/creator-123")!;
+    const statusTotals = aggregate.status_totals as Record<
+      string,
+      { count: number; approved_amount_cents: number }
+    >;
+    statusTotals.paid = { count: 1, approved_amount_cents: 999 };
+    docs.set("creatorEarningsAggregates/creator-123", aggregate);
+
+    const drifted = await buildStripeLedgerReconciliationReport({ fromIso: from, toIso: to });
+    expect(drifted.drift_creator_count).toBe(1);
+    expect(drifted.creator_drift[0]).toMatchObject({
+      creator_id: "creator-123",
+      journal_settled_cents: 4500,
+      aggregate_paid_cents: 999,
+      drift_cents: 4500 - 999,
+    });
+  });
+});

--- a/server/tests/stripe-webhook-queue-retry.test.ts
+++ b/server/tests/stripe-webhook-queue-retry.test.ts
@@ -101,11 +101,79 @@ describe("stripe webhook queue retry + dead-letter", () => {
   it("claims transactionally so a job already processing is not double-claimed", async () => {
     seedQueuedEvent("evt_claim_1");
     const job = docs.get("stripeWebhookQueue/evt_claim_1")!;
-    docs.set("stripeWebhookQueue/evt_claim_1", { ...job, status: "processing" });
+    docs.set("stripeWebhookQueue/evt_claim_1", {
+      ...job,
+      status: "processing",
+      processing_started_at: new Date().toISOString(),
+    });
 
     const { drainStripeWebhookQueueOnce } = await import("../utils/stripeWebhookQueue");
     const result = await drainStripeWebhookQueueOnce();
-    expect(result).toMatchObject({ claimed: 0, processed: 0 });
+    expect(result).toMatchObject({ claimed: 0, reclaimed: 0, processed: 0 });
     expect(processStripeWebhookEvent).not.toHaveBeenCalled();
+  });
+
+  it("reclaims and processes a job abandoned mid-processing past the visibility timeout", async () => {
+    // Worker crashed after claim, before settle: status stuck at
+    // "processing" with a stale claim timestamp. Without reclaim this
+    // acknowledged money-plane event would never be processed.
+    seedQueuedEvent("evt_abandoned_1");
+    const job = docs.get("stripeWebhookQueue/evt_abandoned_1")!;
+    docs.set("stripeWebhookQueue/evt_abandoned_1", {
+      ...job,
+      status: "processing",
+      attempts: 1,
+      processing_started_at: new Date(Date.now() - 30 * 60_000).toISOString(),
+    });
+    docs.set("stripeWebhookEvents/evt_abandoned_1", { status: "processing" });
+    processStripeWebhookEvent.mockResolvedValue({ orderId: null, disbursementId: "disb-1" });
+
+    const { drainStripeWebhookQueueOnce } = await import("../utils/stripeWebhookQueue");
+    const result = await drainStripeWebhookQueueOnce();
+    expect(result).toMatchObject({ claimed: 0, reclaimed: 1, processed: 1 });
+    expect(docs.get("stripeWebhookQueue/evt_abandoned_1")).toMatchObject({
+      status: "processed",
+      attempts: 2,
+    });
+
+    // A second drain finds nothing left to reclaim.
+    const second = await drainStripeWebhookQueueOnce();
+    expect(second).toMatchObject({ claimed: 0, reclaimed: 0 });
+  });
+
+  it("leaves a fresh processing claim alone (visibility timeout respected)", async () => {
+    seedQueuedEvent("evt_active_1");
+    const job = docs.get("stripeWebhookQueue/evt_active_1")!;
+    docs.set("stripeWebhookQueue/evt_active_1", {
+      ...job,
+      status: "processing",
+      processing_started_at: new Date(Date.now() - 60_000).toISOString(),
+    });
+
+    const { drainStripeWebhookQueueOnce } = await import("../utils/stripeWebhookQueue");
+    const result = await drainStripeWebhookQueueOnce();
+    expect(result).toMatchObject({ reclaimed: 0 });
+    expect(processStripeWebhookEvent).not.toHaveBeenCalled();
+    expect(docs.get("stripeWebhookQueue/evt_active_1")).toMatchObject({ status: "processing" });
+  });
+
+  it("dead-letters an abandoned job whose reclaim exhausts the attempt budget", async () => {
+    process.env.BLUEPRINT_STRIPE_WEBHOOK_QUEUE_MAX_ATTEMPTS = "2";
+    seedQueuedEvent("evt_abandoned_dead_1");
+    const job = docs.get("stripeWebhookQueue/evt_abandoned_dead_1")!;
+    docs.set("stripeWebhookQueue/evt_abandoned_dead_1", {
+      ...job,
+      status: "processing",
+      attempts: 1,
+      processing_started_at: new Date(Date.now() - 30 * 60_000).toISOString(),
+    });
+    docs.set("stripeWebhookEvents/evt_abandoned_dead_1", { status: "processing" });
+    processStripeWebhookEvent.mockRejectedValue(new Error("still broken"));
+
+    const { drainStripeWebhookQueueOnce } = await import("../utils/stripeWebhookQueue");
+    const result = await drainStripeWebhookQueueOnce();
+    expect(result).toMatchObject({ reclaimed: 1, deadLettered: 1 });
+    expect(docs.get("stripeWebhookQueue/evt_abandoned_dead_1")).toMatchObject({ status: "dead" });
+    expect(docs.get("stripeWebhookDeadLetters/evt_abandoned_dead_1")).toBeTruthy();
   });
 });

--- a/server/tests/stripe-webhook-queue-retry.test.ts
+++ b/server/tests/stripe-webhook-queue-retry.test.ts
@@ -1,0 +1,111 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { sharedFakeFirestoreState } from "./helpers/fake-firestore";
+
+/**
+ * SCALE2-01 queue failure mechanics: bounded retry with backoff, then
+ * dead-letter + ops failure signal (existing opsAlerts pattern) + failed
+ * dedupe record.
+ */
+
+const processStripeWebhookEvent = vi.hoisted(() => vi.fn());
+const recordBetaOpsFailureSignal = vi.hoisted(() => vi.fn(async () => ({ recorded: true })));
+
+vi.mock("../../client/src/lib/firebaseAdmin", async () => {
+  const { sharedFakeFirestore } = await import("./helpers/fake-firestore");
+  return { default: {}, dbAdmin: sharedFakeFirestore };
+});
+
+vi.mock("../utils/stripeEventProcessor", () => ({ processStripeWebhookEvent }));
+vi.mock("../utils/ops-alerts", () => ({ recordBetaOpsFailureSignal }));
+
+const docs = sharedFakeFirestoreState.docs;
+
+function seedQueuedEvent(eventId: string, attempts = 0) {
+  docs.set(`stripeWebhookQueue/${eventId}`, {
+    status: "queued",
+    event_id: eventId,
+    event_type: "payout.failed",
+    livemode: false,
+    event: { id: eventId, type: "payout.failed", data: { object: {} } },
+    attempts,
+    next_attempt_at: "1970-01-01T00:00:00.000Z",
+    created_at: "1970-01-01T00:00:00.000Z",
+    updated_at: "1970-01-01T00:00:00.000Z",
+  });
+}
+
+beforeEach(() => {
+  docs.clear();
+  processStripeWebhookEvent.mockReset();
+  recordBetaOpsFailureSignal.mockClear();
+  delete process.env.BLUEPRINT_STRIPE_WEBHOOK_QUEUE_MAX_ATTEMPTS;
+});
+
+describe("stripe webhook queue retry + dead-letter", () => {
+  it("requeues a failed job with exponential backoff and increments attempts", async () => {
+    seedQueuedEvent("evt_retry_1");
+    processStripeWebhookEvent.mockRejectedValue(new Error("firestore unavailable"));
+
+    const { drainStripeWebhookQueueOnce } = await import("../utils/stripeWebhookQueue");
+    const result = await drainStripeWebhookQueueOnce();
+    expect(result).toMatchObject({ claimed: 1, processed: 0, retried: 1, deadLettered: 0 });
+
+    const jobDoc = docs.get("stripeWebhookQueue/evt_retry_1");
+    expect(jobDoc).toMatchObject({
+      status: "queued",
+      attempts: 1,
+      last_error: "firestore unavailable",
+    });
+    expect(String(jobDoc?.next_attempt_at) > new Date().toISOString()).toBe(true);
+    expect(recordBetaOpsFailureSignal).not.toHaveBeenCalled();
+  });
+
+  it("dead-letters after max attempts, fails the dedupe record, and raises an ops signal", async () => {
+    process.env.BLUEPRINT_STRIPE_WEBHOOK_QUEUE_MAX_ATTEMPTS = "2";
+    // attempts=1 already burned; this claim is attempt 2 of 2.
+    seedQueuedEvent("evt_dead_1", 1);
+    docs.set("stripeWebhookEvents/evt_dead_1", { status: "processing" });
+    processStripeWebhookEvent.mockRejectedValue(new Error("permanently broken"));
+
+    const { drainStripeWebhookQueueOnce } = await import("../utils/stripeWebhookQueue");
+    const result = await drainStripeWebhookQueueOnce();
+    expect(result).toMatchObject({ claimed: 1, retried: 0, deadLettered: 1 });
+
+    expect(docs.get("stripeWebhookQueue/evt_dead_1")).toMatchObject({
+      status: "dead",
+      attempts: 2,
+    });
+    expect(docs.get("stripeWebhookDeadLetters/evt_dead_1")).toMatchObject({
+      event_id: "evt_dead_1",
+      attempts: 2,
+      last_error: "permanently broken",
+    });
+    expect(docs.get("stripeWebhookEvents/evt_dead_1")).toMatchObject({
+      status: "failed",
+    });
+    expect(recordBetaOpsFailureSignal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "payment_webhook_dead_letter",
+        severity: "critical",
+        scopeId: "evt_dead_1",
+      }),
+    );
+
+    // A dead job is never claimed again.
+    const secondDrain = await drainStripeWebhookQueueOnce();
+    expect(secondDrain).toMatchObject({ claimed: 0 });
+  });
+
+  it("claims transactionally so a job already processing is not double-claimed", async () => {
+    seedQueuedEvent("evt_claim_1");
+    const job = docs.get("stripeWebhookQueue/evt_claim_1")!;
+    docs.set("stripeWebhookQueue/evt_claim_1", { ...job, status: "processing" });
+
+    const { drainStripeWebhookQueueOnce } = await import("../utils/stripeWebhookQueue");
+    const result = await drainStripeWebhookQueueOnce();
+    expect(result).toMatchObject({ claimed: 0, processed: 0 });
+    expect(processStripeWebhookEvent).not.toHaveBeenCalled();
+  });
+});

--- a/server/tests/stripe-webhook-queue.test.ts
+++ b/server/tests/stripe-webhook-queue.test.ts
@@ -1,0 +1,229 @@
+// @vitest-environment node
+import express from "express";
+import { createServer } from "http";
+import type { Server } from "node:http";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { sharedFakeFirestoreState } from "./helpers/fake-firestore";
+
+/**
+ * SCALE2-01 end-to-end: webhook receipt enqueues durably and returns 200; the
+ * queue drain performs the actual accounting writes; double-processing the
+ * same event never double-writes the append-only stripeLedgerJournal.
+ */
+
+const constructEvent = vi.hoisted(() => vi.fn());
+
+vi.mock("../../client/src/lib/firebaseAdmin", async () => {
+  const { sharedFakeFirestore } = await import("./helpers/fake-firestore");
+  return { default: {}, dbAdmin: sharedFakeFirestore };
+});
+
+vi.mock("../constants/stripe", () => ({
+  stripeClient: {
+    webhooks: {
+      constructEvent,
+    },
+  },
+}));
+
+const docs = sharedFakeFirestoreState.docs;
+
+async function startWebhookServer() {
+  const { stripeWebhookHandler } = await import("../routes/stripe-webhooks");
+  const app = express();
+  app.post(
+    "/api/stripe/webhooks",
+    express.raw({ type: "application/json" }),
+    stripeWebhookHandler,
+  );
+  const server = createServer(app);
+  await new Promise<void>((resolve) => server.listen(0, () => resolve()));
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Failed to bind test server");
+  }
+  return { server, baseUrl: `http://127.0.0.1:${address.port}` };
+}
+
+async function stopServer(server: Server) {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+async function seedPaidCheckoutFixture() {
+  const { createBuyerOrderDraft, attachStripeCheckoutSessionToBuyerOrder } =
+    await import("../utils/accounting");
+  const order = await createBuyerOrderDraft({
+    buyerUserId: "buyer-1",
+    buyerEmail: "buyer@example.com",
+    sku: "scene-warehouse-1",
+    title: "Warehouse Scene",
+    description: "Site world package",
+    itemType: "scene",
+    quantity: 1,
+    licenseTier: "commercial",
+    exclusivity: "non-exclusive",
+    addons: [],
+    inventorySource: "firestore-live",
+    liveInventoryRecordId: "inv-1",
+    deliveryMode: "download_link",
+    inventoryFulfillmentStatus: "ready",
+    rightsStatus: "publishable",
+    unitAmountCents: 25_000,
+    totalAmountCents: 25_000,
+    currency: "usd",
+    successUrl: "https://example.com/success",
+    cancelUrl: "https://example.com/cancel",
+  });
+  if (!order) {
+    throw new Error("order draft not created");
+  }
+  await attachStripeCheckoutSessionToBuyerOrder({
+    orderId: order.id,
+    checkoutSessionId: "cs_test_1",
+    checkoutSessionUrl: "https://stripe.test/cs_test_1",
+    livemode: false,
+  });
+  return order;
+}
+
+function paidCheckoutEvent(order: { id: string }) {
+  return {
+    id: "evt_queue_1",
+    type: "checkout.session.completed",
+    livemode: false,
+    account: null,
+    data: {
+      object: {
+        id: "cs_test_1",
+        object: "checkout.session",
+        client_reference_id: order.id,
+        payment_status: "paid",
+        payment_intent: "pi_test_1",
+        customer: "cus_test_1",
+        livemode: false,
+      },
+    },
+  };
+}
+
+async function postWebhook(baseUrl: string) {
+  return fetch(`${baseUrl}/api/stripe/webhooks`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Stripe-Signature": "t=1,v1=test",
+    },
+    body: JSON.stringify({ ping: true }),
+  });
+}
+
+beforeEach(() => {
+  docs.clear();
+  constructEvent.mockReset();
+  process.env.STRIPE_WEBHOOK_SECRET = "whsec_test";
+  delete process.env.BLUEPRINT_STRIPE_WEBHOOK_INLINE;
+});
+
+afterEach(() => {
+  delete process.env.STRIPE_WEBHOOK_SECRET;
+});
+
+describe("stripe webhook queue transport", () => {
+  it("enqueues durably on receipt, processes on drain, and never double-writes the journal", async () => {
+    const order = await seedPaidCheckoutFixture();
+    const event = paidCheckoutEvent(order);
+    constructEvent.mockReturnValue(event);
+
+    const { server, baseUrl } = await startWebhookServer();
+    try {
+      const response = await postWebhook(baseUrl);
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({ received: true, queued: true });
+
+      // Durable receipt: queued, not yet processed — no accounting writes.
+      const queueDoc = docs.get(`stripeWebhookQueue/${event.id}`);
+      expect(queueDoc).toMatchObject({ status: "queued", event_type: event.type });
+      expect(docs.get(`buyerOrders/${order.id}`)).toMatchObject({
+        payment_status: "checkout_created",
+      });
+
+      // Redelivery before processing: acknowledged without a second enqueue.
+      const redelivery = await postWebhook(baseUrl);
+      expect(redelivery.status).toBe(200);
+      expect(docs.get(`stripeWebhookQueue/${event.id}`)).toMatchObject({
+        status: "queued",
+        attempts: 0,
+      });
+
+      // Drain: the worker-side processor performs the accounting writes.
+      const { drainStripeWebhookQueueOnce } = await import("../utils/stripeWebhookQueue");
+      const drained = await drainStripeWebhookQueueOnce();
+      expect(drained).toMatchObject({ claimed: 1, processed: 1, deadLettered: 0 });
+
+      expect(docs.get(`buyerOrders/${order.id}`)).toMatchObject({
+        status: expect.stringMatching(/paid|fulfilled/),
+        payment_status: "paid",
+      });
+      expect(docs.get(`stripeWebhookQueue/${event.id}`)).toMatchObject({
+        status: "processed",
+      });
+      expect(docs.get(`stripeWebhookEvents/${event.id}`)).toMatchObject({
+        status: "processed",
+      });
+
+      const journalKey = `stripeLedgerJournal/checkout_completed:${event.id}`;
+      const journalEntry = docs.get(journalKey);
+      expect(journalEntry).toMatchObject({
+        entry_type: "checkout_completed",
+        amount_cents: 25_000,
+        order_id: order.id,
+        stripe_event_id: event.id,
+      });
+
+      // Idempotency: draining again is a no-op…
+      const secondDrain = await drainStripeWebhookQueueOnce();
+      expect(secondDrain).toMatchObject({ claimed: 0, processed: 0 });
+
+      // …and even a forced double-process of the same event (double-claimed
+      // job, replayed delivery) must not duplicate or mutate the journal.
+      const before = JSON.stringify(docs.get(journalKey));
+      const { processStripeWebhookEvent } = await import("../utils/stripeEventProcessor");
+      await processStripeWebhookEvent(event as never);
+      expect(JSON.stringify(docs.get(journalKey))).toBe(before);
+      const journalEntries = Array.from(docs.keys()).filter((key) =>
+        key.startsWith("stripeLedgerJournal/"),
+      );
+      expect(journalEntries).toEqual([journalKey]);
+    } finally {
+      await stopServer(server);
+    }
+  });
+
+  it("keeps the round-1 synchronous path behind the inline escape hatch", async () => {
+    process.env.BLUEPRINT_STRIPE_WEBHOOK_INLINE = "1";
+    const order = await seedPaidCheckoutFixture();
+    const event = paidCheckoutEvent(order);
+    constructEvent.mockReturnValue(event);
+
+    const { server, baseUrl } = await startWebhookServer();
+    try {
+      const response = await postWebhook(baseUrl);
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({ received: true });
+
+      // Inline mode: processed synchronously, no queue doc.
+      expect(docs.get(`stripeWebhookQueue/${event.id}`)).toBeUndefined();
+      expect(docs.get(`buyerOrders/${order.id}`)).toMatchObject({
+        payment_status: "paid",
+      });
+      expect(docs.get(`stripeLedgerJournal/checkout_completed:${event.id}`)).toBeTruthy();
+    } finally {
+      await stopServer(server);
+      delete process.env.BLUEPRINT_STRIPE_WEBHOOK_INLINE;
+    }
+  });
+});

--- a/server/tests/worker-entrypoint.test.ts
+++ b/server/tests/worker-entrypoint.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment node
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * SCALE2-02: automation lanes run in the dedicated Render worker service.
+ * These tests pin both halves of the topology change:
+ *  - the worker entrypoint boots the scheduler (leader lease included) and
+ *    stops it exactly once on shutdown;
+ *  - the web process no longer starts the scheduler unless explicitly opted
+ *    in, and the deploy manifests actually declare the worker service.
+ */
+
+const startOpsAutomationScheduler = vi.hoisted(() => vi.fn());
+const validateEnv = vi.hoisted(() => vi.fn(() => ({})));
+
+vi.mock("../utils/opsAutomationScheduler", () => ({ startOpsAutomationScheduler }));
+vi.mock("../config/env", () => ({ validateEnv }));
+vi.mock("../logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  attachRequestMeta: (meta: Record<string, unknown>) => meta,
+}));
+
+const repoRoot = join(__dirname, "..", "..");
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("worker entrypoint", () => {
+  it("boots the scheduler through validateEnv and stops it exactly once", async () => {
+    const stopScheduler = vi.fn();
+    startOpsAutomationScheduler.mockReturnValue(stopScheduler);
+
+    const { startWorker } = await import("../worker");
+    const handle = startWorker();
+
+    expect(validateEnv).toHaveBeenCalled();
+    expect(startOpsAutomationScheduler).toHaveBeenCalledTimes(1);
+    expect(stopScheduler).not.toHaveBeenCalled();
+
+    await handle.stop();
+    await handle.stop();
+    expect(stopScheduler).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("web process scheduler contract", () => {
+  const indexSource = readFileSync(join(repoRoot, "server", "index.ts"), "utf8");
+
+  it("starts the scheduler only behind the explicit web opt-in flag", () => {
+    expect(indexSource).toContain("BLUEPRINT_RUN_OPS_AUTOMATION_IN_WEB");
+    expect(indexSource).toContain(
+      "runOpsAutomationInWebProcess && !disableOpsAutomationScheduler",
+    );
+    // The old unconditional pattern must not come back: every call site of
+    // startOpsAutomationScheduler() in index.ts is the gated ternary above.
+    const callSites = indexSource.match(/startOpsAutomationScheduler\(\)/g) ?? [];
+    expect(callSites.length).toBe(1);
+    expect(indexSource).not.toMatch(
+      /disableOpsAutomationScheduler\s*\?\s*\(\)\s*=>\s*undefined\s*:\s*startOpsAutomationScheduler\(\)/,
+    );
+  });
+});
+
+describe("deploy manifests", () => {
+  it("declares the blueprint-webapp-worker Render service", () => {
+    const renderYaml = readFileSync(join(repoRoot, "render.yaml"), "utf8");
+    expect(renderYaml).toContain("type: worker");
+    expect(renderYaml).toContain("name: blueprint-webapp-worker");
+    expect(renderYaml).toContain("startCommand: npm run start:worker");
+  });
+
+  it("bundles and exposes the worker entrypoint", () => {
+    const pkg = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf8"));
+    expect(pkg.scripts["start:worker"]).toBe("NODE_ENV=production node dist/worker.js");
+    expect(pkg.scripts.build).toContain("server/worker.ts");
+  });
+});

--- a/server/utils/accounting.ts
+++ b/server/utils/accounting.ts
@@ -2,6 +2,7 @@ import crypto from "crypto";
 
 import { dbAdmin as db } from "../../client/src/lib/firebaseAdmin";
 import { entitlementTermForOrderItem } from "./entitlementExpiry";
+import { stripeLedgerJournalTxWriter } from "./stripeLedgerJournal";
 
 const BUYER_ORDER_COLLECTION = "buyerOrders";
 const BUYER_ENTITLEMENT_COLLECTION = "marketplaceEntitlements";
@@ -793,10 +794,31 @@ export async function markBuyerOrderPaidFromCheckout(params: {
   }
 
   const paidAt = order.paid_at || nowIso();
-  await db
-    .collection(BUYER_ORDER_COLLECTION)
-    .doc(order.id)
-    .set(
+  const firestore = db;
+  // The paid status flip and its append-only journal entry commit atomically
+  // (SCALE2-01): reconciliation can trust that a `checkout_completed` journal
+  // row exists iff the order was marked paid.
+  await firestore.runTransaction(async (tx) => {
+    const orderRef = firestore.collection(BUYER_ORDER_COLLECTION).doc(order.id);
+    const journal = stripeLedgerJournalTxWriter(firestore, tx, {
+      entryType: "checkout_completed",
+      discriminator: params.eventId,
+      amountCents: order.pricing.total_amount_cents,
+      currency: order.currency,
+      direction: "buyer_revenue_in",
+      orderId: order.id,
+      stripeEventId: params.eventId,
+      stripeEventType: params.eventType,
+      occurredAt: paidAt,
+      details: {
+        checkout_session_id: params.checkoutSessionId,
+        payment_intent_id: params.paymentIntentId,
+        livemode: params.livemode,
+      },
+    });
+    await journal.read();
+    tx.set(
+      orderRef,
       {
         status: "paid",
         payment_status: "paid",
@@ -814,6 +836,8 @@ export async function markBuyerOrderPaidFromCheckout(params: {
       },
       { merge: true },
     );
+    journal.append();
+  });
 
   if (params.paymentIntentId) {
     await db
@@ -900,30 +924,55 @@ export async function markBuyerOrderPaymentFailure(params: {
   }
 
   const updatedAt = nowIso();
-  await db
-    .collection(BUYER_ORDER_COLLECTION)
-    .doc(params.orderId)
-    .set(
-      {
-        status: params.refunded
-          ? "refunded"
-          : params.expired
-            ? "expired"
-            : "payment_failed",
-        payment_status: params.refunded
-          ? "refunded"
-          : params.expired
-            ? "expired"
-            : "failed",
-        refunded_at: params.refunded ? updatedAt : null,
-        expired_at: params.expired ? updatedAt : null,
-        failure_reason: params.reason,
-        updated_at: updatedAt,
-        last_webhook_event_id: params.eventId,
-        last_webhook_event_type: params.eventType,
-      },
-      { merge: true },
-    );
+  const firestore = db;
+  const failurePayload = {
+    status: params.refunded
+      ? "refunded"
+      : params.expired
+        ? "expired"
+        : "payment_failed",
+    payment_status: params.refunded
+      ? "refunded"
+      : params.expired
+        ? "expired"
+        : "failed",
+    refunded_at: params.refunded ? updatedAt : null,
+    expired_at: params.expired ? updatedAt : null,
+    failure_reason: params.reason,
+    updated_at: updatedAt,
+    last_webhook_event_id: params.eventId,
+    last_webhook_event_type: params.eventType,
+  };
+  const orderRef = firestore.collection(BUYER_ORDER_COLLECTION).doc(params.orderId);
+  if (!params.refunded) {
+    await orderRef.set(failurePayload, { merge: true });
+    return;
+  }
+  // Refunds are financial state transitions: the status flip and the journal
+  // entry commit atomically (SCALE2-01).
+  await firestore.runTransaction(async (tx) => {
+    const orderSnapshot = await tx.get(orderRef);
+    const orderData = (orderSnapshot.data() || {}) as Record<string, unknown>;
+    const pricing = (orderData.pricing || {}) as Record<string, unknown>;
+    const journal = stripeLedgerJournalTxWriter(firestore, tx, {
+      entryType: "order_refunded",
+      discriminator: params.eventId,
+      amountCents:
+        typeof pricing.total_amount_cents === "number"
+          ? (pricing.total_amount_cents as number)
+          : null,
+      currency: typeof orderData.currency === "string" ? orderData.currency : null,
+      direction: "buyer_revenue_in",
+      orderId: params.orderId,
+      stripeEventId: params.eventId,
+      stripeEventType: params.eventType,
+      occurredAt: updatedAt,
+      details: { reason: params.reason },
+    });
+    await journal.read();
+    tx.set(orderRef, failurePayload, { merge: true });
+    journal.append();
+  });
 }
 
 async function fetchCollectionRecord(
@@ -1019,10 +1068,34 @@ export async function markBuyerOrderDisputedFromCharge(params: {
     requires_finance_review: true,
   };
 
-  await db
-    .collection(BUYER_ORDER_COLLECTION)
-    .doc(order.id)
-    .set(
+  const firestore = db;
+  // Dispute open/close transitions journal atomically with the order flip
+  // (SCALE2-01). charge.dispute.created opens; charge.dispute.closed resolves.
+  const disputeEntryType =
+    params.eventType === "charge.dispute.closed" ? "dispute_resolved" : "dispute_opened";
+  await firestore.runTransaction(async (tx) => {
+    const orderRef = firestore.collection(BUYER_ORDER_COLLECTION).doc(order.id);
+    const journal = stripeLedgerJournalTxWriter(firestore, tx, {
+      entryType: disputeEntryType,
+      discriminator: params.eventId,
+      amountCents: params.amountCents,
+      currency: params.currency,
+      direction: "neutral",
+      orderId: order.id,
+      stripeEventId: params.eventId,
+      stripeEventType: params.eventType,
+      occurredAt: updatedAt,
+      details: {
+        dispute_id: params.disputeId,
+        dispute_status: params.disputeStatus,
+        dispute_reason: params.disputeReason,
+        payment_intent_id: params.paymentIntentId,
+        charge_id: params.chargeId,
+      },
+    });
+    await journal.read();
+    tx.set(
+      orderRef,
       {
         status: "disputed",
         payment_status: "disputed",
@@ -1041,6 +1114,8 @@ export async function markBuyerOrderDisputedFromCharge(params: {
       },
       { merge: true },
     );
+    journal.append();
+  });
 
   const entitlementId = order.entitlement_id || order.id;
   const entitlementSnapshot = await db
@@ -1081,7 +1156,6 @@ export async function markBuyerOrderDisputedFromCharge(params: {
     "held_for_dispute",
   ]);
 
-  const firestore = db;
   for (const captureId of captureIds) {
     const payoutRef = firestore.collection(CREATOR_PAYOUT_COLLECTION).doc(captureId);
     const result = await firestore.runTransaction<
@@ -1772,9 +1846,24 @@ export async function upsertCreatorPayoutFromPipeline(params: {
   // The payout entry and the creator earnings aggregate move together in one
   // transaction so the aggregate can never drift from the ledger.
   const payload = await firestore.runTransaction<CreatorPayoutRecord>(async (tx) => {
+    const approvalJournal = stripeLedgerJournalTxWriter(firestore, tx, {
+      entryType: "payout_approved",
+      discriminator: params.captureId,
+      amountCents: basePayoutCents,
+      currency: "usd",
+      direction: "creator_payout_out",
+      creatorId,
+      payoutEntryIds: [params.captureId],
+      occurredAt: null,
+      details: {
+        capture_id: params.captureId,
+        qualification_state: params.qualificationState,
+      },
+    });
     const [existingSnapshot, aggregateSnapshot] = await Promise.all([
       tx.get(payoutRef),
       tx.get(aggregateRef),
+      approvalJournal.read(),
     ]);
     const existing = existingSnapshot.exists
       ? copyCreatorPayout(existingSnapshot.data() as Record<string, unknown>)
@@ -1864,6 +1953,12 @@ export async function upsertCreatorPayoutFromPipeline(params: {
         },
       ],
     });
+    // Journal the first transition into `approved` (SCALE2-01) atomically
+    // with the payout write. The deterministic entry id makes re-upserts
+    // no-ops, so re-qualification churn cannot double-journal an approval.
+    if (nextStatus === "approved" && existing?.status !== "approved") {
+      approvalJournal.append();
+    }
     return nextPayload;
   });
 
@@ -2069,6 +2164,16 @@ export async function beginCreatorPayoutDisbursement(params: {
     const snapshots = await Promise.all(refs.map((ref) => tx.get(ref)));
     const aggregateRef = earningsAggregateRef(firestore, params.creatorId);
     const aggregateSnapshot = await tx.get(aggregateRef);
+    const initiationJournal = stripeLedgerJournalTxWriter(firestore, tx, {
+      entryType: "disbursement_initiated",
+      discriminator: disbursementRef.id,
+      amountCents: null,
+      currency: "usd",
+      direction: "creator_payout_out",
+      creatorId: params.creatorId,
+      disbursementId: disbursementRef.id,
+    });
+    await initiationJournal.read();
 
     const selectedEntries: CreatorPayoutRecord[] = [];
     let runningTotal = 0;
@@ -2134,6 +2239,15 @@ export async function beginCreatorPayoutDisbursement(params: {
     };
 
     tx.set(disbursementRef, disbursement, { merge: true });
+    initiationJournal.append({
+      amountCents: runningTotal,
+      payoutEntryIds: selectedEntries.map((entry) => entry.id),
+      occurredAt: createdAt,
+      details: {
+        stripe_connect_account_id: params.stripeConnectAccountId,
+        requested_amount_cents: requestedAmountCents || runningTotal,
+      },
+    });
 
     for (const entry of selectedEntries) {
       tx.set(
@@ -2416,6 +2530,25 @@ export async function applyCreatorPayoutWebhook(params: {
       const entrySnapshots = await Promise.all(entryRefs.map((ref) => tx.get(ref)));
       const aggregateRef = earningsAggregateRef(firestore, disbursement.creator_id);
       const aggregateSnapshot = await tx.get(aggregateRef);
+      const settlementJournal = stripeLedgerJournalTxWriter(firestore, tx, {
+        entryType: params.status === "paid" ? "disbursement_settled" : "disbursement_failed",
+        discriminator: params.eventId,
+        amountCents: disbursement.disbursed_amount_cents,
+        currency: "usd",
+        direction: "creator_payout_out",
+        creatorId: disbursement.creator_id,
+        disbursementId: disbursement.id,
+        payoutEntryIds: disbursement.payout_entry_ids,
+        stripeEventId: params.eventId,
+        stripeEventType: params.eventType,
+        occurredAt: updatedAt,
+        details: {
+          stripe_payout_id: params.stripePayoutId,
+          settlement_status: params.status,
+          failure_reason: params.failureReason || null,
+        },
+      });
+      await settlementJournal.read();
 
       const updated: CreatorPayoutRecord[] = [];
       const changes: Array<{
@@ -2462,6 +2595,7 @@ export async function applyCreatorPayoutWebhook(params: {
         creatorId: disbursement.creator_id,
         changes,
       });
+      settlementJournal.append();
 
       return updated;
     },

--- a/server/utils/accounting.ts
+++ b/server/utils/accounting.ts
@@ -918,6 +918,9 @@ export async function markBuyerOrderPaymentFailure(params: {
   reason: string;
   expired?: boolean;
   refunded?: boolean;
+  /** Stripe's cumulative charge.amount_refunded, when the event carries it. */
+  refundedAmountCents?: number | null;
+  refundCurrency?: string | null;
 }) {
   if (!db) {
     return;
@@ -954,23 +957,60 @@ export async function markBuyerOrderPaymentFailure(params: {
     const orderSnapshot = await tx.get(orderRef);
     const orderData = (orderSnapshot.data() || {}) as Record<string, unknown>;
     const pricing = (orderData.pricing || {}) as Record<string, unknown>;
+    const orderTotalCents =
+      typeof pricing.total_amount_cents === "number"
+        ? (pricing.total_amount_cents as number)
+        : null;
+    // Journal the per-event refund DELTA, not the order total: Stripe's
+    // charge.amount_refunded is cumulative, and partial refunds fire one
+    // event each. Tracking the previously journaled cumulative on the order
+    // makes each event's entry sum correctly in reconciliation. When the
+    // event carries no amount, fall back to the order total (full refund).
+    const previousRefundedCents =
+      typeof orderData.refunded_amount_cents === "number"
+        ? (orderData.refunded_amount_cents as number)
+        : 0;
+    const cumulativeRefundedCents =
+      typeof params.refundedAmountCents === "number" &&
+      Number.isFinite(params.refundedAmountCents)
+        ? Math.max(0, Math.floor(params.refundedAmountCents))
+        : null;
+    const refundDeltaCents =
+      cumulativeRefundedCents !== null
+        ? Math.max(0, cumulativeRefundedCents - previousRefundedCents)
+        : orderTotalCents;
     const journal = stripeLedgerJournalTxWriter(firestore, tx, {
       entryType: "order_refunded",
       discriminator: params.eventId,
-      amountCents:
-        typeof pricing.total_amount_cents === "number"
-          ? (pricing.total_amount_cents as number)
-          : null,
-      currency: typeof orderData.currency === "string" ? orderData.currency : null,
+      amountCents: refundDeltaCents,
+      currency:
+        params.refundCurrency ||
+        (typeof orderData.currency === "string" ? orderData.currency : null),
       direction: "buyer_revenue_in",
       orderId: params.orderId,
       stripeEventId: params.eventId,
       stripeEventType: params.eventType,
       occurredAt: updatedAt,
-      details: { reason: params.reason },
+      details: {
+        reason: params.reason,
+        cumulative_refunded_cents: cumulativeRefundedCents,
+        previously_journaled_refunded_cents: previousRefundedCents,
+        amount_source:
+          cumulativeRefundedCents !== null ? "stripe_charge_amount_refunded" : "order_total_fallback",
+      },
     });
     await journal.read();
-    tx.set(orderRef, failurePayload, { merge: true });
+    tx.set(
+      orderRef,
+      {
+        ...failurePayload,
+        refunded_amount_cents:
+          cumulativeRefundedCents !== null
+            ? cumulativeRefundedCents
+            : Math.max(previousRefundedCents, orderTotalCents ?? 0),
+      },
+      { merge: true },
+    );
     journal.append();
   });
 }

--- a/server/utils/captureShard.ts
+++ b/server/utils/captureShard.ts
@@ -3,10 +3,11 @@ import { createHash } from "node:crypto";
 /**
  * Firestore createdAt hotspot guard: capture records carry a deterministic
  * `createdAtShard` so high-volume createdAt queries can route through the
- * sharded composite indexes declared in
- * BlueprintCapturePipeline/deploy/terraform/main.tf
- * (captures_status_created_at_shard / captures_user_created_at_shard) instead
- * of a monotonically increasing createdAt index.
+ * sharded composite indexes on `creatorCaptures` declared in this repo's
+ * firestore.indexes.json (creator_id+createdAtShard+created_at and
+ * status+createdAtShard+created_at) instead of a monotonically increasing
+ * createdAt index. (Round 1 mistakenly pointed here at pipeline Terraform
+ * indexes on a `captures` collection nothing writes; those are removed.)
  *
  * Neither the Terraform indexes nor the capacity docs pinned a shard count, so
  * 16 is the canonical choice — pinned alongside the derivation in

--- a/server/utils/ops-alerts.ts
+++ b/server/utils/ops-alerts.ts
@@ -37,6 +37,7 @@ export type BetaOpsFailureKind =
   | "mobile_capture_client_error"
   | "payout_exception"
   | "payment_dispute"
+  | "payment_webhook_dead_letter"
   | "spend_budget_failure";
 
 type BetaOpsFailureSignal = {
@@ -58,6 +59,7 @@ const DEFAULT_FAILURE_THRESHOLDS: Record<BetaOpsFailureKind, number> = {
   mobile_capture_client_error: 3,
   payout_exception: 1,
   payment_dispute: 1,
+  payment_webhook_dead_letter: 1,
   spend_budget_failure: 1,
 };
 

--- a/server/utils/stripeEventProcessor.ts
+++ b/server/utils/stripeEventProcessor.ts
@@ -129,6 +129,9 @@ async function handleChargeRefunded(charge: Stripe.Charge, event: Stripe.Event) 
     eventType: event.type,
     reason: "Stripe reported a refund for the marketplace order.",
     refunded: true,
+    refundedAmountCents:
+      typeof charge.amount_refunded === "number" ? charge.amount_refunded : null,
+    refundCurrency: charge.currency || null,
   });
   return order.id;
 }

--- a/server/utils/stripeEventProcessor.ts
+++ b/server/utils/stripeEventProcessor.ts
@@ -1,0 +1,300 @@
+/**
+ * Stripe event processing, decoupled from HTTP receipt (SCALE2-01).
+ *
+ * The webhook route (server/routes/stripe-webhooks.ts) verifies the
+ * signature, dedupes via stripeWebhookEvents, enqueues, and returns 200; the
+ * queue processor (server/utils/stripeWebhookQueue.ts) calls
+ * processStripeWebhookEvent from the worker service. The handlers below are
+ * the round-1 logic moved verbatim from the route file — processing semantics
+ * (idempotent merges, dispute holds, payout settlement, ops failure signals)
+ * are unchanged.
+ */
+import type Stripe from "stripe";
+
+import {
+  applyCreatorPayoutWebhook,
+  fetchBuyerOrder,
+  findBuyerOrderByCheckoutSessionId,
+  findBuyerOrderByPaymentIntentId,
+  markBuyerOrderPaidFromCheckout,
+  markBuyerOrderDisputedFromCharge,
+  markBuyerOrderPaymentFailure,
+} from "./accounting";
+import { createOnboardingSequence } from "./buyer-onboarding";
+import { initRenewalTracking } from "./growth-ops";
+import { recordBetaOpsFailureSignal } from "./ops-alerts";
+
+async function handleCheckoutSessionCompleted(
+  session: Stripe.Checkout.Session,
+  event: Stripe.Event,
+) {
+  const checkoutSessionId = session.id;
+  const order =
+    (await findBuyerOrderByCheckoutSessionId(checkoutSessionId)) ||
+    (session.client_reference_id
+      ? await fetchBuyerOrder(session.client_reference_id)
+      : null);
+  if (!order) {
+    return null;
+  }
+
+  if (session.payment_status === "paid") {
+    const paidOrder = await markBuyerOrderPaidFromCheckout({
+      orderId: order.id,
+      checkoutSessionId,
+      paymentIntentId:
+        typeof session.payment_intent === "string" ? session.payment_intent : null,
+      customerId: typeof session.customer === "string" ? session.customer : null,
+      livemode: session.livemode,
+      eventId: event.id,
+      eventType: event.type,
+    });
+
+    if (paidOrder?.id && paidOrder.buyer_email) {
+      void createOnboardingSequence({
+        orderId: paidOrder.id,
+        buyerEmail: paidOrder.buyer_email,
+        skuName: paidOrder.item.title || paidOrder.item.sku,
+        licenseTier: paidOrder.item.license_tier || "standard",
+      });
+
+      if (paidOrder.entitlement_id && paidOrder.paid_at) {
+        void initRenewalTracking({
+          entitlementId: paidOrder.entitlement_id,
+          orderId: paidOrder.id,
+          buyerEmail: paidOrder.buyer_email,
+          skuName: paidOrder.item.title || paidOrder.item.sku,
+          licenseTier: paidOrder.item.license_tier || "standard",
+          grantedAt: paidOrder.paid_at,
+        });
+      }
+    }
+
+    return paidOrder;
+  }
+
+  return null;
+}
+
+async function handleCheckoutSessionAsyncFailure(
+  session: Stripe.Checkout.Session,
+  event: Stripe.Event,
+) {
+  const order = await findBuyerOrderByCheckoutSessionId(session.id);
+  if (!order) {
+    return null;
+  }
+
+  await markBuyerOrderPaymentFailure({
+    orderId: order.id,
+    eventId: event.id,
+    eventType: event.type,
+    reason: "Stripe reported an asynchronous payment failure.",
+  });
+  return order.id;
+}
+
+async function handleCheckoutSessionExpired(
+  session: Stripe.Checkout.Session,
+  event: Stripe.Event,
+) {
+  const order = await findBuyerOrderByCheckoutSessionId(session.id);
+  if (!order) {
+    return null;
+  }
+
+  await markBuyerOrderPaymentFailure({
+    orderId: order.id,
+    eventId: event.id,
+    eventType: event.type,
+    reason: "Checkout session expired before payment completed.",
+    expired: true,
+  });
+  return order.id;
+}
+
+async function handleChargeRefunded(charge: Stripe.Charge, event: Stripe.Event) {
+  const paymentIntentId =
+    typeof charge.payment_intent === "string" ? charge.payment_intent : null;
+  const order = paymentIntentId
+    ? await findBuyerOrderByPaymentIntentId(paymentIntentId)
+    : null;
+  if (!order) {
+    return null;
+  }
+
+  await markBuyerOrderPaymentFailure({
+    orderId: order.id,
+    eventId: event.id,
+    eventType: event.type,
+    reason: "Stripe reported a refund for the marketplace order.",
+    refunded: true,
+  });
+  return order.id;
+}
+
+async function handleChargeDispute(dispute: Stripe.Dispute, event: Stripe.Event) {
+  const paymentIntentId =
+    typeof dispute.payment_intent === "string"
+      ? dispute.payment_intent
+      : dispute.payment_intent?.id || null;
+  const chargeId =
+    typeof dispute.charge === "string" ? dispute.charge : dispute.charge?.id || null;
+  const result = await markBuyerOrderDisputedFromCharge({
+    paymentIntentId,
+    chargeId,
+    disputeId: dispute.id,
+    disputeStatus: dispute.status || null,
+    disputeReason: dispute.reason || null,
+    amountCents: typeof dispute.amount === "number" ? dispute.amount : null,
+    currency: dispute.currency || null,
+    evidenceDueBy:
+      typeof dispute.evidence_details?.due_by === "number"
+        ? dispute.evidence_details.due_by
+        : null,
+    eventId: event.id,
+    eventType: event.type,
+  });
+  await recordBetaOpsFailureSignal({
+    kind: "payment_dispute",
+    scopeId: result.orderId || dispute.id,
+    severity: "critical",
+    summary: `Stripe reported ${event.type} for buyer payment ${paymentIntentId || "unknown"}.`,
+    details: {
+      order_id: result.orderId,
+      dispute_id: dispute.id,
+      dispute_status: dispute.status || null,
+      dispute_reason: dispute.reason || null,
+      payment_intent_id: paymentIntentId,
+      charge_id: chargeId,
+      held_payout_ids: result.heldPayoutIds,
+      unresolved_payout_ids: result.unresolvedPayoutIds,
+    },
+  });
+  return result.orderId;
+}
+
+async function handlePayoutEvent(
+  payout: Stripe.Payout,
+  event: Stripe.Event,
+): Promise<string | null> {
+  if (event.type === "payout.paid") {
+    return applyCreatorPayoutWebhook({
+      stripePayoutId: payout.id,
+      eventId: event.id,
+      eventType: event.type,
+      status: "paid",
+    });
+  }
+
+  if (event.type === "payout.failed") {
+    const disbursementId = await applyCreatorPayoutWebhook({
+      stripePayoutId: payout.id,
+      eventId: event.id,
+      eventType: event.type,
+      status: "failed",
+      failureReason: payout.failure_message || "Stripe payout failed.",
+    });
+    await recordBetaOpsFailureSignal({
+      kind: "payout_exception",
+      scopeId: disbursementId || payout.id,
+      severity: "critical",
+      summary: `Stripe payout failed for ${payout.id}.`,
+      details: {
+        stripe_payout_id: payout.id,
+        disbursement_id: disbursementId,
+        failure_message: payout.failure_message || null,
+      },
+    });
+    return disbursementId;
+  }
+
+  if (event.type === "payout.canceled") {
+    const disbursementId = await applyCreatorPayoutWebhook({
+      stripePayoutId: payout.id,
+      eventId: event.id,
+      eventType: event.type,
+      status: "canceled",
+      failureReason: "Stripe payout was canceled.",
+    });
+    await recordBetaOpsFailureSignal({
+      kind: "payout_exception",
+      scopeId: disbursementId || payout.id,
+      severity: "critical",
+      summary: `Stripe payout was canceled for ${payout.id}.`,
+      details: {
+        stripe_payout_id: payout.id,
+        disbursement_id: disbursementId,
+      },
+    });
+    return disbursementId;
+  }
+
+  return null;
+}
+
+export type StripeWebhookProcessingResult = {
+  orderId: string | null;
+  disbursementId: string | null;
+};
+
+export async function processStripeWebhookEvent(
+  event: Stripe.Event,
+): Promise<StripeWebhookProcessingResult> {
+  let orderId: string | null = null;
+  let disbursementId: string | null = null;
+
+  switch (event.type) {
+    case "checkout.session.completed":
+    case "checkout.session.async_payment_succeeded": {
+      const order = await handleCheckoutSessionCompleted(
+        event.data.object as Stripe.Checkout.Session,
+        event,
+      );
+      orderId = order?.id || null;
+      break;
+    }
+    case "checkout.session.async_payment_failed": {
+      orderId = await handleCheckoutSessionAsyncFailure(
+        event.data.object as Stripe.Checkout.Session,
+        event,
+      );
+      break;
+    }
+    case "checkout.session.expired": {
+      orderId = await handleCheckoutSessionExpired(
+        event.data.object as Stripe.Checkout.Session,
+        event,
+      );
+      break;
+    }
+    case "charge.refunded": {
+      orderId = await handleChargeRefunded(
+        event.data.object as Stripe.Charge,
+        event,
+      );
+      break;
+    }
+    case "charge.dispute.created":
+    case "charge.dispute.closed": {
+      orderId = await handleChargeDispute(
+        event.data.object as Stripe.Dispute,
+        event,
+      );
+      break;
+    }
+    case "payout.paid":
+    case "payout.failed":
+    case "payout.canceled": {
+      disbursementId = await handlePayoutEvent(
+        event.data.object as Stripe.Payout,
+        event,
+      );
+      break;
+    }
+    default:
+      break;
+  }
+
+  return { orderId, disbursementId };
+}

--- a/server/utils/stripeLedgerJournal.ts
+++ b/server/utils/stripeLedgerJournal.ts
@@ -1,0 +1,186 @@
+/**
+ * Append-only Stripe financial journal (SCALE2-01).
+ *
+ * One immutable document per financial state transition (checkout completed,
+ * refund, dispute opened/resolved, payout approved, disbursement
+ * initiated/settled/failed), written in the SAME Firestore transaction as the
+ * corresponding `buyerOrders` / `creatorPayouts` /
+ * `creatorPayoutDisbursements` write. Reconciliation sums this journal
+ * instead of scanning mutable ledger projections.
+ *
+ * Invariants:
+ *  - Entries are never updated or deleted (no TTL: this is a permanent
+ *    money-plane record, like the payout ledger collections).
+ *  - Entry ids are deterministic (`{entry_type}:{discriminator}`), so a
+ *    webhook retry or double-processed queue job re-derives the same id and
+ *    the in-transaction existence check makes the write a no-op instead of a
+ *    duplicate.
+ *  - Journal writes are additive: they never replace or weaken the underlying
+ *    ledger writes (including the WEB-01 double-pay transaction guard).
+ */
+
+import { dbAdmin as db } from "../../client/src/lib/firebaseAdmin";
+
+export const STRIPE_LEDGER_JOURNAL_COLLECTION = "stripeLedgerJournal";
+export const STRIPE_LEDGER_JOURNAL_SCHEMA = "blueprint/stripe-ledger-journal/v1";
+
+export type StripeLedgerEntryType =
+  | "checkout_completed"
+  | "order_refunded"
+  | "dispute_opened"
+  | "dispute_resolved"
+  | "payout_approved"
+  | "disbursement_initiated"
+  | "disbursement_settled"
+  | "disbursement_failed";
+
+/** Money direction relative to the platform. */
+export type StripeLedgerDirection =
+  | "buyer_revenue_in"
+  | "creator_payout_out"
+  | "neutral";
+
+export type StripeLedgerJournalEntryInput = {
+  entryType: StripeLedgerEntryType;
+  /** Deterministic idempotency discriminator (event id, disbursement id…). */
+  discriminator: string;
+  amountCents: number | null;
+  currency: string | null;
+  direction: StripeLedgerDirection;
+  orderId?: string | null;
+  creatorId?: string | null;
+  disbursementId?: string | null;
+  payoutEntryIds?: string[];
+  stripeEventId?: string | null;
+  stripeEventType?: string | null;
+  occurredAt?: string | null;
+  details?: Record<string, unknown> | null;
+};
+
+export type StripeLedgerJournalEntry = {
+  id: string;
+  schema: typeof STRIPE_LEDGER_JOURNAL_SCHEMA;
+  entry_type: StripeLedgerEntryType;
+  amount_cents: number | null;
+  currency: string | null;
+  direction: StripeLedgerDirection;
+  order_id: string | null;
+  creator_id: string | null;
+  disbursement_id: string | null;
+  payout_entry_ids: string[];
+  stripe_event_id: string | null;
+  stripe_event_type: string | null;
+  occurred_at: string;
+  recorded_at: string;
+  details: Record<string, unknown> | null;
+};
+
+export function stripeLedgerJournalEntryId(
+  entryType: StripeLedgerEntryType,
+  discriminator: string,
+): string {
+  // Firestore doc ids cannot contain "/" — Stripe ids never do, but fail
+  // closed on anything unexpected rather than silently splitting the path.
+  const safeDiscriminator = discriminator.replace(/\//g, "_");
+  return `${entryType}:${safeDiscriminator}`;
+}
+
+export function buildStripeLedgerJournalEntry(
+  input: StripeLedgerJournalEntryInput,
+): StripeLedgerJournalEntry {
+  const recordedAt = new Date().toISOString();
+  return {
+    id: stripeLedgerJournalEntryId(input.entryType, input.discriminator),
+    schema: STRIPE_LEDGER_JOURNAL_SCHEMA,
+    entry_type: input.entryType,
+    amount_cents:
+      typeof input.amountCents === "number" && Number.isFinite(input.amountCents)
+        ? Math.floor(input.amountCents)
+        : null,
+    currency: input.currency ? input.currency.toLowerCase() : null,
+    direction: input.direction,
+    order_id: input.orderId || null,
+    creator_id: input.creatorId || null,
+    disbursement_id: input.disbursementId || null,
+    payout_entry_ids: input.payoutEntryIds || [],
+    stripe_event_id: input.stripeEventId || null,
+    stripe_event_type: input.stripeEventType || null,
+    occurred_at: input.occurredAt || recordedAt,
+    recorded_at: recordedAt,
+    details: input.details || null,
+  };
+}
+
+type FirestoreLike = NonNullable<typeof db>;
+
+export function stripeLedgerJournalEntryRef(
+  firestore: FirestoreLike,
+  input: Pick<StripeLedgerJournalEntryInput, "entryType" | "discriminator">,
+) {
+  return firestore
+    .collection(STRIPE_LEDGER_JOURNAL_COLLECTION)
+    .doc(stripeLedgerJournalEntryId(input.entryType, input.discriminator));
+}
+
+/**
+ * Transactional two-phase helper honoring Firestore's reads-before-writes
+ * rule: call `read()` alongside the transaction's other reads, then
+ * `append()` alongside its writes. `append()` is a no-op when the entry
+ * already exists (idempotent replay), preserving append-only semantics.
+ */
+export function stripeLedgerJournalTxWriter(
+  firestore: FirestoreLike,
+  tx: FirebaseFirestore.Transaction,
+  input: StripeLedgerJournalEntryInput,
+) {
+  const ref = stripeLedgerJournalEntryRef(firestore, input);
+  let exists: boolean | null = null;
+  return {
+    read: async () => {
+      const snapshot = await tx.get(ref);
+      exists = snapshot.exists;
+      return exists;
+    },
+    append: (overrides?: Partial<StripeLedgerJournalEntryInput>) => {
+      if (exists === null) {
+        throw new Error(
+          "stripeLedgerJournalTxWriter.append() called before read(); Firestore requires reads before writes",
+        );
+      }
+      if (exists) {
+        return false;
+      }
+      // Overrides let a transaction fill amounts/entry ids computed after its
+      // reads (e.g. disbursement selection); identity fields stay fixed.
+      tx.set(
+        ref,
+        buildStripeLedgerJournalEntry({
+          ...input,
+          ...overrides,
+          entryType: input.entryType,
+          discriminator: input.discriminator,
+        }),
+      );
+      return true;
+    },
+  };
+}
+
+/**
+ * Standalone append for call sites that are not already inside a transaction:
+ * runs its own get-then-create transaction so the entry is written exactly
+ * once.
+ */
+export async function appendStripeLedgerJournalEntry(
+  input: StripeLedgerJournalEntryInput,
+): Promise<boolean> {
+  if (!db) {
+    return false;
+  }
+  const firestore = db;
+  return firestore.runTransaction(async (tx) => {
+    const writer = stripeLedgerJournalTxWriter(firestore, tx, input);
+    await writer.read();
+    return writer.append();
+  });
+}

--- a/server/utils/stripeLedgerReconciliation.ts
+++ b/server/utils/stripeLedgerReconciliation.ts
@@ -1,0 +1,176 @@
+/**
+ * Stripe ledger reconciliation (SCALE2-01).
+ *
+ * Sums the append-only stripeLedgerJournal for a period and cross-checks
+ * creator payout totals against creatorEarningsAggregates (round 1). Neither
+ * source is trusted blindly: drift between them is *flagged*, never
+ * auto-corrected — a mismatch means either a journal gap (transition written
+ * before the journal existed / outside a journaled path) or an aggregate bug,
+ * and both need a human eye.
+ *
+ * Exposed as a pure report builder + a CLI (scripts/stripe-ledger-reconcile.ts)
+ * so ops can run it on demand; it deliberately has no write path.
+ */
+import { dbAdmin as db } from "../../client/src/lib/firebaseAdmin";
+import type { CreatorEarningsAggregateRecord } from "./accounting";
+import {
+  STRIPE_LEDGER_JOURNAL_COLLECTION,
+  type StripeLedgerJournalEntry,
+} from "./stripeLedgerJournal";
+
+const CREATOR_EARNINGS_AGGREGATE_COLLECTION = "creatorEarningsAggregates";
+
+export type StripeLedgerPeriodTotals = {
+  buyer_revenue_cents: number;
+  refunded_cents: number;
+  payouts_approved_cents: number;
+  disbursements_initiated_cents: number;
+  disbursements_settled_cents: number;
+  disbursements_failed_cents: number;
+  disputes_opened: number;
+  disputes_resolved: number;
+  entry_count: number;
+};
+
+export type CreatorSettlementDrift = {
+  creator_id: string;
+  journal_settled_cents: number;
+  aggregate_paid_cents: number;
+  drift_cents: number;
+};
+
+export type StripeLedgerReconciliationReport = {
+  schema: "blueprint/stripe-ledger-reconciliation/v1";
+  period: { from_iso: string; to_iso: string };
+  totals: StripeLedgerPeriodTotals;
+  creator_drift: CreatorSettlementDrift[];
+  drift_creator_count: number;
+  checked_creator_count: number;
+  claim_boundary: string;
+  generated_at: string;
+};
+
+function emptyTotals(): StripeLedgerPeriodTotals {
+  return {
+    buyer_revenue_cents: 0,
+    refunded_cents: 0,
+    payouts_approved_cents: 0,
+    disbursements_initiated_cents: 0,
+    disbursements_settled_cents: 0,
+    disbursements_failed_cents: 0,
+    disputes_opened: 0,
+    disputes_resolved: 0,
+    entry_count: 0,
+  };
+}
+
+function applyEntryToTotals(totals: StripeLedgerPeriodTotals, entry: StripeLedgerJournalEntry) {
+  const amount = typeof entry.amount_cents === "number" ? entry.amount_cents : 0;
+  totals.entry_count += 1;
+  switch (entry.entry_type) {
+    case "checkout_completed":
+      totals.buyer_revenue_cents += amount;
+      break;
+    case "order_refunded":
+      totals.refunded_cents += amount;
+      break;
+    case "payout_approved":
+      totals.payouts_approved_cents += amount;
+      break;
+    case "disbursement_initiated":
+      totals.disbursements_initiated_cents += amount;
+      break;
+    case "disbursement_settled":
+      totals.disbursements_settled_cents += amount;
+      break;
+    case "disbursement_failed":
+      totals.disbursements_failed_cents += amount;
+      break;
+    case "dispute_opened":
+      totals.disputes_opened += 1;
+      break;
+    case "dispute_resolved":
+      totals.disputes_resolved += 1;
+      break;
+    default:
+      break;
+  }
+}
+
+/**
+ * Cross-check: lifetime settled cents per creator computed from the journal
+ * vs the paid bucket of the transactionally-maintained aggregate. Only
+ * creators that appear in the period's journal are checked (bounded work).
+ */
+export async function buildStripeLedgerReconciliationReport(params: {
+  fromIso: string;
+  toIso: string;
+}): Promise<StripeLedgerReconciliationReport> {
+  if (!db) {
+    throw new Error("Database not available for reconciliation.");
+  }
+  const firestore = db;
+
+  const periodSnapshot = await firestore
+    .collection(STRIPE_LEDGER_JOURNAL_COLLECTION)
+    .where("recorded_at", ">=", params.fromIso)
+    .where("recorded_at", "<=", params.toIso)
+    .get();
+
+  const totals = emptyTotals();
+  const creatorsInPeriod = new Set<string>();
+  for (const doc of periodSnapshot.docs) {
+    const entry = doc.data() as StripeLedgerJournalEntry;
+    applyEntryToTotals(totals, entry);
+    if (entry.creator_id) {
+      creatorsInPeriod.add(entry.creator_id);
+    }
+  }
+
+  const creatorDrift: CreatorSettlementDrift[] = [];
+  for (const creatorId of creatorsInPeriod) {
+    // Lifetime journal truth for this creator (bounded per-creator query).
+    const settledSnapshot = await firestore
+      .collection(STRIPE_LEDGER_JOURNAL_COLLECTION)
+      .where("creator_id", "==", creatorId)
+      .where("entry_type", "==", "disbursement_settled")
+      .get();
+    const journalSettledCents = settledSnapshot.docs.reduce((sum, doc) => {
+      const entry = doc.data() as StripeLedgerJournalEntry;
+      return sum + (typeof entry.amount_cents === "number" ? entry.amount_cents : 0);
+    }, 0);
+
+    const aggregateSnapshot = await firestore
+      .collection(CREATOR_EARNINGS_AGGREGATE_COLLECTION)
+      .doc(creatorId)
+      .get();
+    const aggregate = aggregateSnapshot.exists
+      ? (aggregateSnapshot.data() as CreatorEarningsAggregateRecord)
+      : null;
+    const aggregatePaidCents =
+      aggregate?.status_totals?.paid?.approved_amount_cents ?? 0;
+
+    if (journalSettledCents !== aggregatePaidCents) {
+      creatorDrift.push({
+        creator_id: creatorId,
+        journal_settled_cents: journalSettledCents,
+        aggregate_paid_cents: aggregatePaidCents,
+        drift_cents: journalSettledCents - aggregatePaidCents,
+      });
+    }
+  }
+
+  return {
+    schema: "blueprint/stripe-ledger-reconciliation/v1",
+    period: { from_iso: params.fromIso, to_iso: params.toIso },
+    totals,
+    creator_drift: creatorDrift.sort(
+      (a, b) => Math.abs(b.drift_cents) - Math.abs(a.drift_cents),
+    ),
+    drift_creator_count: creatorDrift.length,
+    checked_creator_count: creatorsInPeriod.size,
+    claim_boundary:
+      "Drift is flagged, not auto-corrected. The journal only covers transitions since it shipped (scaling round 2); creators with pre-journal paid history will show negative drift until a one-time backfill entry is recorded — investigate before trusting either side.",
+    generated_at: new Date().toISOString(),
+  };
+}

--- a/server/utils/stripeWebhookQueue.ts
+++ b/server/utils/stripeWebhookQueue.ts
@@ -112,9 +112,12 @@ type ClaimedJob = {
   event: Stripe.Event;
 };
 
-async function claimQueuedJob(jobId: string): Promise<ClaimedJob | null> {
+function claimJob(
+  jobId: string,
+  options: { expectStatus: StripeWebhookQueueStatus; staleBeforeIso?: string },
+): Promise<ClaimedJob | null> {
   if (!db) {
-    return null;
+    return Promise.resolve(null);
   }
   const firestore = db;
   const ref = firestore.collection(STRIPE_WEBHOOK_QUEUE_COLLECTION).doc(jobId);
@@ -124,8 +127,17 @@ async function claimQueuedJob(jobId: string): Promise<ClaimedJob | null> {
       return null;
     }
     const data = (snapshot.data() || {}) as Record<string, unknown>;
-    if (data.status !== "queued") {
+    if (data.status !== options.expectStatus) {
       return null;
+    }
+    if (options.staleBeforeIso) {
+      // Reclaim path: only take over a `processing` job whose claim is
+      // still stale at transaction time — a live worker that refreshed the
+      // doc since the query keeps its claim.
+      const startedAt = String(data.processing_started_at || "");
+      if (!startedAt || startedAt > options.staleBeforeIso) {
+        return null;
+      }
     }
     const attempts = Number(data.attempts || 0) + 1;
     tx.set(
@@ -232,19 +244,73 @@ async function settleJobFailure(job: ClaimedJob, error: Error) {
 
 export type DrainResult = {
   claimed: number;
+  reclaimed: number;
   processed: number;
   retried: number;
   deadLettered: number;
 };
 
+const DEFAULT_VISIBILITY_TIMEOUT_MS = 10 * 60_000;
+
+function visibilityTimeoutMs(): number {
+  const raw = Number(process.env.BLUEPRINT_STRIPE_WEBHOOK_QUEUE_VISIBILITY_TIMEOUT_MS);
+  return Number.isFinite(raw) && raw >= 60_000 ? raw : DEFAULT_VISIBILITY_TIMEOUT_MS;
+}
+
+async function processClaimedJob(job: ClaimedJob, result: DrainResult): Promise<void> {
+  try {
+    const { orderId, disbursementId } = await processStripeWebhookEvent(job.event);
+    await completeStripeWebhookEvent({
+      eventId: job.id,
+      orderId,
+      disbursementId,
+      eventType: job.event?.type || "unknown",
+    });
+    await settleJobSuccess(job.id);
+    result.processed += 1;
+  } catch (error) {
+    const failure = error instanceof Error ? error : new Error(String(error));
+    await settleJobFailure(job, failure);
+    if (job.attempts < maxAttempts()) {
+      result.retried += 1;
+    } else {
+      result.deadLettered += 1;
+    }
+    logger.error(
+      attachRequestMeta({
+        route: "stripe-webhook-queue",
+        event_id: job.id,
+        attempts: job.attempts,
+      }),
+      `Stripe webhook queue processing failed: ${failure.message}`,
+    );
+  }
+}
+
 /**
  * Process one batch of due queue jobs. Exposed separately from the poller so
  * tests (and manual ops replays) can drain deterministically.
+ *
+ * Two passes:
+ *  1. due `queued` jobs;
+ *  2. abandoned `processing` jobs whose claim is older than the visibility
+ *     timeout — a worker crash/restart between claim and settle would
+ *     otherwise strand an acknowledged money-plane event forever (Stripe
+ *     redeliveries no-op against the existing queue doc). Reclaims are
+ *     transactional and re-check staleness, so a live worker keeps its
+ *     claim; the event processor is idempotent (deterministic journal ids,
+ *     merge writes), so the rare double-execution race is safe.
  */
 export async function drainStripeWebhookQueueOnce(options?: {
   batchSize?: number;
 }): Promise<DrainResult> {
-  const result: DrainResult = { claimed: 0, processed: 0, retried: 0, deadLettered: 0 };
+  const result: DrainResult = {
+    claimed: 0,
+    reclaimed: 0,
+    processed: 0,
+    retried: 0,
+    deadLettered: 0,
+  };
   if (!db) {
     return result;
   }
@@ -258,38 +324,38 @@ export async function drainStripeWebhookQueueOnce(options?: {
     .get();
 
   for (const doc of snapshot.docs) {
-    const job = await claimQueuedJob(doc.id);
+    const job = await claimJob(doc.id, { expectStatus: "queued" });
     if (!job) {
       continue;
     }
     result.claimed += 1;
-    try {
-      const { orderId, disbursementId } = await processStripeWebhookEvent(job.event);
-      await completeStripeWebhookEvent({
-        eventId: job.id,
-        orderId,
-        disbursementId,
-        eventType: job.event?.type || "unknown",
-      });
-      await settleJobSuccess(job.id);
-      result.processed += 1;
-    } catch (error) {
-      const failure = error instanceof Error ? error : new Error(String(error));
-      await settleJobFailure(job, failure);
-      if (job.attempts < maxAttempts()) {
-        result.retried += 1;
-      } else {
-        result.deadLettered += 1;
-      }
-      logger.error(
-        attachRequestMeta({
-          route: "stripe-webhook-queue",
-          event_id: job.id,
-          attempts: job.attempts,
-        }),
-        `Stripe webhook queue processing failed: ${failure.message}`,
-      );
+    await processClaimedJob(job, result);
+  }
+
+  const staleBeforeIso = new Date(Date.now() - visibilityTimeoutMs()).toISOString();
+  const staleSnapshot = await db
+    .collection(STRIPE_WEBHOOK_QUEUE_COLLECTION)
+    .where("status", "==", "processing")
+    .where("processing_started_at", "<=", staleBeforeIso)
+    .orderBy("processing_started_at", "asc")
+    .limit(batchSize)
+    .get();
+
+  for (const doc of staleSnapshot.docs) {
+    const job = await claimJob(doc.id, { expectStatus: "processing", staleBeforeIso });
+    if (!job) {
+      continue;
     }
+    result.reclaimed += 1;
+    logger.warn(
+      attachRequestMeta({
+        route: "stripe-webhook-queue",
+        event_id: job.id,
+        attempts: job.attempts,
+      }),
+      "Reclaimed abandoned Stripe webhook queue job (stale processing claim)",
+    );
+    await processClaimedJob(job, result);
   }
 
   return result;

--- a/server/utils/stripeWebhookQueue.ts
+++ b/server/utils/stripeWebhookQueue.ts
@@ -1,0 +1,346 @@
+/**
+ * Firestore-backed Stripe webhook queue (SCALE2-01).
+ *
+ * The webhook route's synchronous job shrinks to: verify signature, dedupe
+ * via stripeWebhookEvents, enqueue here, return 200. Processing happens on
+ * the dedicated worker service (server/worker.ts) behind the ops automation
+ * leader lease, so a burst of Stripe events (payout batches, dispute waves)
+ * never competes for web event-loop time — and the durable queue doc means a
+ * worker crash mid-processing is retried instead of lost.
+ *
+ * Design notes:
+ *  - Queue doc id == Stripe event id: a redelivered event upserts nothing
+ *    (create() no-ops on already-exists), and processing claims are
+ *    transactional, so an event is processed by at most one drainer at a
+ *    time even if the lease ever double-fires.
+ *  - Bounded retry with exponential backoff; exhausted events land in
+ *    stripeWebhookDeadLetters and raise a payment_webhook_dead_letter ops
+ *    failure signal (existing opsAlerts pattern).
+ *  - Inline escape hatch (BLUEPRINT_STRIPE_WEBHOOK_INLINE=1) keeps the
+ *    round-1 synchronous path available for single-service deploys.
+ */
+import type Stripe from "stripe";
+
+import { dbAdmin as db } from "../../client/src/lib/firebaseAdmin";
+import { attachRequestMeta, logger } from "../logger";
+import {
+  completeStripeWebhookEvent,
+  failStripeWebhookEvent,
+} from "./accounting";
+import { getOpsAutomationLeaderLease } from "./automationLeaderLease";
+import { recordBetaOpsFailureSignal } from "./ops-alerts";
+import { processStripeWebhookEvent } from "./stripeEventProcessor";
+
+export const STRIPE_WEBHOOK_QUEUE_COLLECTION = "stripeWebhookQueue";
+export const STRIPE_WEBHOOK_DEAD_LETTER_COLLECTION = "stripeWebhookDeadLetters";
+
+const DEFAULT_POLL_INTERVAL_MS = 5_000;
+const DEFAULT_BATCH_SIZE = 25;
+const DEFAULT_MAX_ATTEMPTS = 5;
+const BASE_RETRY_DELAY_MS = 30_000;
+const QUEUE_RETENTION_DAYS_DEFAULT = 30;
+
+export type StripeWebhookQueueStatus = "queued" | "processing" | "processed" | "dead";
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function queueRetentionExpiresAt(): Date {
+  const raw = Number(process.env.BLUEPRINT_STRIPE_WEBHOOK_QUEUE_RETENTION_DAYS);
+  const days = Number.isFinite(raw) && raw > 0 ? raw : QUEUE_RETENTION_DAYS_DEFAULT;
+  return new Date(Date.now() + days * 24 * 60 * 60 * 1000);
+}
+
+function maxAttempts(): number {
+  const raw = Number(process.env.BLUEPRINT_STRIPE_WEBHOOK_QUEUE_MAX_ATTEMPTS);
+  return Number.isFinite(raw) && raw >= 1 ? Math.floor(raw) : DEFAULT_MAX_ATTEMPTS;
+}
+
+function retryDelayMs(attempts: number): number {
+  return BASE_RETRY_DELAY_MS * 2 ** Math.max(0, attempts - 1);
+}
+
+export function stripeWebhookInlineMode(): boolean {
+  return process.env.BLUEPRINT_STRIPE_WEBHOOK_INLINE === "1";
+}
+
+function isAlreadyExistsError(error: unknown): boolean {
+  const code = (error as { code?: unknown })?.code;
+  return code === 6 || code === "already-exists" || code === "ALREADY_EXISTS";
+}
+
+/**
+ * Durable receipt: persist the verified event for deferred processing.
+ * Returns "enqueued" | "duplicate".
+ */
+export async function enqueueStripeWebhookEvent(
+  event: Stripe.Event,
+): Promise<"enqueued" | "duplicate"> {
+  if (!db) {
+    throw new Error("Database not available for Stripe webhook enqueue.");
+  }
+  const createdAt = nowIso();
+  const ref = db.collection(STRIPE_WEBHOOK_QUEUE_COLLECTION).doc(event.id);
+  try {
+    await ref.create({
+      status: "queued" satisfies StripeWebhookQueueStatus,
+      event_id: event.id,
+      event_type: event.type,
+      livemode: Boolean(event.livemode),
+      // Full verified payload; processing must never re-fetch from Stripe.
+      event: JSON.parse(JSON.stringify(event)) as Record<string, unknown>,
+      attempts: 0,
+      next_attempt_at: createdAt,
+      last_error: null,
+      created_at: createdAt,
+      updated_at: createdAt,
+      expires_at: queueRetentionExpiresAt(),
+    });
+    return "enqueued";
+  } catch (error) {
+    if (isAlreadyExistsError(error)) {
+      return "duplicate";
+    }
+    throw error;
+  }
+}
+
+type ClaimedJob = {
+  id: string;
+  attempts: number;
+  event: Stripe.Event;
+};
+
+async function claimQueuedJob(jobId: string): Promise<ClaimedJob | null> {
+  if (!db) {
+    return null;
+  }
+  const firestore = db;
+  const ref = firestore.collection(STRIPE_WEBHOOK_QUEUE_COLLECTION).doc(jobId);
+  return firestore.runTransaction(async (tx) => {
+    const snapshot = await tx.get(ref);
+    if (!snapshot.exists) {
+      return null;
+    }
+    const data = (snapshot.data() || {}) as Record<string, unknown>;
+    if (data.status !== "queued") {
+      return null;
+    }
+    const attempts = Number(data.attempts || 0) + 1;
+    tx.set(
+      ref,
+      {
+        status: "processing" satisfies StripeWebhookQueueStatus,
+        attempts,
+        processing_started_at: nowIso(),
+        updated_at: nowIso(),
+      },
+      { merge: true },
+    );
+    return {
+      id: jobId,
+      attempts,
+      event: data.event as Stripe.Event,
+    };
+  });
+}
+
+async function settleJobSuccess(jobId: string) {
+  if (!db) {
+    return;
+  }
+  await db
+    .collection(STRIPE_WEBHOOK_QUEUE_COLLECTION)
+    .doc(jobId)
+    .set(
+      {
+        status: "processed" satisfies StripeWebhookQueueStatus,
+        processed_at: nowIso(),
+        updated_at: nowIso(),
+        last_error: null,
+      },
+      { merge: true },
+    );
+}
+
+async function settleJobFailure(job: ClaimedJob, error: Error) {
+  if (!db) {
+    return;
+  }
+  const firestore = db;
+  const ref = firestore.collection(STRIPE_WEBHOOK_QUEUE_COLLECTION).doc(job.id);
+  if (job.attempts < maxAttempts()) {
+    const nextAttemptAt = new Date(Date.now() + retryDelayMs(job.attempts)).toISOString();
+    await ref.set(
+      {
+        status: "queued" satisfies StripeWebhookQueueStatus,
+        next_attempt_at: nextAttemptAt,
+        last_error: error.message || "Stripe webhook processing failed.",
+        updated_at: nowIso(),
+      },
+      { merge: true },
+    );
+    return;
+  }
+
+  // Dead-letter: bounded retries exhausted. Keep the full event for manual
+  // replay, mark the dedupe record failed, and raise an ops failure signal.
+  const deadLetteredAt = nowIso();
+  await ref.set(
+    {
+      status: "dead" satisfies StripeWebhookQueueStatus,
+      dead_lettered_at: deadLetteredAt,
+      last_error: error.message || "Stripe webhook processing failed.",
+      updated_at: deadLetteredAt,
+    },
+    { merge: true },
+  );
+  await firestore
+    .collection(STRIPE_WEBHOOK_DEAD_LETTER_COLLECTION)
+    .doc(job.id)
+    .set(
+      {
+        event_id: job.id,
+        event_type: job.event?.type || null,
+        event: JSON.parse(JSON.stringify(job.event || null)),
+        attempts: job.attempts,
+        last_error: error.message || "Stripe webhook processing failed.",
+        dead_lettered_at: deadLetteredAt,
+      },
+      { merge: true },
+    );
+  await failStripeWebhookEvent({
+    eventId: job.id,
+    eventType: job.event?.type || "unknown",
+    reason: `Dead-lettered after ${job.attempts} attempts: ${error.message}`,
+  });
+  await recordBetaOpsFailureSignal({
+    kind: "payment_webhook_dead_letter",
+    scopeId: job.id,
+    severity: "critical",
+    summary: `Stripe webhook ${job.event?.type || "unknown"} (${job.id}) dead-lettered after ${job.attempts} attempts.`,
+    details: {
+      event_id: job.id,
+      event_type: job.event?.type || null,
+      attempts: job.attempts,
+      last_error: error.message || null,
+      dead_letter_collection: STRIPE_WEBHOOK_DEAD_LETTER_COLLECTION,
+    },
+  });
+}
+
+export type DrainResult = {
+  claimed: number;
+  processed: number;
+  retried: number;
+  deadLettered: number;
+};
+
+/**
+ * Process one batch of due queue jobs. Exposed separately from the poller so
+ * tests (and manual ops replays) can drain deterministically.
+ */
+export async function drainStripeWebhookQueueOnce(options?: {
+  batchSize?: number;
+}): Promise<DrainResult> {
+  const result: DrainResult = { claimed: 0, processed: 0, retried: 0, deadLettered: 0 };
+  if (!db) {
+    return result;
+  }
+  const batchSize = Math.max(1, options?.batchSize ?? DEFAULT_BATCH_SIZE);
+  const snapshot = await db
+    .collection(STRIPE_WEBHOOK_QUEUE_COLLECTION)
+    .where("status", "==", "queued")
+    .where("next_attempt_at", "<=", nowIso())
+    .orderBy("next_attempt_at", "asc")
+    .limit(batchSize)
+    .get();
+
+  for (const doc of snapshot.docs) {
+    const job = await claimQueuedJob(doc.id);
+    if (!job) {
+      continue;
+    }
+    result.claimed += 1;
+    try {
+      const { orderId, disbursementId } = await processStripeWebhookEvent(job.event);
+      await completeStripeWebhookEvent({
+        eventId: job.id,
+        orderId,
+        disbursementId,
+        eventType: job.event?.type || "unknown",
+      });
+      await settleJobSuccess(job.id);
+      result.processed += 1;
+    } catch (error) {
+      const failure = error instanceof Error ? error : new Error(String(error));
+      await settleJobFailure(job, failure);
+      if (job.attempts < maxAttempts()) {
+        result.retried += 1;
+      } else {
+        result.deadLettered += 1;
+      }
+      logger.error(
+        attachRequestMeta({
+          route: "stripe-webhook-queue",
+          event_id: job.id,
+          attempts: job.attempts,
+        }),
+        `Stripe webhook queue processing failed: ${failure.message}`,
+      );
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Poller for the worker service. Only the automation leader drains the queue
+ * (claims are transactional regardless, so this is a load optimization, not
+ * the correctness boundary).
+ */
+export function startStripeWebhookQueueProcessor(): () => void {
+  if (stripeWebhookInlineMode()) {
+    logger.info(
+      attachRequestMeta({ route: "stripe-webhook-queue" }),
+      "Stripe webhook queue processor not started: inline mode is enabled",
+    );
+    return () => undefined;
+  }
+
+  const lease = getOpsAutomationLeaderLease();
+  lease.start();
+
+  const pollMsRaw = Number(process.env.BLUEPRINT_STRIPE_WEBHOOK_QUEUE_POLL_MS);
+  const pollMs =
+    Number.isFinite(pollMsRaw) && pollMsRaw >= 1_000 ? pollMsRaw : DEFAULT_POLL_INTERVAL_MS;
+
+  let draining = false;
+  const intervalId = setInterval(() => {
+    if (draining || !lease.isLeader()) {
+      return;
+    }
+    draining = true;
+    void drainStripeWebhookQueueOnce()
+      .catch((error) => {
+        logger.error(
+          attachRequestMeta({ route: "stripe-webhook-queue" }),
+          `Stripe webhook queue drain failed: ${(error as Error).message}`,
+        );
+      })
+      .finally(() => {
+        draining = false;
+      });
+  }, pollMs);
+  intervalId.unref?.();
+
+  logger.info(
+    attachRequestMeta({ route: "stripe-webhook-queue", poll_ms: pollMs }),
+    "Stripe webhook queue processor started",
+  );
+
+  return () => {
+    clearInterval(intervalId);
+  };
+}

--- a/server/worker.ts
+++ b/server/worker.ts
@@ -1,0 +1,63 @@
+/**
+ * Dedicated background worker entrypoint (SCALE2-02).
+ *
+ * Runs the ~20 ops automation lanes outside the HTTP web process so a slow
+ * Notion sync or large batch write can never compete for event-loop time with
+ * live buyer/creator traffic. Deployed as the `blueprint-webapp-worker`
+ * Render worker service (`npm run start:worker`); the web service
+ * (`npm start`) serves HTTP only.
+ *
+ * The ops automation leader lease stays active here: if Render ever scales
+ * this worker beyond one instance — or the web-process escape hatch
+ * (BLUEPRINT_RUN_OPS_AUTOMATION_IN_WEB=1) is enabled during a transition —
+ * only the lease holder actually runs lanes.
+ */
+import { pathToFileURL } from "node:url";
+
+import { validateEnv } from "./config/env";
+import { attachRequestMeta, logger } from "./logger";
+import { startOpsAutomationScheduler } from "./utils/opsAutomationScheduler";
+
+export type WorkerHandle = {
+  stop: () => Promise<void>;
+};
+
+export function startWorker(): WorkerHandle {
+  validateEnv();
+
+  logger.info(
+    attachRequestMeta({ route: "worker" }),
+    "Blueprint worker starting: ops automation scheduler",
+  );
+  const stopScheduler = startOpsAutomationScheduler();
+
+  let stopped = false;
+  const stop = async () => {
+    if (stopped) return;
+    stopped = true;
+    stopScheduler();
+    logger.info(attachRequestMeta({ route: "worker" }), "Blueprint worker stopped");
+  };
+
+  return { stop };
+}
+
+const isMainModule = (() => {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  try {
+    return import.meta.url === pathToFileURL(entry).href;
+  } catch {
+    return false;
+  }
+})();
+
+if (isMainModule) {
+  const handle = startWorker();
+  for (const signal of ["SIGTERM", "SIGINT"] as const) {
+    process.once(signal, () => {
+      logger.info(attachRequestMeta({ route: "worker" }), `Worker received ${signal}, stopping`);
+      void handle.stop().then(() => process.exit(0));
+    });
+  }
+}

--- a/server/worker.ts
+++ b/server/worker.ts
@@ -17,6 +17,7 @@ import { pathToFileURL } from "node:url";
 import { validateEnv } from "./config/env";
 import { attachRequestMeta, logger } from "./logger";
 import { startOpsAutomationScheduler } from "./utils/opsAutomationScheduler";
+import { startStripeWebhookQueueProcessor } from "./utils/stripeWebhookQueue";
 
 export type WorkerHandle = {
   stop: () => Promise<void>;
@@ -27,14 +28,16 @@ export function startWorker(): WorkerHandle {
 
   logger.info(
     attachRequestMeta({ route: "worker" }),
-    "Blueprint worker starting: ops automation scheduler",
+    "Blueprint worker starting: ops automation scheduler + Stripe webhook queue processor",
   );
   const stopScheduler = startOpsAutomationScheduler();
+  const stopQueueProcessor = startStripeWebhookQueueProcessor();
 
   let stopped = false;
   const stop = async () => {
     if (stopped) return;
     stopped = true;
+    stopQueueProcessor();
     stopScheduler();
     logger.info(attachRequestMeta({ route: "worker" }), "Blueprint worker stopped");
   };


### PR DESCRIPTION
WebApp half of scaling round 2 — the deferred "operational-shape" items from round 1. Canonical write-up updated in `docs/backend-scaling-architecture-2026-07-20.md` (§5 documents this round; §6 lists the new deliberate follow-ups).

## Item 2 — Dedicated Render worker service

- `render.yaml` gains `blueprint-webapp-worker` (`type: worker`, `npm run start:worker` → new `server/worker.ts`, bundled by the existing esbuild step). The worker boots the ops automation scheduler + the Stripe webhook queue processor — no Express server.
- The web process **no longer starts the scheduler**. Transition escape hatch: `BLUEPRINT_RUN_OPS_AUTOMATION_IN_WEB=1`. In every configuration (worker only, escape hatch on, both up mid-rollout) the round-1 leader lease still guarantees at most one automation runner — the exact double-run class the lease was built to prevent.
- Env manifests (`render.required/optional.env.example`) now instruct importing the same environment into both services (env is dashboard-managed for this blueprint; the worker needs the same Firebase/Stripe/Redis/Notion config).
- Tests: worker boots the scheduler through `validateEnv` and stops it exactly once; source contract pins that `index.ts` only starts the scheduler behind the opt-in flag; deploy manifests declare the worker service and `start:worker`/build wiring.

## Item 1 — Queue-based Stripe webhook processing + append-only journal

**Durable receipt, deferred processing.** The webhook handler's synchronous job is now: verify signature, dedupe via `stripeWebhookEvents` (both untouched — load-bearing round-1 guarantees), enqueue the verified event to `stripeWebhookQueue` (doc id = event id), return 200. Processing logic moved **verbatim** to `server/utils/stripeEventProcessor.ts` and runs on the worker via a leader-leased poller with transactional job claims, bounded exponential retry, and a `stripeWebhookDeadLetters` collection raising a `payment_webhook_dead_letter` ops failure signal (existing `opsAlerts` pattern) on exhaustion. `BLUEPRINT_STRIPE_WEBHOOK_INLINE=1` restores the round-1 synchronous path. If enqueue itself fails, the handler 500s and rolls the dedupe record to retryable — Stripe redelivers; an event is never acked without being durably persisted.

**Queue-backend evaluation (as requested):** Firestore-backed queue **(chosen — shipped)** vs Cloud Tasks. Firestore needs no new provider, reuses the lease + alerting patterns, and 10k payouts/month peaks are orders of magnitude below its limits. Cloud Tasks would add managed backoff/rate limits but brings a new runtime dependency into this repo, payload-size limits, and push-endpoint auth surface. **Recommendation: stay Firestore-backed; revisit Cloud Tasks only if sustained rates approach hundreds of events/second.** Flagged here as a recommendation — not wired up.

**Append-only journal.** Every financial state transition — checkout completed, refund, dispute opened/resolved, payout approved, disbursement initiated/settled/failed — writes one immutable `stripeLedgerJournal` document **in the same Firestore transaction** as the corresponding `buyerOrders`/`creatorPayouts`/`creatorPayoutDisbursements` write. Deterministic entry ids (`{entry_type}:{event_id|disbursement_id|payout_id}`) + in-transaction existence checks make webhook retries and double-processed queue jobs no-ops. **The WEB-01 double-pay guard and the transactional earnings-aggregate maintenance are untouched** — journal writes are additive inside the existing transactions.

**Reconciliation.** `npm run stripe:reconcile` (`scripts/stripe-ledger-reconcile.ts` → `server/utils/stripeLedgerReconciliation.ts`) sums the journal for a period and cross-checks per-creator settlement totals against `creatorEarningsAggregates`, flagging drift (exit 1) rather than trusting either source. Claim boundary: the journal covers transitions from this change onward; pre-journal paid history shows as negative drift until a one-time backfill (listed as a follow-up).

**Supporting:** `stripeWebhookQueue` composite index (`status`+`next_attempt_at`); TTL on queue transport docs only — the journal and dead letters are permanent money-plane records; BigQuery export deliberately deferred (journal is the export-ready source).

## Item 7 (WebApp half) — real creatorCaptures shard composites

Round 1 wrote `createdAtShard` on `creatorCaptures` but the matching indexes were phantoms in pipeline Terraform against a `captures` collection nothing writes (deleted in the sibling pipeline PR) — the shard write was a no-op for its stated purpose. This adds the real composites to `firestore.indexes.json` (`creator_id`+`createdAtShard`+`created_at` DESC; `status`+`createdAtShard`+`created_at` ASC), fixes the stale cross-reference in `captureShard.ts`, and pins both (plus the absence of any literal `captures` indexes) with a test.

## Contracts preserved
HTTP route shapes (webhook endpoint path/verbs/status codes unchanged; 200 body gains an additive `queued: true` field), Stripe signature verification and dedupe semantics, WEB-01 guard, earnings aggregates, `creatorCaptures` write shape: all unchanged. New collections (`stripeWebhookQueue`, `stripeWebhookDeadLetters`, `stripeLedgerJournal`) are additive.

## Deploy notes for the owner
- Deploy order: this ships web + worker from one `render.yaml`; create the worker service and import the same env group before/with the web deploy. If the worker lags, `BLUEPRINT_STRIPE_WEBHOOK_INLINE=1` + `BLUEPRINT_RUN_OPS_AUTOMATION_IN_WEB=1` on the web service reproduce round-1 behavior exactly.
- `firebase deploy --only firestore:indexes` for the new composites; `scripts/apply_firestore_ttl_policies.sh` for the queue TTL.

## Testing
- `npm run check`: clean.
- `npm run test:coverage`: **352 files / 1,732 tests, all passing.**
- New suites: queue enqueue→drain end-to-end with real accounting against an extended in-memory Firestore fake (durable receipt, redelivery ack, drain effects, double-processing never duplicates/mutates the journal); retry/backoff/dead-letter mechanics incl. ops signal; journal atomicity + replay idempotency across the full payout lifecycle (approve → disburse → settle); reconciliation drift detection (clean and corrupted-aggregate cases); worker entrypoint + deploy-manifest contracts; index-manifest guard.
- Existing accounting-ledger tests pinned to the inline escape hatch they exercise (transport has its own tests).
- graphify architecture pilot re-run per repo policy (no output changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011gpLDSjqYwZEhohAxVcbLz

---
_Generated by [Claude Code](https://claude.ai/code/session_011gpLDSjqYwZEhohAxVcbLz)_