### PR TITLE
Fix WebApp post-merge CI regressions

### DIFF
--- a/client/tests/pages/HowItWorks.test.tsx
+++ b/client/tests/pages/HowItWorks.test.tsx
@@ -27,7 +27,7 @@ describe("HowItWorks", () => {
       screen.getByRole("heading", { name: /^Decide the next test\.$/i }),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(/Five steps from real site to a decision\./i),
+      screen.getByText(/Four steps from real site to a decision\./i),
     ).toBeInTheDocument();
     expect(
       screen.getByText(/Not every value is proof\./i),

--- a/e2e/robot-team-eval.spec.ts
+++ b/e2e/robot-team-eval.spec.ts
@@ -48,7 +48,7 @@ test("robot-team eval route is simple and submits normalized policy payload", as
   ).toBeVisible();
   await expect(page.getByText(/the full scoring harness, hidden failure labels/i)).toBeVisible();
   await expect(
-    page.getByLabel("5 Protect hardware and site IP"),
+    page.getByLabel("6 Protect hardware and site IP"),
   ).toHaveValue("customer_hosted_sealed_eval_capsule");
   await expect(page.getByText(/raw captures, full scenes, scoring harnesses/i)).toBeVisible();
 
@@ -61,7 +61,7 @@ test("robot-team eval route is simple and submits normalized policy payload", as
     .fill("warehouse-policy, baseline-policy, ignored-fourth");
   await page.getByLabel("4 Choose episodes").selectOption("500");
   await page
-    .getByLabel("5 Protect hardware and site IP")
+    .getByLabel("6 Protect hardware and site IP")
     .selectOption("physical_robot_evidence_bridge");
   await page.getByText("Advanced details").click();
   await page

--- a/package-lock.json
+++ b/package-lock.json
@@ -8476,9 +8476,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -197,5 +197,8 @@
   },
   "optionalDependencies": {
     "bufferutil": "^4.0.8"
+  },
+  "overrides": {
+    "fast-uri": "3.1.4"
   }
 }


### PR DESCRIPTION
## Summary
- update the remaining unit/E2E assertions for the current four-step How It Works copy and six-step evaluation form
- override `fast-uri` to patched 3.1.4 so the production high-severity audit gate passes

## Validation
- `npm audit --omit=dev --audit-level=high`
- focused Vitest suites: 4 tests passed
- Robot Team Eval Playwright suite: 2 tests passed
- `npm run check`
- `git diff --check`
