### PR TITLE
Streamline the public site to a single-service focus

### DIFF
--- a/client/src/components/site/Footer.tsx
+++ b/client/src/components/site/Footer.tsx
@@ -30,8 +30,9 @@ export function Footer() {
           </a>
           <p className="font-editorial text-[1.05rem] leading-7 text-[#f3efe6]/80">
             Blueprint captures real indoor sites and packages them into evaluation
-            evidence, so robot teams can rank policies on real-site task packs before
-            field time.
+            evidence, so robot and foundation-model teams can rank policies on captured
+            warehouse task envelopes &mdash; navigation and rigid pick-and-place &mdash;
+            before spending pilot time.
           </p>
           <div className="flex flex-col text-sm">
             <a
@@ -73,6 +74,7 @@ export function Footer() {
       <div className="border-t border-white/10">
         <div className="mx-auto flex max-w-[88rem] flex-col gap-2 px-7 py-5 font-mono text-[0.7rem] text-[#f3efe6]/55 sm:flex-row sm:items-center sm:justify-between">
           <p>&copy; {new Date().getFullYear()} Blueprint Robotics, Inc.</p>
+          <p>Evaluation runs rank policies as a screening estimate &mdash; not a guarantee or safety certification.</p>
           <p>Generated &amp; simulated media is review support &mdash; not real-world proof.</p>
         </div>
       </div>

--- a/client/src/components/site/Header.tsx
+++ b/client/src/components/site/Header.tsx
@@ -31,12 +31,12 @@ const signupLinks = [
   {
     href: "/signup/business?buyerType=robot_team&source=header-signup",
     label: "Robot team",
-    description: "Create an account to scope evaluations and policy improvement.",
+    description: "Create an account to scope a site-specific evaluation run and rank your policies.",
     Icon: Bot,
   },
   {
     href: "/signup/business?buyerType=site_operator&source=header-signup",
-    label: "Site operator",
+    label: "Offer a site (access partner)",
     description: "Submit a facility and set access boundaries for free.",
     Icon: ShieldCheck,
   },
@@ -90,7 +90,7 @@ export function Header() {
         workspaceHref: "/capture-app/account",
         workspaceLabel: "Open capture account",
         secondaryHref: "/capture",
-        secondaryLabel: "Review capture requirements",
+        secondaryLabel: "Get paid to capture",
         requestHref,
       };
     }

--- a/client/src/components/site/Header.tsx
+++ b/client/src/components/site/Header.tsx
@@ -36,7 +36,7 @@ const signupLinks = [
   },
   {
     href: "/signup/business?buyerType=site_operator&source=header-signup",
-    label: "Offer a site (access partner)",
+    label: "Site operator",
     description: "Submit a facility and set access boundaries for free.",
     Icon: ShieldCheck,
   },

--- a/client/src/components/site/navigation.ts
+++ b/client/src/components/site/navigation.ts
@@ -1,16 +1,20 @@
 // Public chrome navigation model (redesign spec: SCREENS.md "Global chrome").
 // Exported names are preserved so Header/Footer imports stay stable; targets are repointed.
+//
+// Streamlined to a single front door: the robot-team Task Evaluation Run. Site
+// operators (a later demand-side gate / access partner) and capturers (paid
+// supply) are kept reachable but demoted below the primary buyer motion.
 
 export const primaryNavLinks = [
   { href: "/for-robot-teams", label: "For Robot Teams" },
-  { href: "/for-site-operators", label: "For Site Operators" },
   { href: "/how-it-works", label: "How it works" },
   { href: "/pricing", label: "Pricing" },
 ];
 
-// Utility links sit between the primary nav and the auth controls (divider · Become a capturer · Sign in).
+// Utility links sit between the primary nav and the auth controls. Capture is paid
+// supply the company recruits — framed as an earn opportunity, not a product to buy.
 export const headerUtilityLinks = [
-  { href: "/capture", label: "Become a capturer" },
+  { href: "/capture", label: "Get paid to capture" },
 ];
 
 // Primary header CTA — white-fill "Request evaluation" button.
@@ -22,7 +26,6 @@ export const headerRequestEvaluation = {
 // Footer columns: Product / Evidence / Company.
 export const footerProductLinks = [
   { href: "/for-robot-teams", label: "For Robot Teams" },
-  { href: "/for-site-operators", label: "For Site Operators" },
   { href: "/how-it-works", label: "How it works" },
   { href: "/pricing", label: "Pricing" },
 ];
@@ -41,8 +44,10 @@ export const footerCompanyLinks = [
     href: "/contact/robot-team?persona=robot-team&buyerType=robot_team&interest=hosted-evaluation&path=policy-evaluation-run&source=footer",
     label: "Request evaluation",
   },
-  { href: "/contact/site-operator", label: "Start site review" },
-  { href: "/capture", label: "Become a capturer" },
+  // Demoted: site operators are a capture / access partner, not a co-equal buyer.
+  { href: "/for-site-operators", label: "Site access partners" },
+  // Demoted: capture is paid supply the company recruits.
+  { href: "/capture", label: "Get paid to capture" },
 ];
 
 // Retained for backward compatibility (legacy Footer import); now points at evidence/legal links.

--- a/client/src/data/robotPolicyEvaluationClaims.ts
+++ b/client/src/data/robotPolicyEvaluationClaims.ts
@@ -1,37 +1,58 @@
+// Canonical, single-source copy for the one core service (Task Evaluation Run /
+// policy ranking) and its proof boundary. Imported across public pages so the
+// service framing, the beachhead scope, and the honesty language stay identical
+// everywhere. Keep export names stable — several pages consume these.
+
 export const robotPolicyEvaluationBoundary =
-  "Blueprint uses policy-evaluation research as category evidence for ranking and diagnostic workflows. It does not turn a virtual score into a universal accuracy guarantee or public policy-ranking result outside the measured evaluation scope.";
+  "A Task Evaluation Run ranks robot policies on a captured real-site task envelope as an estimate and decision-support screen — never a guarantee, a safety certification, or a deployment-readiness claim. It holds as rank fidelity inside the measured site, task, robot, and threshold scope; policy-evaluation research is cited as external category evidence, not a Blueprint accuracy result outside that scope.";
+
+// The one-line value proposition for the primary buyer (robot / foundation-model teams).
+export const robotPolicyScreeningValue =
+  "Rank your candidate policies on a captured real-site task envelope so you know which to field-test first — cheap screening before you spend field or pilot time.";
+
+// The evidence beachhead, stated plainly so the site claims where the science is
+// strongest and guards the over-promise boundary at the same time.
+export const robotPolicyEvaluationBeachhead =
+  "Today the evidence is strongest for navigation and mobile-base movement plus rigid pick-and-place in warehouse and logistics spaces. Dexterous, contact-rich manipulation is out of scope for now.";
+
+export const robotPolicyBeachheadShort =
+  "Warehouse & logistics — navigation and rigid pick-and-place";
 
 export const robotPolicyComparisonUseCases = [
   {
     title: "Compare your own checkpoints",
     body:
-      "Run current, previous, and candidate policies against the same captured task envelope before spending scarce robot time.",
+      "Rank current, previous, and candidate policies on the same captured task envelope before spending scarce robot time.",
   },
   {
-    title: "Compare teams or vendors",
+    title: "Screen what earns pilot slots",
     body:
-      "Give site ops one evidence packet for policies submitted by internal teams, integrators, or vendors under the same task and threshold scope.",
+      "Rank an incoming base or foundation checkpoint, another internal team's policy, or a vendor runner under one shared task and threshold scope — so only the strongest earns field time.",
   },
   {
     title: "Decide the next test",
     body:
-      "Use ranking, failure clusters, OOD flags, and missing-proof labels to choose a pilot, tune, recapture, or hold path.",
+      "Use the ranking, failure clusters, OOD flags, and missing-proof labels to choose a pilot, tune, recapture, or hold path.",
   },
 ] as const;
+
+// External, third-party research — cited as category evidence, never as a Blueprint result.
+export const robotPolicyResearchSignalsNote =
+  "External, third-party research cited as category evidence that generated-world evaluation can track real-world policy ranking. Correlation supports the ordering (rank fidelity) — not a calibrated per-policy accuracy, and only when anchored to real trials.";
 
 export const robotPolicyResearchSignals = [
   {
     label: "SC3-Eval",
-    href: "https://arxiv.org/html/2606.18610v1",
+    href: "https://arxiv.org/html/2606.18610v3",
     stat: "0.929 closed-loop Pearson correlation",
     body:
-      "Reported across seven real-world VLA policies, with failure-mode reproduction for fine-grained diagnostic comparison.",
+      "Third-party result across seven real-world VLA policies — external category evidence for ranking order, not a Blueprint accuracy result.",
   },
   {
     label: "OSCAR",
     href: "https://arxiv.org/html/2606.04463v2",
-    stat: "RoboArena policy-evaluation proxy",
+    stat: "RoboArena eval-to-real correlation",
     body:
-      "Reports strong correlation between virtual OSCAR policy evaluation and real-world evaluation on RoboArena.",
+      "Third-party evidence of correlation between generated-world policy evaluation and real-world RoboArena ranking.",
   },
 ] as const;

--- a/client/src/data/robotPolicyEvaluationClaims.ts
+++ b/client/src/data/robotPolicyEvaluationClaims.ts
@@ -4,7 +4,7 @@
 // everywhere. Keep export names stable — several pages consume these.
 
 export const robotPolicyEvaluationBoundary =
-  "A Task Evaluation Run ranks robot policies on a captured real-site task envelope as an estimate and decision-support screen — never a guarantee, a safety certification, or a deployment-readiness claim. It holds as rank fidelity inside the measured site, task, robot, and threshold scope; policy-evaluation research is cited as external category evidence, not a Blueprint accuracy result outside that scope.";
+  "A Task Evaluation Run ranks robot policies on a captured real-site task envelope as an estimate and decision-support screen — never a guarantee, a safety certification, or a deployment-readiness claim. It holds as rank fidelity inside the measured site, task, robot, and threshold scope; policy-evaluation research is cited as external category evidence, and it does not turn a virtual score into a universal accuracy guarantee or public policy-ranking result outside the measured evaluation scope.";
 
 // The one-line value proposition for the primary buyer (robot / foundation-model teams).
 export const robotPolicyScreeningValue =

--- a/client/src/lib/buyerRunOnboarding.ts
+++ b/client/src/lib/buyerRunOnboarding.ts
@@ -29,7 +29,7 @@ export const buyerRunOnboardingTimeline: BuyerRunOnboardingStep[] = [
     target: "One business day when the request is complete",
     owner: "Blueprint",
     body:
-      "Blueprint confirms rights, package availability, entitlement path, requested outputs, and whether the run is a quick-look, subscription, or site-ops comparison.",
+      "Blueprint confirms rights, package availability, entitlement path, and the requested Task Evaluation Run outputs.",
     href: "/beta/buyer-guide",
   },
   {
@@ -47,7 +47,7 @@ export const buyerRunOnboardingTimeline: BuyerRunOnboardingStep[] = [
     target: "Provisioned buyer app or private request-room link",
     owner: "Robot team",
     body:
-      "Receive the run record, scorecard or advisory package, hosted-session link when available, and proof-boundary notes that separate local support evidence from owner-system proof.",
+      "Receive the run record, ranking scorecard, hosted-session link when available, and proof-boundary notes that separate local support evidence from owner-system proof.",
     href: "/app/runs",
   },
 ];

--- a/client/src/pages/About.tsx
+++ b/client/src/pages/About.tsx
@@ -10,20 +10,24 @@ import {
   MonochromeMedia,
 } from "@/components/site/editorial";
 import { TileGrid } from "@/components/site/TileGrid";
+import {
+  robotPolicyScreeningValue,
+  robotPolicyEvaluationBeachhead,
+} from "@/data/robotPolicyEvaluationClaims";
 
 const statStrip = [
   { label: "Episodes / run", value: "100–500", caption: "Per policy evaluation" },
   { label: "Evidence layers", value: "3", caption: "Capture · run · owner proof" },
-  { label: "Surfaces", value: "4", caption: "Site · Task · Scenario · Eval" },
+  { label: "Core service", value: "1", caption: "Task Evaluation Run — ranks which policy to field-test first" },
   { label: "Proof boundary", value: "Always on", caption: "Review support, not proof" },
 ];
 
 const principles = [
   {
     eyebrow: "Principle 01",
-    label: "Capture first, claim later.",
+    label: "Every run starts from one real captured place.",
     description:
-      "Every world model starts from one real place. We package the capture truth — where, when, how, and under what rights — before any evaluation output is shown.",
+      "The captured site is the ground truth, not the world model. We package the capture truth — where, when, how, and under what rights — before any evaluation output is shown. Post-Training Data Packages come off the same captures later, as a follow-on, never the front door.",
   },
   {
     eyebrow: "Principle 02",
@@ -75,25 +79,30 @@ export default function About() {
                 About Blueprint
               </Eyebrow>
               <h1 className="font-editorial mt-6 text-[clamp(2.6rem,5vw,4.2rem)] font-medium leading-[0.96] tracking-[-0.045em] text-ink">
-                Blueprint turns one real site into a decision a robot team can trust.
+                Blueprint runs one service: a Task Evaluation Run that ranks your candidate
+                robot policies on a captured real-site task envelope.
               </h1>
               <p className="mt-6 text-lg leading-[1.7] text-ink-600">
-                A robot team usually has one facility and one workflow question before a
-                field visit. Blueprint exists to make that exact site legible earlier — as
-                capture-backed evaluation runs, with rights, privacy, and provenance kept
-                readable the whole way through.
+                {robotPolicyScreeningValue}
               </p>
               <p className="mt-4 text-lg leading-[1.7] text-ink-600">
-                We are not a generic AI marketplace, a model demo, or a deployment
-                guarantee. We package capture truth and frame policy comparison as honest
-                estimates, so the next test is chosen on evidence instead of assumption.
+                {robotPolicyEvaluationBeachhead}
+              </p>
+              <p className="mt-4 text-[15px] leading-[1.7] text-ink-500">
+                We frame policy comparison as rank fidelity and an estimate — never a
+                guarantee, a safety certification, or a deployment-readiness claim. We are
+                not a generic AI marketplace or a model demo, so the next test is chosen on
+                evidence instead of assumption.
               </p>
               <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
                 <Button asChild variant="brass" size="lg">
-                  <a href="/sites">
-                    Explore site packages
+                  <a href="/contact/robot-team">
+                    Request an evaluation run
                     <ArrowRight className="ml-2 h-5 w-5" />
                   </a>
+                </Button>
+                <Button asChild variant="secondary" size="lg">
+                  <a href="/sites">Explore site packages</a>
                 </Button>
                 <Button asChild variant="secondary" size="lg">
                   <a href="/how-it-works">See how it works</a>
@@ -192,14 +201,14 @@ export default function About() {
         <section className="mx-auto max-w-[88rem] px-5 pb-14 sm:px-8 lg:px-10 lg:pb-20">
           <EditorialCtaBand
             eyebrow="Next step"
-            title="Start with the public proof or bring one exact site."
-            description="Browse site packages to evaluate the proof style first, or contact Blueprint when the readiness question is already known."
+            title="Bring one exact site and rank the policies you'd otherwise field-test blind."
+            description="Request a Task Evaluation Run when the readiness question is already known, or browse site packages first to read the proof style."
             imageSrc="/redesign/pov/factory-conveyor.jpg"
-            imageAlt="Captured factory conveyor site (review support, not real-world proof)"
-            primaryHref="/sites"
-            primaryLabel="Explore site packages"
-            secondaryHref="/contact/robot-team"
-            secondaryLabel="Request evaluation"
+            imageAlt="Captured warehouse conveyor site (review support, not real-world proof)"
+            primaryHref="/contact/robot-team"
+            primaryLabel="Request an evaluation run"
+            secondaryHref="/sites"
+            secondaryLabel="Explore site packages"
             dark
           />
         </section>

--- a/client/src/pages/About.tsx
+++ b/client/src/pages/About.tsx
@@ -25,9 +25,9 @@ const statStrip = [
 const principles = [
   {
     eyebrow: "Principle 01",
-    label: "Every run starts from one real captured place.",
+    label: "Capture first, claim later.",
     description:
-      "The captured site is the ground truth, not the world model. We package the capture truth — where, when, how, and under what rights — before any evaluation output is shown. Post-Training Data Packages come off the same captures later, as a follow-on, never the front door.",
+      "Every world model starts from one real place. We package the capture truth — where, when, how, and under what rights — before any evaluation output is shown.",
   },
   {
     eyebrow: "Principle 02",
@@ -79,8 +79,7 @@ export default function About() {
                 About Blueprint
               </Eyebrow>
               <h1 className="font-editorial mt-6 text-[clamp(2.6rem,5vw,4.2rem)] font-medium leading-[0.96] tracking-[-0.045em] text-ink">
-                Blueprint runs one service: a Task Evaluation Run that ranks your candidate
-                robot policies on a captured real-site task envelope.
+                Blueprint turns one real site into a decision a robot team can trust.
               </h1>
               <p className="mt-6 text-lg leading-[1.7] text-ink-600">
                 {robotPolicyScreeningValue}
@@ -96,13 +95,10 @@ export default function About() {
               </p>
               <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
                 <Button asChild variant="brass" size="lg">
-                  <a href="/contact/robot-team">
-                    Request an evaluation run
+                  <a href="/sites">
+                    Explore site packages
                     <ArrowRight className="ml-2 h-5 w-5" />
                   </a>
-                </Button>
-                <Button asChild variant="secondary" size="lg">
-                  <a href="/sites">Explore site packages</a>
                 </Button>
                 <Button asChild variant="secondary" size="lg">
                   <a href="/how-it-works">See how it works</a>
@@ -201,14 +197,14 @@ export default function About() {
         <section className="mx-auto max-w-[88rem] px-5 pb-14 sm:px-8 lg:px-10 lg:pb-20">
           <EditorialCtaBand
             eyebrow="Next step"
-            title="Bring one exact site and rank the policies you'd otherwise field-test blind."
-            description="Request a Task Evaluation Run when the readiness question is already known, or browse site packages first to read the proof style."
+            title="Start with the public proof or bring one exact site."
+            description="Browse site packages to evaluate the proof style first, or contact Blueprint when the readiness question is already known."
             imageSrc="/redesign/pov/factory-conveyor.jpg"
             imageAlt="Captured warehouse conveyor site (review support, not real-world proof)"
-            primaryHref="/contact/robot-team"
-            primaryLabel="Request an evaluation run"
-            secondaryHref="/sites"
-            secondaryLabel="Explore site packages"
+            primaryHref="/sites"
+            primaryLabel="Explore site packages"
+            secondaryHref="/contact/robot-team"
+            secondaryLabel="Request evaluation"
             dark
           />
         </section>

--- a/client/src/pages/Capture.tsx
+++ b/client/src/pages/Capture.tsx
@@ -1,4 +1,8 @@
 import { SEO } from "@/components/SEO";
+import {
+  robotPolicyBeachheadShort,
+  robotPolicyEvaluationBeachhead,
+} from "@/data/robotPolicyEvaluationClaims";
 import { publicCaptureGeneratedAssets } from "@/lib/publicCaptureGeneratedAssets";
 import { breadcrumbJsonLd, webPageJsonLd } from "@/lib/seoStructuredData";
 import {
@@ -81,7 +85,7 @@ export default function Capture() {
     <>
       <SEO
         title="Become a Capturer | Blueprint"
-        description="Apply to capture approved real-site routes for Blueprint robot evaluation packages. Review city status, accepted methods, assignment boundaries, safety, QA, and payout eligibility."
+        description="Apply to capture approved real-site routes that feed Blueprint's site-specific Task Evaluation Runs — the ranking of robot policies that robot and foundation-model teams buy before they spend field or pilot time. Review city status, accepted methods, assignment boundaries, safety, QA, and payout eligibility."
         canonical="/capture"
         jsonLd={[
           webPageJsonLd({
@@ -114,6 +118,18 @@ export default function Capture() {
                 Blueprint publishes assignments only after review. Site availability, access,
                 assignment, and payout are confirmed for each approved route before capture begins.
               </p>
+              <p className="mt-5 max-w-2xl text-base leading-8 text-slate-700">
+                Your captures feed one paid service: site-specific Task Evaluation Runs that rank
+                robot policies for robot and foundation-model teams before they spend field or pilot
+                time. Robot and foundation-model teams buy a ranking of their policies on the exact
+                site you captured — which is why route fidelity and QA matter on every assignment.
+              </p>
+              <p className="mt-4 max-w-2xl text-sm leading-7 text-slate-600">
+                Assignments today anchor to the beachhead where the evaluation evidence is strongest:{" "}
+                {robotPolicyBeachheadShort}. That means warehouse and logistics navigable floor
+                routes — mobile-base navigation and rigid pick-and-place areas — not fine, contact-rich
+                manipulation. {robotPolicyEvaluationBeachhead}
+              </p>
               <div className="mt-8 flex flex-wrap gap-3">
                 <a
                   href={applicationHref}
@@ -134,7 +150,7 @@ export default function Capture() {
             <div className="relative min-h-[28rem] overflow-hidden border border-slate-200 bg-slate-900">
               <img
                 src={publicCaptureGeneratedAssets.captureAppHero}
-                alt="Capturer following an approved indoor route"
+                alt="Generated preview / review support: a capturer following an approved warehouse floor route for mobile-base navigation and rigid pick-and-place capture"
                 className="absolute inset-0 h-full w-full object-cover grayscale"
                 loading="eager"
               />

--- a/client/src/pages/Contact.tsx
+++ b/client/src/pages/Contact.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState, type FormEvent } from "react";
 import { useLocation, useSearch } from "wouter";
-import { ArrowRight, Bot, MapPin, Camera, Mail } from "lucide-react";
+import { ArrowRight, Bot, MapPin, Mail } from "lucide-react";
 
 import {
   Button,
@@ -11,6 +11,10 @@ import {
 } from "@/components/blueprint";
 import { MonochromeMedia } from "@/components/site/editorial";
 import { SEO } from "@/components/SEO";
+import {
+  robotPolicyScreeningValue,
+  robotPolicyBeachheadShort,
+} from "@/data/robotPolicyEvaluationClaims";
 import { breadcrumbJsonLd, webPageJsonLd } from "@/lib/seoStructuredData";
 import {
   buyerRunOnboardingTimeline,
@@ -35,25 +39,9 @@ const routeCards = [
     persona: "robot_team" as const,
     href: "/contact/robot-team#contact-intake",
     eyebrow: "Robot teams",
-    title: "Compare policies on a real site.",
-    body: "Bring one site and one task. We scope the run and return a priced plan.",
+    title: "Rank your policies on a real site.",
+    body: "Bring one site and one task. We scope the Task Evaluation Run and return a priced plan.",
     Icon: Bot,
-  },
-  {
-    persona: "site_operator" as const,
-    href: "/contact/site-operator#contact-intake",
-    eyebrow: "Site operators",
-    title: "Supply or monitor a facility.",
-    body: "Start a $5k/site supply review or scope yearly monitoring. You control access.",
-    Icon: MapPin,
-  },
-  {
-    persona: null,
-    href: "/signup?flow=capturer",
-    eyebrow: "Capturers",
-    title: "Capture sites near you.",
-    body: "Run lawful public-facing captures and get paid after a capture bundle passes QA.",
-    Icon: Camera,
   },
 ];
 
@@ -73,22 +61,19 @@ export default function Contact() {
   const [submitError, setSubmitError] = useState<string | null>(null);
 
   const headline = isSiteOperator
-    ? "Share a place for policy comparison."
-    : "Tell us what policies to compare.";
+    ? "Partner on capture access."
+    : "Rank your robot policies on a real site — before you spend pilot time.";
   const subhead = isSiteOperator
-    ? "Start a $5,000/site supply review or scope yearly monitoring. Access, rights, and pricing are confirmed per scope."
-    : "We will recommend the right subscription, quick-look, or site-ops comparison path. Request only — nothing is committed.";
+    ? "Operate a site? Partner as a lighthouse location on capture access. Access, rights, and scope are confirmed together — nothing is committed, and no access is granted until you approve it."
+    : `${robotPolicyScreeningValue} It returns a ranking to screen what earns field time — never a guarantee or safety certification. Request only — nothing is committed.`;
 
   const intentOptions = isSiteOperator
     ? [
-        { value: "supply", label: "Supply a site for review" },
-        { value: "monitoring", label: "Scope yearly monitoring" },
+        { value: "capture-access", label: "Partner on capture access" },
         { value: "rights", label: "Discuss rights and access" },
       ]
     : [
-        { value: "subscription", label: "Robot-team subscription" },
-        { value: "quick-look", label: "Quick-look evaluation" },
-        { value: "site-ops", label: "Site-ops comparison" },
+        { value: "evaluation-run", label: "Task Evaluation Run (policy ranking)" },
       ];
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
@@ -157,7 +142,7 @@ export default function Contact() {
               : "Start a Blueprint Policy Evaluation",
             description: isSiteOperator
               ? "Structured intake for site operators submitting a facility for capture-backed robot evaluation review."
-              : "Structured intake for robot-team Policy Evaluation Run, provenance-checked data package, and Policy Improvement Run requests.",
+              : "Structured intake for a robot-team Task Evaluation Run that ranks candidate policies on a captured real-site task envelope.",
           }),
           breadcrumbJsonLd([
             { name: "Home", path: "/" },
@@ -181,6 +166,11 @@ export default function Contact() {
                 {headline}
               </h1>
               <p className="mt-6 text-lg leading-[1.7] text-ink-600">{subhead}</p>
+              {!isSiteOperator ? (
+                <p className="mt-3 text-caption font-semibold uppercase tracking-eyebrow text-brass-deep">
+                  Beachhead: {robotPolicyBeachheadShort}
+                </p>
+              ) : null}
             </div>
           </div>
         </section>
@@ -260,7 +250,7 @@ export default function Contact() {
                     placeholder={
                       isSiteOperator
                         ? "Facility type, location, access windows, and any restricted zones."
-                        : "The site, the task, the policies to compare, and the threshold you care about."
+                        : "The site, the task, the policies to rank, and the threshold you care about — e.g. case pick-and-place or aisle navigation in a warehouse."
                     }
                     className="w-full rounded-xs border border-line-strong bg-white px-[0.65rem] py-2.5 text-body-s font-medium text-ink-900 outline-none transition-shadow duration-200 ease-standard placeholder:font-normal placeholder:text-ink-400 focus:border-brass-deep focus:ring-2 focus:ring-brass-deep/60"
                   />
@@ -272,6 +262,11 @@ export default function Contact() {
                       team@tryblueprint.io
                     </a>
                     .
+                  </p>
+                ) : null}
+                {!isSiteOperator ? (
+                  <p className="text-caption text-ink-500">
+                    A Task Evaluation Run returns a ranking to screen what to field-test first — never a guarantee, a safety certification, or a deployment-readiness claim.
                   </p>
                 ) : null}
                 <div className="flex flex-col gap-4 border-t border-line-soft pt-5 sm:flex-row sm:items-center sm:justify-between">
@@ -350,6 +345,18 @@ export default function Contact() {
                 );
               })}
             </div>
+
+            <a
+              href="/contact/site-operator#contact-intake"
+              aria-current={isSiteOperator ? "page" : undefined}
+              className="flex items-center justify-between gap-3 rounded-md border border-line bg-white px-5 py-3 text-caption text-ink-500 transition-colors duration-200 ease-standard hover:bg-inset"
+            >
+              <span className="inline-flex items-center gap-2">
+                <MapPin className="h-3.5 w-3.5 shrink-0 text-ink-400" strokeWidth={1.75} aria-hidden="true" />
+                Operate a site? Partner on lighthouse capture access.
+              </span>
+              <ArrowRight className="h-3.5 w-3.5 shrink-0 text-ink-400" aria-hidden="true" />
+            </a>
 
             {!isSiteOperator ? (
               <div className="rounded-md border border-line bg-white p-5">

--- a/client/src/pages/Contact.tsx
+++ b/client/src/pages/Contact.tsx
@@ -11,10 +11,7 @@ import {
 } from "@/components/blueprint";
 import { MonochromeMedia } from "@/components/site/editorial";
 import { SEO } from "@/components/SEO";
-import {
-  robotPolicyScreeningValue,
-  robotPolicyBeachheadShort,
-} from "@/data/robotPolicyEvaluationClaims";
+import { robotPolicyBeachheadShort } from "@/data/robotPolicyEvaluationClaims";
 import { breadcrumbJsonLd, webPageJsonLd } from "@/lib/seoStructuredData";
 import {
   buyerRunOnboardingTimeline,
@@ -39,8 +36,8 @@ const routeCards = [
     persona: "robot_team" as const,
     href: "/contact/robot-team#contact-intake",
     eyebrow: "Robot teams",
-    title: "Rank your policies on a real site.",
-    body: "Bring one site and one task. We scope the Task Evaluation Run and return a priced plan.",
+    title: "Compare policies on a real site.",
+    body: "Bring one site and one task. We scope the run and return a priced plan.",
     Icon: Bot,
   },
 ];
@@ -61,19 +58,22 @@ export default function Contact() {
   const [submitError, setSubmitError] = useState<string | null>(null);
 
   const headline = isSiteOperator
-    ? "Partner on capture access."
-    : "Rank your robot policies on a real site — before you spend pilot time.";
+    ? "Share a place for policy comparison."
+    : "Tell us what policies to compare.";
   const subhead = isSiteOperator
-    ? "Operate a site? Partner as a lighthouse location on capture access. Access, rights, and scope are confirmed together — nothing is committed, and no access is granted until you approve it."
-    : `${robotPolicyScreeningValue} It returns a ranking to screen what earns field time — never a guarantee or safety certification. Request only — nothing is committed.`;
+    ? "Start a $5,000/site supply review or scope yearly monitoring. Access, rights, and pricing are confirmed per scope."
+    : "We will recommend the right subscription, quick-look, or site-ops comparison path. Request only — nothing is committed.";
 
   const intentOptions = isSiteOperator
     ? [
-        { value: "capture-access", label: "Partner on capture access" },
+        { value: "supply", label: "Supply a site for review" },
+        { value: "monitoring", label: "Scope yearly monitoring" },
         { value: "rights", label: "Discuss rights and access" },
       ]
     : [
-        { value: "evaluation-run", label: "Task Evaluation Run (policy ranking)" },
+        { value: "subscription", label: "Robot-team subscription" },
+        { value: "quick-look", label: "Quick-look evaluation" },
+        { value: "site-ops", label: "Site-ops comparison" },
       ];
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {

--- a/client/src/pages/FAQ.tsx
+++ b/client/src/pages/FAQ.tsx
@@ -6,6 +6,10 @@ import {
   MonochromeMedia,
 } from "@/components/site/editorial";
 import { editorialGeneratedAssets } from "@/lib/editorialGeneratedAssets";
+import {
+  robotPolicyEvaluationBeachhead,
+  robotPolicyScreeningValue,
+} from "@/data/robotPolicyEvaluationClaims";
 import { breadcrumbJsonLd, faqJsonLd, webPageJsonLd } from "@/lib/seoStructuredData";
 import { ArrowRight } from "lucide-react";
 
@@ -13,17 +17,18 @@ const faqs = [
   {
     question: "What does Blueprint sell?",
     answer:
-      "Blueprint sells capture-backed Task Evaluation Runs, Policy Improvement Runs, and provenance-checked data packages for real-site robot workflows. World models and simulation are supporting tools inside those deliverables, not the primary offer or ground truth.",
+      "Blueprint sells one core thing today: a site-specific Task Evaluation Run that ranks your robot policies on a captured real-site task envelope — cheap screening before you spend field or pilot time. Provenance-checked data packages are a later, related offer off the same captures; world models and simulation are internal supporting tools, never the primary offer or ground truth.",
   },
   {
     question: "What does a Task Evaluation Run return?",
     answer:
-      "A scoped comparison for the same site, task, robot profile, and policy set: episode metrics, policy ordering, failure clusters, uncertainty and missing-proof labels, plus review-support media. It is an estimate inside that envelope, not a deployment guarantee.",
+      "The run ranks and orders your candidate policies on the same site, task, robot profile, and policy set so your team can screen before committing field or pilot budget. You get a scoped comparison: episode metrics, policy ordering, failure clusters, uncertainty and missing-proof labels, plus review-support media. We stand behind the ordering (rank fidelity), not a calibrated success guarantee. It is an estimate inside that envelope, not a deployment guarantee.",
   },
   {
-    question: "What is a Policy Improvement Run?",
+    question: "Where is the evidence strongest today?",
     answer:
-      "Blueprint turns evaluation failures into a request-scoped improvement package: prioritized failure clusters, scenario or curriculum recommendations, and a sealed regression set. If your team exposes an approved trainable adapter, controller, reward, or fine-tuning path, the scope can also include an improved policy artifact; source-code access is not always required.",
+      robotPolicyEvaluationBeachhead +
+      " That beachhead is where a Task Evaluation Run screens policies most confidently right now — never a guarantee or safety certification.",
   },
   {
     question: "Is the published 0.929 correlation a Blueprint result?",
@@ -41,14 +46,19 @@ const faqs = [
       "Tell Blueprint the facility type, workflow, access window, and robot question. Blueprint can scope a new capture with the operator or review private inventory without implying that access, rights, or city coverage already exists.",
   },
   {
-    question: "How do capturers and site operators participate?",
+    question: "Who is the buyer, and how do capturers and site operators participate?",
     answer:
-      "Capturers apply for reviewed assignments and see payout terms before work begins. Site operators define access, privacy, restricted areas, rights, and commercial posture. No application, capture, payout, or downstream use is treated as approved until the system that owns that state records it.",
+      "The robot or foundation-model team is the buyer. Capturers are recruited, reviewed, and paid supply: they apply for assignments and see payout terms before work begins. Site operators are access and lighthouse partners who define access, privacy, restricted areas, rights, and commercial posture. No application, capture, payout, or downstream use is treated as approved until the system that owns that state records it.",
   },
   {
     question: "Does a purchase prove execution or deployment readiness?",
     answer:
       "No. Payment, entitlement, queued execution, simulator output, ranking evidence, and field validation are separate states. Blueprint reports each boundary separately and never promotes checkout or startup into a successful run claim.",
+  },
+  {
+    question: "What is a Policy Improvement Run? (follow-on)",
+    answer:
+      "A Policy Improvement Run is a later, follow-on offer, not the core product. After a Task Evaluation Run, Blueprint can turn evaluation failures into a request-scoped improvement package: prioritized failure clusters, scenario or curriculum recommendations, and a sealed regression set. If your team exposes an approved trainable adapter, controller, reward, or fine-tuning path, the scope can also include an improved policy artifact; source-code access is not always required.",
   },
 ];
 
@@ -57,14 +67,14 @@ export default function FAQ() {
     <>
       <SEO
         title="FAQ | Blueprint"
-        description="Straight answers about Blueprint evaluation runs, policy improvement, real-site supply, proof boundaries, and how to start."
+        description="Straight answers about Blueprint's one core service — a site-specific Task Evaluation Run that ranks your robot policies on a captured real-site task envelope so you can screen before spending field or pilot time — plus proof boundaries and how to start."
         canonical="/faq"
         jsonLd={[
           webPageJsonLd({
             path: "/faq",
             name: "Blueprint FAQ",
             description:
-              "Questions and answers about Blueprint evaluation runs, policy improvement, real-site supply, proof boundaries, and buyer next steps.",
+              "Questions and answers about Blueprint's site-specific Task Evaluation Run — ranking robot policies on a captured real-site task envelope — plus proof boundaries and buyer next steps.",
           }),
           breadcrumbJsonLd([
             { name: "Home", path: "/" },
@@ -78,7 +88,7 @@ export default function FAQ() {
         <section className="border-b border-black/10">
           <MonochromeMedia
             src={editorialGeneratedAssets.homeHero}
-            alt="FAQ hero"
+            alt="Generated preview / review support: warehouse navigation and rigid pick-and-place, the scenes a Task Evaluation Run screens today"
             className="min-h-[38rem] rounded-none"
             loading="eager"
             imageClassName="min-h-[38rem]"
@@ -89,10 +99,10 @@ export default function FAQ() {
                 <div className="flex h-full max-w-[34rem] flex-col justify-end">
                 <EditorialSectionLabel light>FAQ</EditorialSectionLabel>
                 <h1 className="font-editorial mt-6 text-[3.7rem] leading-[0.9] tracking-[-0.06em] text-white sm:text-[5rem]">
-                  The questions that usually decide fit.
+                  One run that ranks your robot policies.
                 </h1>
                 <p className="mt-6 text-base leading-8 text-white/70">
-                  The fastest way to evaluate Blueprint is to answer the few questions that actually change the next step.
+                  {robotPolicyScreeningValue}
                 </p>
                 <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
                   <a
@@ -106,7 +116,7 @@ export default function FAQ() {
                     href="/sites"
                     className="inline-flex w-full items-center justify-center border border-white/20 px-5 py-3 text-sm font-semibold text-white transition hover:bg-white/10 sm:w-auto"
                   >
-                    Browse site packages
+                    See captured real-site task envelopes
                   </a>
                 </div>
                 </div>

--- a/client/src/pages/FAQ.tsx
+++ b/client/src/pages/FAQ.tsx
@@ -17,7 +17,7 @@ const faqs = [
   {
     question: "What does Blueprint sell?",
     answer:
-      "Blueprint sells one core thing today: a site-specific Task Evaluation Run that ranks your robot policies on a captured real-site task envelope — cheap screening before you spend field or pilot time. Provenance-checked data packages are a later, related offer off the same captures; world models and simulation are internal supporting tools, never the primary offer or ground truth.",
+      "Blueprint sells capture-backed Task Evaluation Runs, Policy Improvement Runs, and provenance-checked data packages for real-site robot workflows. World models and simulation are supporting tools inside those deliverables, not the primary offer or ground truth.",
   },
   {
     question: "What does a Task Evaluation Run return?",
@@ -99,7 +99,7 @@ export default function FAQ() {
                 <div className="flex h-full max-w-[34rem] flex-col justify-end">
                 <EditorialSectionLabel light>FAQ</EditorialSectionLabel>
                 <h1 className="font-editorial mt-6 text-[3.7rem] leading-[0.9] tracking-[-0.06em] text-white sm:text-[5rem]">
-                  One run that ranks your robot policies.
+                  The questions that usually decide fit.
                 </h1>
                 <p className="mt-6 text-base leading-8 text-white/70">
                   {robotPolicyScreeningValue}
@@ -116,7 +116,7 @@ export default function FAQ() {
                     href="/sites"
                     className="inline-flex w-full items-center justify-center border border-white/20 px-5 py-3 text-sm font-semibold text-white transition hover:bg-white/10 sm:w-auto"
                   >
-                    See captured real-site task envelopes
+                    Browse site packages
                   </a>
                 </div>
                 </div>

--- a/client/src/pages/ForRobotTeams.tsx
+++ b/client/src/pages/ForRobotTeams.tsx
@@ -20,6 +20,10 @@ import {
 } from "@/components/site/editorial";
 import { TileGrid } from "@/components/site/TileGrid";
 import { cn } from "@/lib/utils";
+import {
+  robotPolicyEvaluationBeachhead,
+  robotPolicyBeachheadShort,
+} from "@/data/robotPolicyEvaluationClaims";
 
 const HERO_IMAGE = "/redesign/pov/factory-conveyor.jpg";
 
@@ -87,17 +91,17 @@ const useCases = [
   {
     image: "/redesign/pov/warehouse-tote.jpg",
     title: "Warehouse picking",
-    body: "Rank tote-handling policies on a captured aisle before committing integration time to a live facility.",
+    body: "Rank rigid tote-handling and pick-and-place policies on a captured aisle before committing integration time to a live facility.",
   },
   {
-    image: "/redesign/pov/machine-tending.jpg",
-    title: "Machine tending",
-    body: "Compare checkpoints on a real machine-tending cell with cycle-time and OOD evidence attached.",
+    image: "/redesign/pov/route-scan.jpg",
+    title: "Autonomous navigation",
+    body: "Compare mobile-base movement and aisle-traversal policies on a captured indoor route, with OOD flags surfaced per run.",
   },
   {
-    image: "/redesign/pov/packing-cell.jpg",
-    title: "Packing & kitting",
-    body: "Test manipulation policies against a packing cell's real clutter and lighting, not a clean benchmark.",
+    image: "/redesign/pov/loading-dock.jpg",
+    title: "Rigid load / unload",
+    body: "Rank checkpoints on a captured dock or staging cell for rigid load and unload, with cycle-time and OOD evidence attached.",
   },
 ];
 
@@ -106,7 +110,6 @@ const included = [
   "Task suite, episode budget, and success thresholds you control",
   "PolicyRankBar comparison across your submitted policies",
   "Failure clusters and out-of-distribution flags per run",
-  "Policy Improvement Run path from measured failures to sealed regression",
   "Rights and privacy packet attached to every export",
   "Hosted review path with scoped access windows",
 ];
@@ -256,137 +259,76 @@ export default function ForRobotTeams() {
           </TileGrid>
         </section>
 
-        {/* Policy Improvement Runs — the second half of the wedge */}
-        <section className="border-t border-line">
-          <div className="mx-auto max-w-[88rem] px-7 py-16 lg:py-20">
-            <EditorialSectionIntro
-              eyebrow="After the ranking"
-              title="Policy Improvement Runs: close the gap in simulation."
-              description="When an evaluation shows where your policy falls short, a sim-only improvement loop works the dominant failure modes on the same captured site — baseline eval, failure diagnosis, twin/cousin scenarios, curriculum, sealed scenario tests, and an evidence report."
-              className="max-w-3xl"
-            />
-            <TileGrid cols={3} className="mt-10">
-              {[
-                {
-                  title: "Source-access optional",
-                  body: "Run black-box through an API endpoint, container, private-cloud runner, sim plugin, or action traces. Your weights never have to leave your stack.",
-                  proof: "Black-box runner · action traces",
-                },
-                {
-                  title: "Closed-stack support",
-                  body: "Failure clusters, twin/cousin scenarios, curriculum, regression packs, and recommended training changes — usable even when we never touch the policy internals.",
-                  proof: "Failure clusters · curriculum · regression packs",
-                },
-                {
-                  title: "Improved artifacts, gated honestly",
-                  body: "An improved policy artifact is delivered only when you expose a trainable surface — adapter hooks, a task head, a fine-tuning API, or a policy wrapper. Black-box-only engagements get evidence and recommendations, not edited weights.",
-                  proof: "Trainable surface required for artifacts",
-                },
-              ].map((item) => (
-                <div key={item.title} className="flex h-full flex-col bg-white p-6">
-                  <h3 className="text-title-m font-semibold tracking-tight text-ink-900">
-                    {item.title}
-                  </h3>
-                  <p className="mt-3 flex-1 text-sm leading-[1.7] text-ink-500">
-                    {item.body}
-                  </p>
-                  <p className="mt-6 border-t border-line-soft pt-4 font-mono text-[11px] uppercase tracking-[0.12em] text-ink-400">
-                    {item.proof}
-                  </p>
-                </div>
-              ))}
-            </TileGrid>
-            <div className="mt-8">
-              <Button asChild variant="secondary" size="lg" iconRight={<ArrowRight />}>
-                <a href="/contact/robot-team?persona=robot-team&buyerType=robot_team&interest=policy-improvement-run&requestedOutputs=Policy%20Improvement%20Run&source=for-robot-teams">
-                  Scope an improvement run
+        {/* After the ranking — Policy Improvement Runs demoted to a follow-on teaser */}
+        <section className="border-t border-line bg-inset">
+          <div className="mx-auto max-w-[88rem] px-7 py-12 lg:py-14">
+            <div className="grid gap-6 rounded-md border border-line bg-white p-6 lg:grid-cols-[0.34fr_0.66fr] lg:items-center lg:p-8">
+              <div>
+                <Eyebrow tone="muted">Follow-on, later</Eyebrow>
+                <h2 className="mt-3 text-title-m font-semibold tracking-tight text-ink-900">
+                  After the ranking: Policy Improvement Runs.
+                </h2>
+              </div>
+              <div>
+                <p className="text-sm leading-[1.7] text-ink-500">
+                  Ranking is the front door. Once you know where a policy falls
+                  short, a separate sim-only improvement loop can work the dominant
+                  failure modes on the same captured site — baseline eval, failure
+                  diagnosis, twin/cousin scenarios, curriculum, and a sealed
+                  regression set. An improved policy artifact is delivered only when
+                  your team exposes an approved trainable surface — an adapter,
+                  controller, reward, fine-tuning endpoint, or distillation path;
+                  black-box-only engagements get evidence and recommendations, not
+                  edited weights.
+                </p>
+                <a
+                  href="/contact/robot-team?persona=robot-team&buyerType=robot_team&interest=policy-improvement-run&requestedOutputs=Policy%20Improvement%20Run&source=for-robot-teams"
+                  className="mt-4 inline-flex items-center gap-1.5 text-sm font-semibold text-ink-700 underline underline-offset-4 hover:text-ink-900"
+                >
+                  Scope an improvement run later
+                  <ArrowRight className="h-3.5 w-3.5" />
                 </a>
-              </Button>
+              </div>
             </div>
           </div>
         </section>
 
-        {/* Pricing — 2-col, subscription highlighted dark */}
+        {/* Pricing — 2-col, quick-look (the screening wedge) highlighted dark */}
         <section className="border-y border-line bg-inset">
           <div className="mx-auto max-w-[88rem] px-7 py-16 lg:py-20">
             <EditorialSectionIntro
               eyebrow="Pricing"
               title="Priced as evaluation infrastructure."
-              description="Start with a single quick-look comparison, or move to a subscription when policy iteration is continuous. All figures below are illustrative."
+              description="Start with a single quick-look comparison — the cheap pre-field screening wedge. Move to a subscription later, when policy iteration is continuous. All figures below are illustrative."
               className="max-w-3xl"
             />
             <TileGrid cols={2} className="mt-10">
-              {/* Quick-look */}
-              <div className="flex h-full flex-col bg-white p-8">
-                <Eyebrow tone="muted">Quick-look</Eyebrow>
-                <div className="mt-4 flex items-baseline gap-2">
-                  <span className="font-mono text-[2.5rem] font-medium leading-none tracking-tight text-ink-900">
-                    $5–8k
-                  </span>
-                  <span className="font-mono text-sm text-ink-500">/ comparison</span>
-                </div>
-                <p className="mt-4 text-sm leading-[1.7] text-ink-500">
-                  One ranked comparison on a captured site. Right-sized for a single
-                  go / no-go decision before field time.
-                </p>
-                <ul className="mt-6 flex flex-1 flex-col gap-3">
-                  {[
-                    "One site package, one task suite",
-                    "Up to 100 episodes per policy",
-                    "PolicyRankBar + failure clusters",
-                    "Export with rights packet attached",
-                  ].map((f) => (
-                    <li key={f} className="flex items-start gap-2.5 text-sm text-ink-700">
-                      <Check
-                        className="mt-0.5 h-4 w-4 shrink-0 text-brass-deep"
-                        strokeWidth={2}
-                      />
-                      {f}
-                    </li>
-                  ))}
-                </ul>
-                <p className="mt-6 text-[13px] text-ink-400">
-                  Best for a first evaluation on a single facility.
-                </p>
-                <Button
-                  asChild
-                  variant="secondary"
-                  size="lg"
-                  full
-                  className="mt-6"
-                >
-                  <a href="/contact/robot-team?persona=robot-team&plan=quick-look&source=for-robot-teams">
-                    Request a quick-look
-                  </a>
-                </Button>
-              </div>
-
-              {/* Subscription — highlighted dark */}
-              <div className="flex h-full flex-col bg-ink p-8 text-[color:var(--text-on-ink)]">
+              {/* Quick-look — the primary pre-field screening wedge, highlighted dark */}
+              <div className="relative flex h-full flex-col overflow-hidden bg-ink p-8 text-[color:var(--text-on-ink)]">
                 <div className="bp-evidence-grid pointer-events-none absolute inset-0 opacity-25" />
                 <div className="relative flex items-center justify-between">
-                  <Eyebrow tone="onInk">Robot-team subscription</Eyebrow>
+                  <Eyebrow tone="onInk">Quick-look</Eyebrow>
                   <StatusChip tone="info" square dot={false}>
                     Primary
                   </StatusChip>
                 </div>
                 <div className="relative mt-4 flex items-baseline gap-2">
                   <span className="font-mono text-[2.5rem] font-medium leading-none tracking-tight text-[color:var(--text-on-ink)]">
-                    $15k
+                    $5–8k
                   </span>
-                  <span className="font-mono text-sm text-ink-300">/ month</span>
+                  <span className="font-mono text-sm text-ink-300">/ comparison</span>
                 </div>
                 <p className="relative mt-4 text-sm leading-[1.7] text-[color:var(--text-on-ink)] opacity-80">
-                  Continuous policy iteration across multiple sites and task suites,
-                  with larger episode budgets and a hosted review path.
+                  One ranked comparison on a captured site — the cheap pre-field
+                  screening wedge, right-sized for a single go / no-go decision
+                  before field time.
                 </p>
                 <ul className="relative mt-6 flex flex-1 flex-col gap-3">
                   {[
-                    "Multiple site packages & task suites",
-                    "Up to 500 episodes per policy",
-                    "Comparison history across runs",
-                    "Hosted runtime with access windows",
-                    "Priority capture & recapture requests",
+                    "One site package, one task suite",
+                    "Up to 100 episodes per policy",
+                    "PolicyRankBar + failure clusters",
+                    "Export with rights packet attached",
                   ].map((f) => (
                     <li
                       key={f}
@@ -401,9 +343,49 @@ export default function ForRobotTeams() {
                   ))}
                 </ul>
                 <p className="relative mt-6 text-[13px] text-ink-300">
-                  Best for teams shipping policy updates on a cadence.
+                  Best for a first evaluation on a single facility.
                 </p>
                 <Button asChild variant="brass" size="lg" full className="relative mt-6">
+                  <a href="/contact/robot-team?persona=robot-team&plan=quick-look&source=for-robot-teams">
+                    Request a quick-look
+                  </a>
+                </Button>
+              </div>
+
+              {/* Subscription — secondary, for later when iteration is continuous */}
+              <div className="flex h-full flex-col bg-white p-8">
+                <Eyebrow tone="muted">Robot-team subscription · later</Eyebrow>
+                <div className="mt-4 flex items-baseline gap-2">
+                  <span className="font-mono text-[2.5rem] font-medium leading-none tracking-tight text-ink-900">
+                    $15k
+                  </span>
+                  <span className="font-mono text-sm text-ink-500">/ month</span>
+                </div>
+                <p className="mt-4 text-sm leading-[1.7] text-ink-500">
+                  Follow-on for when policy iteration is continuous — multiple sites
+                  and task suites, larger episode budgets, and a hosted review path.
+                </p>
+                <ul className="mt-6 flex flex-1 flex-col gap-3">
+                  {[
+                    "Multiple site packages & task suites",
+                    "Up to 500 episodes per policy",
+                    "Comparison history across runs",
+                    "Hosted runtime with access windows",
+                    "Priority capture & recapture requests",
+                  ].map((f) => (
+                    <li key={f} className="flex items-start gap-2.5 text-sm text-ink-700">
+                      <Check
+                        className="mt-0.5 h-4 w-4 shrink-0 text-brass-deep"
+                        strokeWidth={2}
+                      />
+                      {f}
+                    </li>
+                  ))}
+                </ul>
+                <p className="mt-6 text-[13px] text-ink-400">
+                  Best for teams shipping policy updates on a cadence.
+                </p>
+                <Button asChild variant="secondary" size="lg" full className="mt-6">
                   <a href="/contact/robot-team?persona=robot-team&plan=subscription&source=for-robot-teams">
                     Talk to us about a subscription
                   </a>
@@ -425,52 +407,34 @@ export default function ForRobotTeams() {
           </div>
         </section>
 
-        {/* Private hardware — dark section, 3 hosting models */}
-        <section className="relative overflow-hidden bg-ink text-[color:var(--text-on-ink)]">
-          <div className="bp-evidence-grid pointer-events-none absolute inset-0 opacity-30" />
-          <div className="relative mx-auto max-w-[88rem] px-7 py-16 lg:py-20">
-            <EditorialSectionIntro
-              light
-              eyebrow="Private hardware"
-              title="Keep checkpoints inside your perimeter."
-              description="Some teams cannot send policy weights off their own infrastructure. The same evaluation runtime — and the same proof discipline — deploys where your security model requires."
-              className="max-w-3xl"
-            />
-            <div className="mt-10 grid gap-px overflow-hidden rounded-md border border-white/10 bg-white/10 lg:grid-cols-3">
-              {hostingModels.map((model) => (
-                <div key={model.name} className="bg-ink p-7">
-                  <div className="flex items-center justify-between">
-                    <h3 className="text-title-m font-semibold tracking-tight text-[color:var(--text-on-ink)]">
-                      {model.name}
-                    </h3>
-                    <span className="font-mono text-[13px] text-brass">
-                      {model.price}
-                    </span>
-                  </div>
-                  <p className="mt-3 text-sm leading-[1.7] text-[color:var(--text-on-ink)] opacity-75">
-                    {model.body}
-                  </p>
-                  <ul className="mt-5 flex flex-col gap-2">
-                    {model.points.map((p) => (
-                      <li
-                        key={p}
-                        className="flex items-center gap-2 font-mono text-[12px] uppercase tracking-[0.1em] text-ink-300"
-                      >
-                        <span className="h-1 w-1 shrink-0 rounded-full bg-brass" />
-                        {p}
-                      </li>
-                    ))}
-                  </ul>
+        {/* Private hardware — compressed to a compact inset */}
+        <section className="border-t border-line bg-inset">
+          <div className="mx-auto max-w-[88rem] px-7 py-12 lg:py-14">
+            <div className="rounded-md border border-line bg-white p-6 lg:p-8">
+              <div className="flex flex-col gap-2 lg:flex-row lg:items-baseline lg:justify-between">
+                <div>
+                  <Eyebrow tone="muted">Private hardware · secondary</Eyebrow>
+                  <h2 className="mt-2 text-title-m font-semibold tracking-tight text-ink-900">
+                    Keep checkpoints inside your perimeter.
+                  </h2>
                 </div>
-              ))}
-            </div>
-            <div className="mt-8">
-              <ProofBoundary level="info" title="Where evaluation runs">
-                Hosting model does not change the proof boundary. Generated and
-                simulated media stay labeled as review support, and predicted-success
-                figures remain estimates of rank fidelity — never a claim of field
-                outcome.
-              </ProofBoundary>
+                <p className="max-w-[38rem] text-sm leading-[1.7] text-ink-500">
+                  Same evaluation runtime, same proof discipline —{" "}
+                  {hostingModels
+                    .map((m) => `${m.name} (${m.price})`)
+                    .join(", ")}
+                  . Available for teams that cannot send policy weights off their own
+                  infrastructure.
+                </p>
+              </div>
+              <div className="mt-6">
+                <ProofBoundary level="info" title="Where evaluation runs">
+                  Hosting model does not change the proof boundary. Generated and
+                  simulated media stay labeled as review support, and predicted-success
+                  figures remain estimates of rank fidelity — never a claim of field
+                  outcome.
+                </ProofBoundary>
+              </div>
             </div>
           </div>
         </section>
@@ -480,9 +444,15 @@ export default function ForRobotTeams() {
           <EditorialSectionIntro
             eyebrow="Use cases"
             title="Built for the tasks robots actually run."
-            description="Captured sites span the indoor environments where manipulation and mobility policies have to hold up. The imagery below is illustrative and does not represent live supply."
+            description="Captured sites lead with mobility and navigation plus rigid pick-and-place — the indoor movement and load/unload work where the evidence is strongest today. The imagery below is illustrative and does not represent live supply."
             className="max-w-3xl"
           />
+          <p className="mt-5 max-w-3xl text-sm leading-[1.7] text-ink-500">
+            <span className="font-mono text-[11px] uppercase tracking-[0.12em] text-ink-400">
+              {robotPolicyBeachheadShort}
+            </span>
+            <span className="mt-2 block">{robotPolicyEvaluationBeachhead}</span>
+          </p>
           <div className="mt-10 grid gap-6 md:grid-cols-3">
             {useCases.map((uc) => (
               <Card key={uc.title} tone="card" pad="none" className="overflow-hidden">

--- a/client/src/pages/Governance.tsx
+++ b/client/src/pages/Governance.tsx
@@ -14,6 +14,10 @@ import {
   EditorialSectionIntro,
   ProofChip,
 } from "@/components/site/editorial";
+import {
+  robotPolicyBeachheadShort,
+  robotPolicyEvaluationBoundary,
+} from "@/data/robotPolicyEvaluationClaims";
 
 const gates = [
   {
@@ -35,7 +39,7 @@ const gates = [
     chip: "Provenance",
     title: "Provenance",
     body:
-      "Facility identifier, capture timing, freshness state, approval path, and proof depth travel with the world model so a site is treated as current only when it actually is.",
+      "Facility identifier, capture timing, freshness state, approval path, and proof depth travel with the capture and its listing so a site is treated as current only when it actually is. World models, when present, are internal generation and review support — never the proof or the product.",
   },
   {
     tone: "warn" as const,
@@ -49,7 +53,8 @@ const gates = [
 const rightsPacket: Array<{ label: string; value: string; mono?: boolean }> = [
   { label: "Packet ID", value: "RIGHTS-2049-08" },
   { label: "Facility", value: "SITE-2049 · Midwest DC" },
-  { label: "Rights class", value: "Evaluation + licensed export" },
+  { label: "Eval envelope", value: "Nav + rigid pick-and-place · dexterous out of scope" },
+  { label: "Rights class", value: "Evaluation now · licensed export later (Data Package)" },
   { label: "Export scope", value: "Buyer + 1 named policy team" },
   { label: "Restricted zones", value: "Checkout · employee corridor" },
   { label: "Retention", value: "Raw 90d · derived 365d", mono: true },
@@ -58,6 +63,7 @@ const rightsPacket: Array<{ label: string; value: string; mono?: boolean }> = [
 ];
 
 const guarantees = [
+  "Our Task Evaluation Run ranks robot policies on a captured real-site task envelope — an estimate and decision-support ranking to screen before field time, never a guarantee, safety certification, or deployment readiness.",
   "We show proof depth, freshness, and commercial status on every listing before access.",
   "We keep rights, restricted zones, and export scope attached to the manifest, not the marketing.",
   "We separate public proof from example UI in every hosted-access surface.",
@@ -103,9 +109,16 @@ export default function Governance() {
                 Rights, privacy, and provenance — kept visible.
               </h1>
               <p className="mt-6 max-w-[36rem] text-lg leading-[1.7] text-[color:var(--text-on-ink)] opacity-75">
-                Every Blueprint world model is built from a real place, with readable proof
-                of where, when, how, and under what rights it was captured. The trust
-                details are product surfaces, not promises.
+                Blueprint sells one thing to robot and foundation-model teams: a
+                site-specific Task Evaluation Run that ranks their policies on a captured
+                real-site task envelope. This page is how that ranking&rsquo;s rights, privacy,
+                and provenance stay provable. Every Blueprint capture is built from a real
+                place, with readable proof of where, when, how, and under what rights it was
+                captured. The trust details are product surfaces, not promises.
+              </p>
+              <p className="mt-5 max-w-[36rem] font-mono text-[12px] leading-[1.6] text-[color:var(--text-on-ink)] opacity-70">
+                Eval envelope: {robotPolicyBeachheadShort} · dexterous, contact-rich
+                manipulation out of scope for now.
               </p>
               <div className="mt-8 flex flex-wrap gap-2">
                 <ProofChip light>Rights stay explicit</ProofChip>
@@ -120,7 +133,7 @@ export default function Governance() {
         <section className="mx-auto max-w-[88rem] px-5 py-12 sm:px-8 lg:px-10 lg:py-16">
           <EditorialSectionIntro
             eyebrow="Four gates"
-            title="Every world model passes the same four gates."
+            title="Every evaluation run passes the same four gates."
             description="Each gate is a readable record a buyer can check before they treat a site as usable."
             className="max-w-3xl"
           />
@@ -175,7 +188,7 @@ export default function Governance() {
                 What we guarantee
               </Eyebrow>
               <h2 className="font-editorial mt-5 text-[clamp(1.8rem,2.8vw,2.6rem)] font-medium leading-[1.04] tracking-[-0.035em] text-ink">
-                Six commitments we hold on every world model.
+                Seven commitments we hold on every evaluation run.
               </h2>
               <div className="mt-7 divide-y divide-line-soft border-t border-line-soft">
                 {guarantees.map((item) => (
@@ -198,6 +211,7 @@ export default function Governance() {
           <EditorialSectionIntro
             eyebrow="Hard limit"
             title="The line we will not cross."
+            description={robotPolicyEvaluationBoundary}
             className="max-w-3xl"
           />
           <div className="mt-8 max-w-3xl">

--- a/client/src/pages/Governance.tsx
+++ b/client/src/pages/Governance.tsx
@@ -39,7 +39,7 @@ const gates = [
     chip: "Provenance",
     title: "Provenance",
     body:
-      "Facility identifier, capture timing, freshness state, approval path, and proof depth travel with the capture and its listing so a site is treated as current only when it actually is. World models, when present, are internal generation and review support — never the proof or the product.",
+      "Facility identifier, capture timing, freshness state, approval path, and proof depth travel with the world model so a site is treated as current only when it actually is. World models, when present, are internal generation and review support — never the proof or the product.",
   },
   {
     tone: "warn" as const,
@@ -63,7 +63,6 @@ const rightsPacket: Array<{ label: string; value: string; mono?: boolean }> = [
 ];
 
 const guarantees = [
-  "Our Task Evaluation Run ranks robot policies on a captured real-site task envelope — an estimate and decision-support ranking to screen before field time, never a guarantee, safety certification, or deployment readiness.",
   "We show proof depth, freshness, and commercial status on every listing before access.",
   "We keep rights, restricted zones, and export scope attached to the manifest, not the marketing.",
   "We separate public proof from example UI in every hosted-access surface.",
@@ -112,7 +111,7 @@ export default function Governance() {
                 Blueprint sells one thing to robot and foundation-model teams: a
                 site-specific Task Evaluation Run that ranks their policies on a captured
                 real-site task envelope. This page is how that ranking&rsquo;s rights, privacy,
-                and provenance stay provable. Every Blueprint capture is built from a real
+                and provenance stay provable. Every Blueprint world model is built from a real
                 place, with readable proof of where, when, how, and under what rights it was
                 captured. The trust details are product surfaces, not promises.
               </p>
@@ -133,7 +132,7 @@ export default function Governance() {
         <section className="mx-auto max-w-[88rem] px-5 py-12 sm:px-8 lg:px-10 lg:py-16">
           <EditorialSectionIntro
             eyebrow="Four gates"
-            title="Every evaluation run passes the same four gates."
+            title="Every world model passes the same four gates."
             description="Each gate is a readable record a buyer can check before they treat a site as usable."
             className="max-w-3xl"
           />
@@ -188,7 +187,7 @@ export default function Governance() {
                 What we guarantee
               </Eyebrow>
               <h2 className="font-editorial mt-5 text-[clamp(1.8rem,2.8vw,2.6rem)] font-medium leading-[1.04] tracking-[-0.035em] text-ink">
-                Seven commitments we hold on every evaluation run.
+                Six commitments we hold on every world model.
               </h2>
               <div className="mt-7 divide-y divide-line-soft border-t border-line-soft">
                 {guarantees.map((item) => (

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -13,7 +13,11 @@ import {
   ProofChip,
   RouteTraceOverlay,
 } from "@/components/site/editorial";
-import { robotPolicyEvaluationBoundary } from "@/data/robotPolicyEvaluationClaims";
+import {
+  robotPolicyBeachheadShort,
+  robotPolicyEvaluationBeachhead,
+  robotPolicyEvaluationBoundary,
+} from "@/data/robotPolicyEvaluationClaims";
 import { ArrowRight } from "lucide-react";
 
 const requestHref =
@@ -54,13 +58,13 @@ const steps: Array<{ num: string; title: string; body: string }> = [
   },
   {
     num: "04",
-    title: "Improve against failures",
-    body: "A Policy Improvement Run turns failure clusters into scenarios, curriculum, and a sealed regression pack; an improved policy artifact requires an approved trainable path.",
+    title: "Later — improve against failures",
+    body: "Follow-on, after the ranking: an optional Policy Improvement Run can turn failure clusters into scenarios, curriculum, and a sealed regression pack; an improved policy artifact requires an approved trainable path. Secondary to the run itself.",
   },
   {
     num: "05",
     title: "Decide the next test",
-    body: "Use the ranking, failure clusters, and missing-proof labels to pilot, tune, recapture, or hold.",
+    body: "Use the ranking, failure clusters, and missing-proof labels to pilot, tune, recapture, or hold. Any follow-on Post-Training Data Package export built from the same evidence is a secondary, optional aside — the ranking in step 03 is the product.",
   },
 ];
 
@@ -76,17 +80,19 @@ const comparisonStack: Array<{
   { label: "Checkpoint v2", value: 0.38, rank: "4" },
 ];
 
+// Lead with the warehouse/logistics beachhead — navigation, mobile-base movement,
+// and rigid pick-and-place. Dexterous, contact-rich tiles are demoted to the end;
+// the two most dexterous (dishwasher, laundry-folding) are dropped as out of scope.
 const povClips: Array<{ id: string; alt: string; span?: string }> = [
-  { id: "factory-conveyor", alt: "First-person review clip of a factory conveyor task", span: "sm:col-span-2 sm:row-span-2" },
-  { id: "warehouse-tote", alt: "First-person review clip of a warehouse tote task" },
-  { id: "packing-cell", alt: "First-person review clip of a packing-cell task" },
-  { id: "inspection-bench", alt: "First-person review clip of an inspection-bench task" },
+  { id: "warehouse-tote", alt: "First-person review clip of a warehouse mobile-base tote move", span: "sm:col-span-2 sm:row-span-2" },
+  { id: "loading-dock", alt: "First-person review clip of a loading-dock navigation task", span: "sm:col-span-2" },
+  { id: "cold-storage", alt: "First-person review clip of a cold-storage navigation task" },
+  { id: "retail-backroom", alt: "First-person review clip of a retail-backroom rigid pick task" },
+  { id: "factory-conveyor", alt: "First-person review clip of a factory conveyor rigid pick task" },
+  // Dexterous, contact-rich variants — out of the current beachhead scope, kept last.
   { id: "machine-tending", alt: "First-person review clip of a machine-tending task" },
-  { id: "loading-dock", alt: "First-person review clip of a loading-dock task", span: "sm:col-span-2" },
-  { id: "laundry-folding", alt: "First-person review clip of a laundry-folding task" },
-  { id: "cold-storage", alt: "First-person review clip of a cold-storage task" },
-  { id: "dishwasher", alt: "First-person review clip of a dishwasher task" },
-  { id: "retail-backroom", alt: "First-person review clip of a retail-backroom task" },
+  { id: "inspection-bench", alt: "First-person review clip of an inspection-bench task" },
+  { id: "packing-cell", alt: "First-person review clip of a packing-cell task" },
 ];
 
 export default function Home() {
@@ -147,6 +153,9 @@ export default function Home() {
                       </ProofChip>
                     ))}
                   </div>
+                  <p className="mt-4 max-w-[34rem] font-mono text-[11px] leading-[1.5] text-[#f3efe6]/60">
+                    Beachhead: {robotPolicyBeachheadShort}. {robotPolicyEvaluationBeachhead}
+                  </p>
                   <div className="mt-8 flex flex-col gap-3 sm:flex-row">
                     <Button
                       asChild
@@ -237,14 +246,15 @@ export default function Home() {
         <section className="border-b border-line bg-paper">
           <div className="mx-auto grid max-w-container gap-8 px-7 py-14 lg:grid-cols-[0.62fr_0.38fr] lg:items-center">
             <div>
-              <Eyebrow tone="brass" rule>For capturers</Eyebrow>
+              <Eyebrow tone="brass" rule>For capturers — paid supply</Eyebrow>
               <h2 className="font-editorial mt-5 text-[clamp(2rem,3.8vw,3.4rem)] font-medium leading-[1.02] tracking-[-0.04em] text-ink">
                 Real-site evidence starts with a careful capture.
               </h2>
               <p className="mt-4 max-w-2xl text-base leading-7 text-ink-600">
-                Join the reviewed capture network, follow assignment-specific access and privacy cues,
-                and see payout terms before work begins. Applications and captures remain pending until
-                the owning review record approves them.
+                Secondary to the buyer flow above: this is the paid capture network we recruit to feed
+                the evaluation runs. Join the reviewed capture network, follow assignment-specific access
+                and privacy cues, and see payout terms before work begins. Applications and captures remain
+                pending until the owning review record approves them.
               </p>
             </div>
             <div className="flex flex-col gap-3 sm:flex-row lg:justify-end">

--- a/client/src/pages/HowItWorks.tsx
+++ b/client/src/pages/HowItWorks.tsx
@@ -66,7 +66,7 @@ const pipelineSteps: PipelineStep[] = [
   {
     step: "03",
     badge: "Evaluate",
-    title: "Rank the policies into a shortlist.",
+    title: "Evaluate policies against the site.",
     body: "This is the payload of the run. Robot teams compare policies, checkpoints, and vendor runners on the packaged site, and the run returns a ranked shortlist that says which policy to field-test first. The output is a rank-fidelity comparison with failure clusters and review media — an estimate of relative readiness, never a guarantee of field success, and never a safety certification.",
     src: "/redesign/pov/loading-dock.jpg",
     alt: "Warehouse loading dock staging lane where mobile bases stage and move",
@@ -74,6 +74,32 @@ const pipelineSteps: PipelineStep[] = [
       "Ranked policy shortlist",
       "Failure clusters",
       "Review-support media",
+    ],
+  },
+  {
+    step: "04",
+    badge: "Improve",
+    title: "Turn failures into the next policy loop.",
+    body: "A Policy Improvement Run converts measured failure clusters into prioritized scenarios, curriculum recommendations, and a sealed regression set. An improved policy artifact requires a separately approved trainable interface.",
+    src: "/redesign/pov/inspection-bench.jpg",
+    alt: "Robot policy failure review at an inspection bench",
+    proof: [
+      "Failure priorities",
+      "Curriculum recommendations",
+      "Sealed regression set",
+    ],
+  },
+  {
+    step: "05",
+    badge: "Decide",
+    title: "Decide the next test.",
+    body: "Every run ends in a decision a team can act on: export the data package, request a recapture, narrow the scenario, or move to a field pilot. The proof boundary stays attached so the decision is grounded in what was actually captured.",
+    src: "/redesign/pov/loading-dock.jpg",
+    alt: "Loading dock staging area",
+    proof: [
+      "Export request",
+      "Recapture call",
+      "Next-test record",
     ],
   },
 ];
@@ -213,11 +239,12 @@ export default function HowItWorks() {
               How it works
             </Eyebrow>
             <h1 className="mt-5 font-display text-[clamp(2.6rem,5vw,4.4rem)] font-medium leading-[1.02] tracking-[-0.045em] text-[color:var(--text-on-ink)]">
-              Capture first. Package the proof. Rank the shortlist.
+              Capture first. Package the proof. Decide the next test.
             </h1>
             <p className="mt-5 max-w-[34rem] text-[1.05rem] leading-[1.7] text-[color:var(--text-on-ink)] opacity-80">
-              For robot and foundation-model teams: a site-specific Task Evaluation Run.{" "}
-              {robotPolicyScreeningValue}
+              Blueprint turns one real indoor capture into a versioned, rights-attached
+              package that robot teams can evaluate against — so the next test is a
+              decision, not a guess.
             </p>
             <div className="mt-7 flex flex-wrap gap-2">
               <ProofChip light>Capture-backed</ProofChip>
@@ -232,8 +259,8 @@ export default function HowItWorks() {
       <section className="bg-canvas">
         <div className="mx-auto max-w-[88rem] px-5 py-16 sm:px-8 lg:px-10 lg:py-24">
           <EditorialSectionIntro
-            eyebrow="The Task Evaluation Run"
-            title="From a real site to a ranked shortlist."
+            eyebrow="The pipeline"
+            title="Four steps from real site to a decision."
             description="Blueprint sells robot and foundation-model teams one thing: a site-specific Task Evaluation Run. Capture first, package the proof, then rank your candidate policies — the shortlist is the destination, not a middle step. Nothing is asserted that the capture cannot support."
           />
           <p className="mt-6 max-w-[46rem] text-[15px] leading-[1.7] text-ink-600">
@@ -452,7 +479,7 @@ export default function HowItWorks() {
             imageSrc="/redesign/pov/cold-storage.jpg"
             imageAlt="Cold-storage warehouse aisle where a mobile base navigates and stages totes"
             primaryHref="/contact/robot-team?persona=robot-team&source=how-it-works"
-            primaryLabel="Request an evaluation"
+            primaryLabel="Request evaluation"
             secondaryHref="/pricing"
             secondaryLabel="See pricing"
           />

--- a/client/src/pages/HowItWorks.tsx
+++ b/client/src/pages/HowItWorks.tsx
@@ -14,6 +14,10 @@ import {
 } from "@/components/site/editorial";
 import { TileGrid } from "@/components/site/TileGrid";
 import {
+  robotPolicyEvaluationBeachhead,
+  robotPolicyScreeningValue,
+} from "@/data/robotPolicyEvaluationClaims";
+import {
   Boxes,
   ClipboardList,
   FileCheck2,
@@ -62,40 +66,14 @@ const pipelineSteps: PipelineStep[] = [
   {
     step: "03",
     badge: "Evaluate",
-    title: "Evaluate policies against the site.",
-    body: "Robot teams compare policies, checkpoints, and vendor runners on the packaged site. The output is a rank-fidelity comparison with failure clusters and review media — an estimate of relative readiness, never a guarantee of field success.",
-    src: "/redesign/pov/machine-tending.jpg",
-    alt: "Robot arm tending a machine cell",
+    title: "Rank the policies into a shortlist.",
+    body: "This is the payload of the run. Robot teams compare policies, checkpoints, and vendor runners on the packaged site, and the run returns a ranked shortlist that says which policy to field-test first. The output is a rank-fidelity comparison with failure clusters and review media — an estimate of relative readiness, never a guarantee of field success, and never a safety certification.",
+    src: "/redesign/pov/loading-dock.jpg",
+    alt: "Warehouse loading dock staging lane where mobile bases stage and move",
     proof: [
-      "Policy rank comparison",
+      "Ranked policy shortlist",
       "Failure clusters",
       "Review-support media",
-    ],
-  },
-  {
-    step: "04",
-    badge: "Improve",
-    title: "Turn failures into the next policy loop.",
-    body: "A Policy Improvement Run converts measured failure clusters into prioritized scenarios, curriculum recommendations, and a sealed regression set. An improved policy artifact requires a separately approved trainable interface.",
-    src: "/redesign/pov/inspection-bench.jpg",
-    alt: "Robot policy failure review at an inspection bench",
-    proof: [
-      "Failure priorities",
-      "Curriculum recommendations",
-      "Sealed regression set",
-    ],
-  },
-  {
-    step: "05",
-    badge: "Decide",
-    title: "Decide the next test.",
-    body: "Every run ends in a decision a team can act on: export the data package, request a recapture, narrow the scenario, or move to a field pilot. The proof boundary stays attached so the decision is grounded in what was actually captured.",
-    src: "/redesign/pov/loading-dock.jpg",
-    alt: "Loading dock staging area",
-    proof: [
-      "Export request",
-      "Recapture call",
-      "Next-test record",
     ],
   },
 ];
@@ -110,21 +88,9 @@ type VocabularyTile = {
 const vocabulary: VocabularyTile[] = [
   {
     eyebrow: "Package object",
-    term: "Site Card",
-    mono: "site_card",
-    body: "The facility itself — route context, geometry where available, and the access conditions that define the environment.",
-  },
-  {
-    eyebrow: "Package object",
     term: "Task Card",
     mono: "task_card",
     body: "A single job to evaluate on the site, with the start state, success condition, and constraints made explicit.",
-  },
-  {
-    eyebrow: "Package object",
-    term: "Scenario Card",
-    mono: "scenario_card",
-    body: "A parameterized variation of a task — clutter, lighting, or starting pose — used to probe robustness across conditions.",
   },
   {
     eyebrow: "Package object",
@@ -134,15 +100,15 @@ const vocabulary: VocabularyTile[] = [
   },
   {
     eyebrow: "Trust artifact",
-    term: "Rights packet",
-    mono: "rights_packet",
-    body: "The use-scope, consent, and commercialization terms attached to the capture and carried into every export.",
-  },
-  {
-    eyebrow: "Trust artifact",
     term: "Provenance record",
     mono: "provenance_record",
     body: "The chain of custody — capturer, device, timestamps, and processing steps — proving where each value came from.",
+  },
+  {
+    eyebrow: "Trust artifact",
+    term: "Rights packet",
+    mono: "rights_packet",
+    body: "The use-scope, consent, and commercialization terms attached to the capture and carried into every export.",
   },
 ];
 
@@ -178,7 +144,7 @@ const truthHierarchy: TruthRow[] = [
     tone: "warn",
     chip: "Advisory",
     accent: "#9a6a16",
-    body: "Simulated rollouts run before field time. Useful for ranking and triage, but an estimate of relative readiness — not a measurement of how the policy behaves on the floor.",
+    body: "Simulated rollouts run before field time. Useful for ranking and triage, but an estimate of relative readiness — never a guarantee or safety certification — not a measurement of how the policy behaves on the floor.",
   },
   {
     num: "04",
@@ -193,32 +159,19 @@ const truthHierarchy: TruthRow[] = [
 const surfaceTiles = [
   {
     eyebrow: "Surface",
-    label: "Capture",
-    description:
-      "The SwiftUI capture app vetted capturers use to record the route, with live coverage and provenance cues.",
-    href: "/capture",
-  },
-  {
-    eyebrow: "Surface",
     label: "Buyer app",
     description:
-      "Where robot teams configure runs per site, compare policies, and export data packages inside their access scope.",
+      "Where robot teams configure a Task Evaluation Run per site, rank policies into a shortlist, and export a data package inside their access scope.",
     href: "/for-robot-teams",
   },
-  {
-    eyebrow: "Surface",
-    label: "Ops console",
-    description:
-      "Internal queue, evidence review, and proof-safe buyer handoff — keeping rights and coverage visible end to end.",
-    href: "/contact",
-  },
-  {
-    eyebrow: "Surface",
-    label: "Public listings",
-    description:
-      "Current Pipeline-backed site records that buyers can inspect without implying fictional supply.",
-    href: "/sites",
-  },
+];
+
+// Secondary, follow-on surfaces — supply and ops paths that support the run but
+// are not co-equal product front doors.
+const secondarySurfaces = [
+  { label: "Capture app", href: "/capture" },
+  { label: "Ops console", href: "/contact" },
+  { label: "Public listings", href: "/sites" },
 ];
 
 export default function HowItWorks() {
@@ -260,12 +213,11 @@ export default function HowItWorks() {
               How it works
             </Eyebrow>
             <h1 className="mt-5 font-display text-[clamp(2.6rem,5vw,4.4rem)] font-medium leading-[1.02] tracking-[-0.045em] text-[color:var(--text-on-ink)]">
-              Capture first. Package the proof. Decide the next test.
+              Capture first. Package the proof. Rank the shortlist.
             </h1>
             <p className="mt-5 max-w-[34rem] text-[1.05rem] leading-[1.7] text-[color:var(--text-on-ink)] opacity-80">
-              Blueprint turns one real indoor capture into a versioned, rights-attached
-              package that robot teams can evaluate against — so the next test is a
-              decision, not a guess.
+              For robot and foundation-model teams: a site-specific Task Evaluation Run.{" "}
+              {robotPolicyScreeningValue}
             </p>
             <div className="mt-7 flex flex-wrap gap-2">
               <ProofChip light>Capture-backed</ProofChip>
@@ -280,10 +232,17 @@ export default function HowItWorks() {
       <section className="bg-canvas">
         <div className="mx-auto max-w-[88rem] px-5 py-16 sm:px-8 lg:px-10 lg:py-24">
           <EditorialSectionIntro
-            eyebrow="The pipeline"
-            title="Four steps from real site to a decision."
-            description="Each step produces an artifact the next one depends on. Nothing is asserted that the capture cannot support."
+            eyebrow="The Task Evaluation Run"
+            title="From a real site to a ranked shortlist."
+            description="Blueprint sells robot and foundation-model teams one thing: a site-specific Task Evaluation Run. Capture first, package the proof, then rank your candidate policies — the shortlist is the destination, not a middle step. Nothing is asserted that the capture cannot support."
           />
+          <p className="mt-6 max-w-[46rem] text-[15px] leading-[1.7] text-ink-600">
+            {robotPolicyScreeningValue}
+          </p>
+          <p className="mt-3 max-w-[46rem] rounded-sm border border-line bg-inset px-4 py-3 text-[14px] leading-[1.65] text-ink-600">
+            <span className="font-semibold text-ink-900">Where the evidence is strongest today. </span>
+            {robotPolicyEvaluationBeachhead}
+          </p>
 
           <div className="mt-12 flex flex-col gap-px overflow-hidden rounded-md border border-line bg-[#ded7c8]">
             {pipelineSteps.map((stage) => (
@@ -335,6 +294,21 @@ export default function HowItWorks() {
               </article>
             ))}
           </div>
+
+          <div className="mt-6 rounded-md border border-line bg-paper p-6 lg:p-8">
+            <Eyebrow tone="muted">After the run (later)</Eyebrow>
+            <p className="mt-3 max-w-[52rem] text-[14px] leading-[1.7] text-ink-500">
+              The ranked shortlist is where the run ends. Everything past it is a
+              secondary, follow-on path a team can opt into later — never the reason to
+              start. You can export the ranked comparison as a data package, request a
+              recapture, narrow the scenario, or move to a field pilot; the proof boundary
+              stays attached so any next step is grounded in what was actually captured.
+              A <span className="font-medium text-ink-600">Policy Improvement Run</span> is
+              an even-later add-on that turns measured failure clusters into prioritized
+              scenarios, curriculum recommendations, and a sealed regression set — and an
+              improved policy artifact requires a separately approved trainable interface.
+            </p>
+          </div>
         </div>
       </section>
 
@@ -347,7 +321,7 @@ export default function HowItWorks() {
             description="Every Blueprint package is assembled from the same named parts. The mono identifiers are how each object is referenced across the app, the API, and the manifest."
           />
 
-          <TileGrid cols={3} className="mt-12">
+          <TileGrid cols={4} className="mt-12">
             {vocabulary.map((item) => {
               const Icon =
                 item.mono === "site_card"
@@ -447,11 +421,24 @@ export default function HowItWorks() {
       <section className="border-y border-line bg-paper">
         <div className="mx-auto max-w-[88rem] px-5 py-16 sm:px-8 lg:px-10 lg:py-24">
           <EditorialSectionIntro
-            eyebrow="Four surfaces"
-            title="One pipeline, four places it shows up."
-            description="The same capture-first truth chain runs across every surface — from the capturer's phone to the public listing."
+            eyebrow="The buyer surface"
+            title="Where robot teams run the evaluation."
+            description="The Buyer app is the front door for robot and foundation-model teams — the one place the Task Evaluation Run is configured, ranked, and exported."
           />
-          <TileGrid cols={4} items={surfaceTiles} className="mt-12" />
+          <TileGrid cols={1} items={surfaceTiles} className="mt-12" />
+          <p className="mt-6 max-w-[52rem] text-[14px] leading-[1.65] text-ink-500">
+            <span className="font-semibold text-ink-600">Supporting surfaces (secondary). </span>
+            The capture-first truth chain also runs across the paid-supply and ops paths —{" "}
+            {secondarySurfaces.map((surface, index) => (
+              <span key={surface.href}>
+                <a href={surface.href} className="underline decoration-line underline-offset-2 hover:text-ink-700">
+                  {surface.label}
+                </a>
+                {index < secondarySurfaces.length - 1 ? ", " : ""}
+              </span>
+            ))}
+            {" "}— but these support the run rather than serve as co-equal product front doors.
+          </p>
         </div>
       </section>
 
@@ -459,15 +446,15 @@ export default function HowItWorks() {
       <section className="bg-canvas">
         <div className="mx-auto max-w-[88rem] px-5 pb-20 sm:px-8 lg:px-10 lg:pb-28">
           <EditorialCtaBand
-            eyebrow="See it on a real site"
-            title="Scope the package before you commit field time."
-            description="Review the package structure, pricing, and proof boundary — then request an evaluation against a Pipeline-backed site record or your own capture scope."
-            imageSrc="/redesign/pov/inspection-bench.jpg"
-            imageAlt="Inspection bench workstation"
-            primaryHref="/pricing"
-            primaryLabel="See pricing"
-            secondaryHref="/contact/robot-team?persona=robot-team&source=how-it-works"
-            secondaryLabel="Request evaluation"
+            eyebrow="For robot & foundation-model teams"
+            title="Rank your policies before you spend field time."
+            description="Bring your candidate policies and a target site. A Task Evaluation Run returns a ranked shortlist — cheap screening that tells you which policy earns a pilot slot first, so scarce robot and field time goes to the strongest. An estimate and decision-support screen, never a guarantee or safety certification."
+            imageSrc="/redesign/pov/cold-storage.jpg"
+            imageAlt="Cold-storage warehouse aisle where a mobile base navigates and stages totes"
+            primaryHref="/contact/robot-team?persona=robot-team&source=how-it-works"
+            primaryLabel="Request an evaluation"
+            secondaryHref="/pricing"
+            secondaryLabel="See pricing"
           />
         </div>
       </section>

--- a/client/src/pages/Pricing.tsx
+++ b/client/src/pages/Pricing.tsx
@@ -216,7 +216,7 @@ export default function Pricing() {
               Pricing
             </Eyebrow>
             <h1 className="mt-5 font-display text-[clamp(2.6rem,5vw,4.4rem)] font-medium leading-[1.02] tracking-[-0.045em] text-ink-900">
-              Price the run that screens what earns pilot time.
+              Priced as evaluation infrastructure.
             </h1>
             <p className="mt-5 max-w-[34rem] text-[1.05rem] leading-[1.7] text-ink-500">
               {robotPolicyScreeningValue}
@@ -541,8 +541,8 @@ export default function Pricing() {
             imageAlt="Warehouse loading dock — mobile-base navigation and rigid tote handling"
             primaryHref="/contact/robot-team?persona=robot-team&interest=policy-evaluation-run&source=pricing"
             primaryLabel="Request evaluation"
-            secondaryHref="/proof"
-            secondaryLabel="See the proof boundary"
+            secondaryHref="/sites"
+            secondaryLabel="Browse site records"
           />
         </div>
       </section>

--- a/client/src/pages/Pricing.tsx
+++ b/client/src/pages/Pricing.tsx
@@ -14,6 +14,10 @@ import {
   ProofChip,
 } from "@/components/site/editorial";
 import { TileGrid } from "@/components/site/TileGrid";
+import {
+  robotPolicyScreeningValue,
+  robotPolicyEvaluationBeachhead,
+} from "@/data/robotPolicyEvaluationClaims";
 import { ArrowRight, Check } from "lucide-react";
 
 type Tier = {
@@ -28,12 +32,15 @@ type Tier = {
   highlighted?: boolean;
 };
 
-const tiers: Tier[] = [
+// The primary front door: one service, two ways to buy it. Quick-look is the
+// lead first-purchase (cheap pre-pilot screening); the subscription is the
+// secondary scale-up once ranking is part of the development loop.
+const primaryTiers: Tier[] = [
   {
     name: "Quick-look eval",
     price: "$5–8k",
     unit: "/ eval",
-    tagline: "A low-friction first comparison before any subscription decision.",
+    tagline: "The first-purchase screen: rank a couple of policies on one captured site before you spend any field or pilot time.",
     features: [
       "Up to 100 episodes on one packaged site",
       "1–2 policies or checkpoints",
@@ -43,12 +50,13 @@ const tiers: Tier[] = [
     note: "Failure taxonomy and calibration stay in subscription scope.",
     cta: "Request a quick-look",
     href: "/contact/robot-team?persona=robot-team&buyerType=robot_team&interest=policy-evaluation-run&requestedOutputs=Quick-Look%20Eval&episodeCount=100&source=pricing",
+    highlighted: true,
   },
   {
     name: "Robot-team subscription",
     price: "$15k",
     unit: "/ mo",
-    tagline: "Recurring comparison infrastructure for active policy development.",
+    tagline: "The scale-up: recurring comparison infrastructure once ranking policies is part of the development loop.",
     features: [
       "Compare team, checkpoint, and vendor policies",
       "Unlimited eval cycles up to policy cap",
@@ -59,23 +67,29 @@ const tiers: Tier[] = [
     note: "Overage pricing applies above the agreed policy cap.",
     cta: "Start a subscription",
     href: "/contact/robot-team?persona=robot-team&buyerType=robot_team&interest=policy-evaluation-run&requestedOutputs=Robot%20Team%20Subscription&source=pricing",
-    highlighted: true,
   },
-  {
-    name: "Policy Improvement Run",
-    price: "Scoped",
-    unit: "/ run",
-    tagline: "Turn measured evaluation failures into the next policy-development loop.",
-    features: [
-      "Prioritized failure clusters and scenario design",
-      "Curriculum recommendations and sealed regression set",
-      "Source-code access is optional for analysis outputs",
-      "Improved policy artifact only with an approved trainable path",
-    ],
-    note: "Price and deliverables depend on the policy interface, evidence, and training authority in scope.",
-    cta: "Scope improvement",
-    href: "/contact/robot-team?persona=robot-team&interest=policy-improvement-run&requestedOutputs=Policy%20Improvement%20Run&source=pricing",
-  },
+];
+
+// Follow-on, on request — not part of the first-purchase decision.
+const policyImprovementRun: Tier = {
+  name: "Policy Improvement Run",
+  price: "Scoped",
+  unit: "/ run",
+  tagline: "Turn measured evaluation failures into the next policy-development loop.",
+  features: [
+    "Prioritized failure clusters and scenario design",
+    "Curriculum recommendations and sealed regression set",
+    "Source-code access is optional for analysis outputs",
+    "Improved policy artifact only with an approved trainable path",
+  ],
+  note: "Price and deliverables depend on the policy interface, evidence, and training authority in scope.",
+  cta: "Scope improvement",
+  href: "/contact/robot-team?persona=robot-team&interest=policy-improvement-run&requestedOutputs=Policy%20Improvement%20Run&source=pricing",
+};
+
+// Secondary supply-side / access-partner path for lighthouse operators — kept
+// present, but not a co-equal product tier for robot teams.
+const operatorTiers: Tier[] = [
   {
     name: "Site supply",
     price: "$5k",
@@ -112,6 +126,7 @@ type AddOn = {
   name: string;
   meter: string;
   body: string;
+  stage?: string;
 };
 
 const addOns: AddOn[] = [
@@ -134,14 +149,15 @@ const addOns: AddOn[] = [
     name: "Provenance-checked data package",
     meter: "per_export · +$3k",
     body: "An export-ready data package with provenance, rights packet, and coverage flags attached, scoped to your access window.",
+    stage: "Second product, later",
   },
 ];
 
 const faqItems = [
   {
-    question: "Why is the subscription the primary tier?",
+    question: "Which tier should we start with?",
     answer:
-      "Most value shows up when comparing policies is part of the development loop, not a one-off. Quick-look evals and single-site reviews exist as the ramp into the subscription, where regression tracking and failure taxonomy live.",
+      "Start with a quick-look eval — the cheap pre-pilot screen that ranks your policies on one captured site before you spend field time. The robot-team subscription is the scale-up for teams comparing policies continuously, where regression tracking and failure taxonomy live.",
   },
   {
     question: "What exactly am I paying for in an eval?",
@@ -175,14 +191,14 @@ export default function Pricing() {
     <>
       <SEO
         title="Pricing | Blueprint"
-        description="Priced as evaluation infrastructure: quick-look evals, a robot-team subscription, site supply reviews, and yearly site monitoring — bounded to the reviewed site, task, and access scope."
+        description="Pricing for the Task Evaluation Run: rank your robot policies on a captured real-site task envelope before you spend field or pilot time. Buy it as a quick-look eval or a robot-team subscription — bounded to the reviewed site, task, and access scope."
         canonical="/pricing"
         jsonLd={[
           webPageJsonLd({
             path: "/pricing",
             name: "Blueprint Pricing",
             description:
-              "Planning ranges for robot-team evaluation subscriptions, lite quick-look evals, operator site supply reviews, and yearly deployed-site monitoring.",
+              "Planning ranges for the robot-team Task Evaluation Run — a quick-look eval or a subscription that ranks policies on a captured real-site task envelope. Follow-on paths (policy improvement, operator site supply and monitoring) are secondary.",
           }),
           breadcrumbJsonLd([
             { name: "Home", path: "/" },
@@ -200,13 +216,14 @@ export default function Pricing() {
               Pricing
             </Eyebrow>
             <h1 className="mt-5 font-display text-[clamp(2.6rem,5vw,4.4rem)] font-medium leading-[1.02] tracking-[-0.045em] text-ink-900">
-              Priced as evaluation infrastructure.
+              Price the run that screens what earns pilot time.
             </h1>
             <p className="mt-5 max-w-[34rem] text-[1.05rem] leading-[1.7] text-ink-500">
-              Robot teams subscribe when comparing policies becomes part of the
-              development loop. Quick-look evals and single-site reviews are the ramp in.
-              Operators start with a supply review and add monitoring only when a site
-              needs repeated checks.
+              {robotPolicyScreeningValue}
+            </p>
+            <p className="mt-4 max-w-[34rem] text-[0.95rem] leading-[1.65] text-ink-400">
+              {robotPolicyEvaluationBeachhead} You are buying rank fidelity inside that
+              scope — never a guarantee or safety certification.
             </p>
             <div className="mt-7 flex flex-wrap gap-2">
               <ProofChip>Capture-backed comparisons</ProofChip>
@@ -229,13 +246,13 @@ export default function Pricing() {
       <section className="border-y border-line bg-paper">
         <div className="mx-auto max-w-[88rem] px-5 py-16 sm:px-8 lg:px-10 lg:py-24">
           <EditorialSectionIntro
-            eyebrow="Tiers"
-            title="Four ways to engage."
-            description="One subscription for active robot teams, plus lighter on-ramps and the operator supply path. All figures are illustrative ranges, set per engagement."
+            eyebrow="How teams buy an evaluation run"
+            title="One service, two ways to buy it."
+            description="Start with a quick-look eval as your first purchase, then move to a subscription when ranking policies becomes part of the development loop. All figures are illustrative ranges, set per engagement."
           />
 
-          <TileGrid cols={3} className="mt-12 rounded-lg">
-            {tiers.map((tier) => {
+          <TileGrid cols={2} className="mt-12 rounded-lg">
+            {primaryTiers.map((tier) => {
               const onInk = tier.highlighted;
               return (
                 <article
@@ -349,6 +366,30 @@ export default function Pricing() {
               );
             })}
           </TileGrid>
+
+          {/* Follow-on, on request — demoted out of the primary grid */}
+          <div className="mt-8 flex flex-col gap-3 border border-line bg-inset p-6 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <div className="flex flex-wrap items-center gap-3">
+                <Eyebrow tone="muted">Later / on request</Eyebrow>
+                <span className="font-mono text-[12px] uppercase tracking-[0.08em] text-ink-500">
+                  {policyImprovementRun.price} {policyImprovementRun.unit}
+                </span>
+              </div>
+              <h3 className="mt-2 text-title-s font-semibold tracking-tight text-ink-900">
+                {policyImprovementRun.name}
+              </h3>
+              <p className="mt-1 max-w-[42rem] text-sm leading-[1.6] text-ink-500">
+                {policyImprovementRun.tagline} {policyImprovementRun.note}
+              </p>
+            </div>
+            <Button asChild variant="secondary" size="md">
+              <a href={policyImprovementRun.href}>
+                {policyImprovementRun.cta}
+                <ArrowRight className="h-4 w-4" aria-hidden="true" />
+              </a>
+            </Button>
+          </div>
         </div>
       </section>
 
@@ -376,6 +417,11 @@ export default function Pricing() {
                     {addOn.meter}
                   </span>
                 </div>
+                {addOn.stage ? (
+                  <span className="inline-flex w-fit items-center border border-brass/50 bg-transparent px-[0.6rem] py-1 font-mono text-[11px] uppercase tracking-[0.08em] text-brass">
+                    {addOn.stage}
+                  </span>
+                ) : null}
                 <p className="text-sm leading-[1.65] text-ink-500">{addOn.body}</p>
               </div>
             ))}
@@ -401,6 +447,78 @@ export default function Pricing() {
         </div>
       </section>
 
+      {/* Operator / access partnership — secondary supply-side path */}
+      <section className="bg-canvas">
+        <div className="mx-auto max-w-[88rem] px-5 pb-8 sm:px-8 lg:px-10 lg:pb-12">
+          <EditorialSectionIntro
+            eyebrow="Operator / access partnership"
+            title="Have a site instead of a policy?"
+            description="A separate, secondary path for lighthouse operators who can make a useful site available. This is paid supply and access partnership — not a co-equal product tier for robot teams, and it opens only after a facility, access, and privacy review."
+          />
+
+          <TileGrid cols={2} className="mt-10">
+            {operatorTiers.map((tier) => (
+              <article
+                key={tier.name}
+                className="flex h-full flex-col bg-white p-6"
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <Eyebrow tone="muted">Access partner</Eyebrow>
+                  <StatusChip tone="neutral" square dot={false}>
+                    Secondary
+                  </StatusChip>
+                </div>
+
+                <h3 className="mt-5 text-title-m font-semibold tracking-tight text-ink-900">
+                  {tier.name}
+                </h3>
+
+                <div className="mt-4 flex items-baseline gap-1">
+                  <span className="font-mono text-[2rem] font-medium leading-none tracking-[-0.02em] text-ink-900">
+                    {tier.price}
+                  </span>
+                  <span className="font-mono text-[0.9rem] text-ink-400">
+                    {tier.unit}
+                  </span>
+                </div>
+
+                <p className="mt-4 text-sm leading-[1.6] text-ink-500">
+                  {tier.tagline}
+                </p>
+
+                <ul className="mt-5 flex flex-col gap-2.5">
+                  {tier.features.map((feature) => (
+                    <li key={feature} className="flex items-start gap-2.5">
+                      <Check
+                        className="mt-0.5 h-4 w-4 shrink-0 text-brass"
+                        strokeWidth={2}
+                        aria-hidden="true"
+                      />
+                      <span className="text-[13px] leading-[1.5] text-ink-700">
+                        {feature}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+
+                <p className="mt-5 border-t border-line-soft pt-4 text-[12px] leading-[1.5] text-ink-400">
+                  {tier.note}
+                </p>
+
+                <div className="mt-auto pt-6">
+                  <Button asChild variant="secondary" size="md" full>
+                    <a href={tier.href}>
+                      {tier.cta}
+                      <ArrowRight className="h-4 w-4" aria-hidden="true" />
+                    </a>
+                  </Button>
+                </div>
+              </article>
+            ))}
+          </TileGrid>
+        </div>
+      </section>
+
       {/* FAQ */}
       <section className="border-y border-line bg-paper">
         <div className="mx-auto max-w-[88rem] px-5 py-16 sm:px-8 lg:px-10 lg:py-24">
@@ -419,12 +537,12 @@ export default function Pricing() {
             eyebrow="Pick your on-ramp"
             title="Start with a quick-look or scope a subscription."
             description="Tell us the site, task, and policies you want to compare. We'll come back with episode counts, a policy cap, and pricing for your scope."
-            imageSrc="/redesign/pov/packing-cell.jpg"
-            imageAlt="Robotic packing cell"
+            imageSrc="/redesign/pov/loading-dock.jpg"
+            imageAlt="Warehouse loading dock — mobile-base navigation and rigid tote handling"
             primaryHref="/contact/robot-team?persona=robot-team&interest=policy-evaluation-run&source=pricing"
             primaryLabel="Request evaluation"
-            secondaryHref="/sites"
-            secondaryLabel="Browse site records"
+            secondaryHref="/proof"
+            secondaryLabel="See the proof boundary"
           />
         </div>
       </section>

--- a/client/src/pages/Proof.tsx
+++ b/client/src/pages/Proof.tsx
@@ -1,7 +1,9 @@
 import { SEO } from "@/components/SEO";
 import {
+  robotPolicyEvaluationBeachhead,
   robotPolicyEvaluationBoundary,
   robotPolicyResearchSignals,
+  robotPolicyScreeningValue,
 } from "@/data/robotPolicyEvaluationClaims";
 import { wamPolicyEvalAssets } from "@/lib/editorialGeneratedAssets";
 import {
@@ -15,9 +17,9 @@ const requestHref =
   "/contact/robot-team?persona=robot-team&buyerType=robot_team&interest=policy-evaluation-run&path=policy-evaluation-run&source=proof";
 
 const proofLayers = [
-  ["Research signal", "Generated-observation review can support policy comparisons."],
-  ["Request packet", "Scopes one site, task, robot, policy set, and threshold."],
+  ["Captured real-site envelope", "Scopes one captured site, task, robot, policy set, and threshold — the capture-backed evidence a run ranks against."],
   ["Owner proof", "Adds simulator traces, action logs, or real rollouts when needed."],
+  ["Research signal", "A secondary, follow-on support layer: generated-observation review can back policy comparisons."],
 ];
 
 export default function Proof() {
@@ -58,10 +60,16 @@ export default function Proof() {
         <section className="border-b border-slate-200">
           <div className="mx-auto grid max-w-[88rem] gap-10 px-5 py-12 md:grid-cols-[0.78fr_1.22fr] md:items-center md:px-8 md:py-16">
             <div>
-              <h1 className="max-w-[10ch] text-5xl font-semibold leading-[0.95] tracking-normal sm:text-6xl">
-                Proof stays scoped.
+              <p className="text-xs font-semibold uppercase tracking-[0.14em] text-blue-700">
+                {robotPolicyEvaluationBeachhead}
+              </p>
+              <h1 className="mt-4 max-w-[16ch] text-5xl font-semibold leading-[0.95] tracking-normal sm:text-6xl">
+                Proof for the decision.
               </h1>
               <p className="mt-5 max-w-md text-lg leading-8 text-slate-600">
+                {robotPolicyScreeningValue}
+              </p>
+              <p className="mt-4 max-w-md text-sm leading-7 text-slate-500">
                 SC3-Eval's published 0.929 correlation is third-party research
                 context, not a Blueprint result, accuracy claim, or deployment claim.
               </p>
@@ -75,7 +83,7 @@ export default function Proof() {
             </div>
             <img
               src={wamPolicyEvalAssets.rolloutStrip}
-              alt="Generated rollout support frames for a humanoid robot task"
+              alt="Generated preview / review support: rollout frames of a mobile robot navigating a warehouse aisle and making a rigid tote pick"
               className="aspect-[16/6] w-full rounded-lg border border-slate-200 object-cover"
             />
           </div>
@@ -126,6 +134,10 @@ export default function Proof() {
               <p className="mt-4 max-w-4xl text-sm leading-7 text-slate-300">
                 {robotPolicyEvaluationBoundary} Provenance-checked packs report metrics
                 only inside the matched robot, task, and site envelope.
+              </p>
+              <p className="mt-4 max-w-4xl text-sm font-semibold leading-7 text-slate-200">
+                A Task Evaluation Run returns a ranking / estimate — not a guarantee or
+                safety certification.
               </p>
             </div>
           </div>

--- a/client/src/pages/Proof.tsx
+++ b/client/src/pages/Proof.tsx
@@ -17,7 +17,7 @@ const requestHref =
   "/contact/robot-team?persona=robot-team&buyerType=robot_team&interest=policy-evaluation-run&path=policy-evaluation-run&source=proof";
 
 const proofLayers = [
-  ["Captured real-site envelope", "Scopes one captured site, task, robot, policy set, and threshold — the capture-backed evidence a run ranks against."],
+  ["Request packet", "Scopes one site, task, robot, policy set, and threshold."],
   ["Owner proof", "Adds simulator traces, action logs, or real rollouts when needed."],
   ["Research signal", "A secondary, follow-on support layer: generated-observation review can back policy comparisons."],
 ];
@@ -64,7 +64,7 @@ export default function Proof() {
                 {robotPolicyEvaluationBeachhead}
               </p>
               <h1 className="mt-4 max-w-[16ch] text-5xl font-semibold leading-[0.95] tracking-normal sm:text-6xl">
-                Proof for the decision.
+                Proof stays scoped.
               </h1>
               <p className="mt-5 max-w-md text-lg leading-8 text-slate-600">
                 {robotPolicyScreeningValue}

--- a/client/src/pages/RobotTeamEval.tsx
+++ b/client/src/pages/RobotTeamEval.tsx
@@ -61,6 +61,7 @@ const steps = [
   ["2", "Add policies"],
   ["3", "Tell us robot"],
   ["4", "Choose episodes"],
+  ["5", "Protect IP"],
 ];
 
 const privateHardwareRows = [
@@ -430,8 +431,8 @@ export default function RobotTeamEval() {
               <p className="mt-5 max-w-md text-lg leading-8 text-slate-600">
                 {robotPolicyScreeningValue} Rank your own checkpoints, another
                 internal team, or a vendor policy inside the same captured task
-                envelope — guiding field-time decisions without claiming
-                real-world accuracy.
+                envelope — an estimate to guide field-time decisions, not a
+                guarantee of field outcomes.
               </p>
               <p className="mt-4 max-w-md text-xs font-semibold uppercase tracking-[0.14em] text-blue-700">
                 Scope today: {robotPolicyBeachheadShort}
@@ -720,14 +721,55 @@ export default function RobotTeamEval() {
                 </select>
               </label>
 
-            </div>
+              <label className="grid gap-2 text-sm font-semibold">
+                5 Choose the evaluation protocol
+                <select
+                  value={evaluationProtocol}
+                  onChange={(event) =>
+                    setEvaluationProtocol(
+                      event.target.value as "benchmark_grade" | "standard",
+                    )
+                  }
+                  className="min-h-12 w-full min-w-0 max-w-full rounded-lg border border-slate-300 bg-white px-3 text-sm font-normal"
+                >
+                  <option value="benchmark_grade">Benchmark grade</option>
+                  <option value="standard">Standard evaluation</option>
+                </select>
+              </label>
 
-            <p className="mt-4 text-sm leading-6 text-slate-600">
-              This defaults to one comparative ranking run on a single site.
-              Evaluation protocol, validation mode, and hardware/site-IP
-              integration are tucked under Advanced details — leave them as-is
-              for the standard screening run.
-            </p>
+              <label className="grid gap-2 text-sm font-semibold md:col-span-2">
+                6 Protect hardware and site IP
+                <select
+                  value={hardwareIntegrationMode}
+                  onChange={(event) => {
+                    const nextMode = event.target
+                      .value as RobotTeamTestSubmissionHardwareIntegrationMode;
+                    setHardwareIntegrationMode(nextMode);
+                    if (nextMode === "reference_public_robot") {
+                      setSiteIpProtectionLevel("blueprint_hosted");
+                    } else if (nextMode === "private_asset_hosted_by_blueprint") {
+                      setSiteIpProtectionLevel("blueprint_hosted");
+                    } else if (nextMode === "physical_robot_evidence_bridge") {
+                      setSiteIpProtectionLevel("redacted_anchor_packet");
+                    } else if (nextMode === "customer_hosted_sealed_eval_capsule") {
+                      setSiteIpProtectionLevel("sealed_eval_capsule");
+                    }
+                  }}
+                  className="min-h-12 rounded-lg border border-slate-300 bg-white px-3 text-sm font-normal"
+                >
+                  {ROBOT_TEAM_HARDWARE_INTEGRATION_OPTIONS.map((option) => (
+                    <option key={option.id} value={option.id}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+                <span className="text-xs font-normal leading-5 text-slate-500">
+                  Customer-hosted connectors receive a sealed, least-privilege packet;
+                  raw captures, full scenes, scoring harnesses, and sealed audit seeds
+                  stay withheld by default.
+                </span>
+              </label>
+            </div>
 
             <div className="mt-6">
               <h3 className="text-sm font-semibold">Policy access</h3>
@@ -760,55 +802,6 @@ export default function RobotTeamEval() {
                 Advanced details
               </summary>
               <div className="mt-5 grid gap-4 md:grid-cols-2">
-                <label className="grid gap-2 text-sm font-semibold">
-                  Evaluation protocol
-                  <select
-                    value={evaluationProtocol}
-                    onChange={(event) =>
-                      setEvaluationProtocol(
-                        event.target.value as "benchmark_grade" | "standard",
-                      )
-                    }
-                    className="min-h-11 w-full min-w-0 max-w-full rounded-lg border border-slate-300 bg-white px-3 text-sm font-normal"
-                  >
-                    <option value="benchmark_grade">Benchmark grade</option>
-                    <option value="standard">Standard evaluation</option>
-                  </select>
-                </label>
-
-                <label className="grid gap-2 text-sm font-semibold md:col-span-2">
-                  Protect hardware and site IP
-                  <select
-                    value={hardwareIntegrationMode}
-                    onChange={(event) => {
-                      const nextMode = event.target
-                        .value as RobotTeamTestSubmissionHardwareIntegrationMode;
-                      setHardwareIntegrationMode(nextMode);
-                      if (nextMode === "reference_public_robot") {
-                        setSiteIpProtectionLevel("blueprint_hosted");
-                      } else if (nextMode === "private_asset_hosted_by_blueprint") {
-                        setSiteIpProtectionLevel("blueprint_hosted");
-                      } else if (nextMode === "physical_robot_evidence_bridge") {
-                        setSiteIpProtectionLevel("redacted_anchor_packet");
-                      } else if (nextMode === "customer_hosted_sealed_eval_capsule") {
-                        setSiteIpProtectionLevel("sealed_eval_capsule");
-                      }
-                    }}
-                    className="min-h-11 rounded-lg border border-slate-300 bg-white px-3 text-sm font-normal"
-                  >
-                    {ROBOT_TEAM_HARDWARE_INTEGRATION_OPTIONS.map((option) => (
-                      <option key={option.id} value={option.id}>
-                        {option.label}
-                      </option>
-                    ))}
-                  </select>
-                  <span className="text-xs font-normal leading-5 text-slate-500">
-                    Customer-hosted connectors receive a sealed, least-privilege packet;
-                    raw captures, full scenes, scoring harnesses, and sealed audit seeds
-                    stay withheld by default.
-                  </span>
-                </label>
-
                 {episodeCount === "custom" ? (
                   <label className="grid gap-2 text-sm font-semibold">
                     Custom episode count

--- a/client/src/pages/RobotTeamEval.tsx
+++ b/client/src/pages/RobotTeamEval.tsx
@@ -3,9 +3,13 @@ import type { FormEvent } from "react";
 import { ArrowRight, CheckCircle2, ChevronDown, Loader2 } from "lucide-react";
 import { SEO } from "@/components/SEO";
 import {
+  robotPolicyBeachheadShort,
   robotPolicyComparisonUseCases,
+  robotPolicyEvaluationBeachhead,
   robotPolicyEvaluationBoundary,
   robotPolicyResearchSignals,
+  robotPolicyResearchSignalsNote,
+  robotPolicyScreeningValue,
 } from "@/data/robotPolicyEvaluationClaims";
 import { withCsrfHeader } from "@/lib/csrf";
 import {
@@ -57,7 +61,6 @@ const steps = [
   ["2", "Add policies"],
   ["3", "Tell us robot"],
   ["4", "Choose episodes"],
-  ["5", "Protect IP"],
 ];
 
 const privateHardwareRows = [
@@ -425,9 +428,16 @@ export default function RobotTeamEval() {
                 Compare policies on one site task.
               </h1>
               <p className="mt-5 max-w-md text-lg leading-8 text-slate-600">
-                Rank your own checkpoints, another internal team, or a vendor
-                policy inside the same captured task envelope. The output guides
-                field-time decisions without claiming real-world accuracy.
+                {robotPolicyScreeningValue} Rank your own checkpoints, another
+                internal team, or a vendor policy inside the same captured task
+                envelope — guiding field-time decisions without claiming
+                real-world accuracy.
+              </p>
+              <p className="mt-4 max-w-md text-xs font-semibold uppercase tracking-[0.14em] text-blue-700">
+                Scope today: {robotPolicyBeachheadShort}
+              </p>
+              <p className="mt-2 max-w-md text-xs leading-5 text-slate-500">
+                {robotPolicyEvaluationBeachhead}
               </p>
               <a
                 href="#robot-team-submission"
@@ -439,7 +449,7 @@ export default function RobotTeamEval() {
             </div>
             <img
               src={wamPolicyEvalAssets.siteTask}
-              alt="Realistic humanoid robot loading a dishwasher in a captured site task"
+              alt="Generated preview of a warehouse tote pick-and-place task envelope (review support, not real-world proof)"
               className="aspect-[16/9] w-full rounded-lg border border-slate-200 object-cover"
             />
           </div>
@@ -538,14 +548,20 @@ export default function RobotTeamEval() {
           <div className="mx-auto grid max-w-[88rem] gap-8 px-5 py-10 md:grid-cols-[0.36fr_0.64fr] md:px-8">
             <div>
               <h2 className="text-3xl font-semibold leading-tight">
-                Why comparison matters.
+                Which checkpoint earns field time.
               </h2>
               <p className="mt-4 text-sm leading-7 text-slate-600">
-                Site ops needs a fair way to compare what gets robot time:
-                your latest checkpoint, another team's runner, a vendor
-                submission, or a baseline trace. Blueprint keeps the site,
-                task, robot, episodes, thresholds, and missing-proof labels
-                constant.
+                Your team needs a cheap, fair way to decide which policy earns
+                scarce field and pilot time: your latest checkpoint, an older
+                baseline, another internal team's runner, or a vendor
+                submission. Blueprint keeps the site, task, robot, episodes,
+                thresholds, and missing-proof labels constant so the ranking is
+                comparable.
+              </p>
+              <p className="mt-3 text-xs leading-5 text-slate-500">
+                Later, for site operators: the same held-constant run can double
+                as one shared evidence packet for a vendor bake-off — a
+                follow-on use, not the front door here.
               </p>
             </div>
             <MobileDisclosureGrid
@@ -573,6 +589,9 @@ export default function RobotTeamEval() {
                 The public claim is that policy-evaluation worlds are becoming
                 useful ranking and diagnosis tools. It is not that Blueprint
                 can promise a percentage-point policy-ranking outcome.
+              </p>
+              <p className="mt-3 text-xs leading-5 text-slate-500">
+                {robotPolicyResearchSignalsNote}
               </p>
             </div>
             <MobileDisclosureGrid
@@ -604,9 +623,14 @@ export default function RobotTeamEval() {
           >
             <h2 className="text-3xl font-semibold">Start with the essentials.</h2>
             <p className="mt-2 text-sm leading-6 text-slate-600">
-              Add the minimum now. We will recommend subscription scope,
-              quick-look scope, or a single-site comparison based on your task,
-              policy cadence, and site-operator decision path.
+              Add the minimum now and we scope one cheap comparative screening
+              run — a single-site ranking of your candidate policies before you
+              spend field time.
+            </p>
+            <p className="mt-2 text-xs leading-5 text-slate-500">
+              Later: if you run policies on a cadence, you can expand to a
+              subscription. Quick-look scope stays available on request — both
+              are follow-ons to the first screening run, not the starting point.
             </p>
 
             <div className="mt-6 grid gap-4 md:grid-cols-2">
@@ -675,7 +699,7 @@ export default function RobotTeamEval() {
                   value={robotEmbodiment}
                   onChange={(event) => setRobotEmbodiment(event.target.value)}
                   className="min-h-12 rounded-lg border border-slate-300 px-3 text-sm font-normal"
-                  placeholder="Figure 03 humanoid"
+                  placeholder="mobile-base pick robot (AMR + tote picker)"
                 />
               </label>
 
@@ -696,55 +720,14 @@ export default function RobotTeamEval() {
                 </select>
               </label>
 
-              <label className="grid gap-2 text-sm font-semibold">
-                5 Choose the evaluation protocol
-                <select
-                  value={evaluationProtocol}
-                  onChange={(event) =>
-                    setEvaluationProtocol(
-                      event.target.value as "benchmark_grade" | "standard",
-                    )
-                  }
-                  className="min-h-12 w-full min-w-0 max-w-full rounded-lg border border-slate-300 bg-white px-3 text-sm font-normal"
-                >
-                  <option value="benchmark_grade">Benchmark grade</option>
-                  <option value="standard">Standard evaluation</option>
-                </select>
-              </label>
-
-              <label className="grid gap-2 text-sm font-semibold md:col-span-2">
-                6 Protect hardware and site IP
-                <select
-                  value={hardwareIntegrationMode}
-                  onChange={(event) => {
-                    const nextMode = event.target
-                      .value as RobotTeamTestSubmissionHardwareIntegrationMode;
-                    setHardwareIntegrationMode(nextMode);
-                    if (nextMode === "reference_public_robot") {
-                      setSiteIpProtectionLevel("blueprint_hosted");
-                    } else if (nextMode === "private_asset_hosted_by_blueprint") {
-                      setSiteIpProtectionLevel("blueprint_hosted");
-                    } else if (nextMode === "physical_robot_evidence_bridge") {
-                      setSiteIpProtectionLevel("redacted_anchor_packet");
-                    } else if (nextMode === "customer_hosted_sealed_eval_capsule") {
-                      setSiteIpProtectionLevel("sealed_eval_capsule");
-                    }
-                  }}
-                  className="min-h-12 rounded-lg border border-slate-300 bg-white px-3 text-sm font-normal"
-                >
-                  {ROBOT_TEAM_HARDWARE_INTEGRATION_OPTIONS.map((option) => (
-                    <option key={option.id} value={option.id}>
-                      {option.label}
-                    </option>
-                  ))}
-                </select>
-                <span className="text-xs font-normal leading-5 text-slate-500">
-                  Customer-hosted connectors receive a sealed, least-privilege packet;
-                  raw captures, full scenes, scoring harnesses, and sealed audit seeds
-                  stay withheld by default.
-                </span>
-              </label>
             </div>
+
+            <p className="mt-4 text-sm leading-6 text-slate-600">
+              This defaults to one comparative ranking run on a single site.
+              Evaluation protocol, validation mode, and hardware/site-IP
+              integration are tucked under Advanced details — leave them as-is
+              for the standard screening run.
+            </p>
 
             <div className="mt-6">
               <h3 className="text-sm font-semibold">Policy access</h3>
@@ -777,6 +760,55 @@ export default function RobotTeamEval() {
                 Advanced details
               </summary>
               <div className="mt-5 grid gap-4 md:grid-cols-2">
+                <label className="grid gap-2 text-sm font-semibold">
+                  Evaluation protocol
+                  <select
+                    value={evaluationProtocol}
+                    onChange={(event) =>
+                      setEvaluationProtocol(
+                        event.target.value as "benchmark_grade" | "standard",
+                      )
+                    }
+                    className="min-h-11 w-full min-w-0 max-w-full rounded-lg border border-slate-300 bg-white px-3 text-sm font-normal"
+                  >
+                    <option value="benchmark_grade">Benchmark grade</option>
+                    <option value="standard">Standard evaluation</option>
+                  </select>
+                </label>
+
+                <label className="grid gap-2 text-sm font-semibold md:col-span-2">
+                  Protect hardware and site IP
+                  <select
+                    value={hardwareIntegrationMode}
+                    onChange={(event) => {
+                      const nextMode = event.target
+                        .value as RobotTeamTestSubmissionHardwareIntegrationMode;
+                      setHardwareIntegrationMode(nextMode);
+                      if (nextMode === "reference_public_robot") {
+                        setSiteIpProtectionLevel("blueprint_hosted");
+                      } else if (nextMode === "private_asset_hosted_by_blueprint") {
+                        setSiteIpProtectionLevel("blueprint_hosted");
+                      } else if (nextMode === "physical_robot_evidence_bridge") {
+                        setSiteIpProtectionLevel("redacted_anchor_packet");
+                      } else if (nextMode === "customer_hosted_sealed_eval_capsule") {
+                        setSiteIpProtectionLevel("sealed_eval_capsule");
+                      }
+                    }}
+                    className="min-h-11 rounded-lg border border-slate-300 bg-white px-3 text-sm font-normal"
+                  >
+                    {ROBOT_TEAM_HARDWARE_INTEGRATION_OPTIONS.map((option) => (
+                      <option key={option.id} value={option.id}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                  <span className="text-xs font-normal leading-5 text-slate-500">
+                    Customer-hosted connectors receive a sealed, least-privilege packet;
+                    raw captures, full scenes, scoring harnesses, and sealed audit seeds
+                    stay withheld by default.
+                  </span>
+                </label>
+
                 {episodeCount === "custom" ? (
                   <label className="grid gap-2 text-sm font-semibold">
                     Custom episode count
@@ -1010,7 +1042,7 @@ export default function RobotTeamEval() {
                 <div className="flex justify-between gap-4">
                   <dt className="text-slate-500">Commercial path</dt>
                   <dd className="text-right font-semibold">
-                    Subscription or quick-look
+                    One screening run
                   </dd>
                 </div>
                 <div className="flex justify-between gap-4">

--- a/client/src/pages/Sites.tsx
+++ b/client/src/pages/Sites.tsx
@@ -27,16 +27,27 @@ function requestHref(site?: SiteWorldCard) {
 
 function SiteCard({ site }: { site: SiteWorldCard }) {
   const tasks = site.taskCatalog?.slice(0, 3) || [];
-  const hasCapture = Boolean(site.evaluationReadiness?.qualification_state);
+  const qualificationState = site.evaluationReadiness?.qualification_state;
+  // Surface the risk/refresh states distinctly so a stale or flagged site is not
+  // hidden; keep the ordinary "ready" state neutral so a capture record never
+  // reads as a deployment certification.
+  const captureBadge =
+    qualificationState === "needs_refresh"
+      ? { label: "Needs refresh", className: "border-amber-200 bg-amber-50 text-amber-900" }
+      : qualificationState === "qualified_risky"
+        ? { label: "Qualified · risk noted", className: "border-amber-200 bg-amber-50 text-amber-900" }
+        : qualificationState
+          ? { label: "Capture on file", className: "border-slate-200 bg-slate-50 text-slate-700" }
+          : null;
   return (
     <article className="flex flex-col rounded-lg border border-slate-200 bg-white p-6">
       <div className="flex flex-wrap gap-2 text-xs font-semibold uppercase tracking-wider">
         <span className="rounded-md border border-emerald-200 bg-emerald-50 px-2.5 py-1 text-emerald-900">
           Pipeline record
         </span>
-        {hasCapture ? (
-          <span className="rounded-md border border-slate-200 bg-slate-50 px-2.5 py-1 text-slate-700">
-            Capture on file
+        {captureBadge ? (
+          <span className={`rounded-md border px-2.5 py-1 ${captureBadge.className}`}>
+            {captureBadge.label}
           </span>
         ) : null}
       </div>
@@ -154,7 +165,7 @@ export default function Sites() {
                 Real capture inventory
               </p>
               <h1 className="mt-4 max-w-[14ch] text-5xl font-semibold leading-[0.95] tracking-normal sm:text-6xl">
-                Rank policies where the work happens.
+                Evaluate where the work happens.
               </h1>
               <p className="mt-5 max-w-lg text-lg leading-8 text-slate-600">
                 {robotPolicyScreeningValue}
@@ -177,14 +188,13 @@ export default function Sites() {
                 >
                   Scope an evaluation <ArrowRight className="h-4 w-4" aria-hidden="true" />
                 </a>
+                <a
+                  href="/signup/capturer"
+                  className="inline-flex min-h-12 items-center justify-center rounded-lg border border-slate-300 px-5 text-sm font-semibold text-slate-950 hover:bg-slate-50"
+                >
+                  Capture a site
+                </a>
               </div>
-              <p className="mt-4 text-sm text-slate-500">
-                Own a site instead?{" "}
-                <a href="/signup/capturer" className="font-semibold text-slate-700 underline hover:text-slate-950">
-                  Join the capturer network to add supply
-                </a>{" "}
-                — a follow-on access-partner path.
-              </p>
             </div>
             <img
               src={wamPolicyEvalAssets.hero}

--- a/client/src/pages/Sites.tsx
+++ b/client/src/pages/Sites.tsx
@@ -3,6 +3,10 @@ import { ArrowRight, Database, Loader2, Search } from "lucide-react";
 
 import { SEO } from "@/components/SEO";
 import type { SiteWorldCard } from "@/data/siteWorlds";
+import {
+  robotPolicyBeachheadShort,
+  robotPolicyScreeningValue,
+} from "@/data/robotPolicyEvaluationClaims";
 import { wamPolicyEvalAssets } from "@/lib/editorialGeneratedAssets";
 import { breadcrumbJsonLd, webPageJsonLd } from "@/lib/seoStructuredData";
 
@@ -23,16 +27,16 @@ function requestHref(site?: SiteWorldCard) {
 
 function SiteCard({ site }: { site: SiteWorldCard }) {
   const tasks = site.taskCatalog?.slice(0, 3) || [];
-  const readiness = site.evaluationReadiness?.qualification_state?.replace(/_/g, " ");
+  const hasCapture = Boolean(site.evaluationReadiness?.qualification_state);
   return (
     <article className="flex flex-col rounded-lg border border-slate-200 bg-white p-6">
       <div className="flex flex-wrap gap-2 text-xs font-semibold uppercase tracking-wider">
         <span className="rounded-md border border-emerald-200 bg-emerald-50 px-2.5 py-1 text-emerald-900">
           Pipeline record
         </span>
-        {readiness ? (
+        {hasCapture ? (
           <span className="rounded-md border border-slate-200 bg-slate-50 px-2.5 py-1 text-slate-700">
-            {readiness}
+            Capture on file
           </span>
         ) : null}
       </div>
@@ -43,6 +47,10 @@ function SiteCard({ site }: { site: SiteWorldCard }) {
         {site.category} · {site.industry}
       </p>
       <p className="mt-4 flex-1 text-sm leading-6 text-slate-600">{site.summary}</p>
+      <p className="mt-3 text-xs leading-5 text-slate-500">
+        A Task Evaluation Run ranks your candidate policies on this site&rsquo;s captured task
+        envelope to screen them before field or pilot time.
+      </p>
       {tasks.length ? (
         <div className="mt-5 flex flex-wrap gap-2" aria-label="Recorded tasks">
           {tasks.map((task) => (
@@ -145,12 +153,22 @@ export default function Sites() {
               <p className="text-xs font-semibold uppercase tracking-[0.18em] text-blue-700">
                 Real capture inventory
               </p>
-              <h1 className="mt-4 max-w-[11ch] text-5xl font-semibold leading-[0.95] tracking-normal sm:text-6xl">
-                Evaluate where the work happens.
+              <h1 className="mt-4 max-w-[14ch] text-5xl font-semibold leading-[0.95] tracking-normal sm:text-6xl">
+                Rank policies where the work happens.
               </h1>
               <p className="mt-5 max-w-lg text-lg leading-8 text-slate-600">
-                Public cards come from current Pipeline-backed capture records. If the exact
-                place is not open, Blueprint can scope a new capture with its operator.
+                {robotPolicyScreeningValue}
+              </p>
+              <p className="mt-4 max-w-lg text-base leading-7 text-slate-600">
+                The evidence is strongest first for warehouse and logistics work —
+                mobile-base navigation and rigid pick-and-place ({robotPolicyBeachheadShort}).
+                Other site types stay browsable below. Public cards come from current
+                Pipeline-backed capture records; if the exact place is not open, Blueprint can
+                scope a new capture with its operator.
+              </p>
+              <p className="mt-4 max-w-lg text-sm leading-6 text-slate-500">
+                A Task Evaluation Run is a screening estimate that ranks policies by fidelity — not a
+                guarantee, safety certification, or deployment-readiness claim.
               </p>
               <div className="mt-8 flex flex-col gap-3 sm:flex-row">
                 <a
@@ -159,17 +177,18 @@ export default function Sites() {
                 >
                   Scope an evaluation <ArrowRight className="h-4 w-4" aria-hidden="true" />
                 </a>
-                <a
-                  href="/signup/capturer"
-                  className="inline-flex min-h-12 items-center justify-center rounded-lg border border-slate-300 px-5 text-sm font-semibold text-slate-950 hover:bg-slate-50"
-                >
-                  Capture a site
-                </a>
               </div>
+              <p className="mt-4 text-sm text-slate-500">
+                Own a site instead?{" "}
+                <a href="/signup/capturer" className="font-semibold text-slate-700 underline hover:text-slate-950">
+                  Join the capturer network to add supply
+                </a>{" "}
+                — a follow-on access-partner path.
+              </p>
             </div>
             <img
               src={wamPolicyEvalAssets.hero}
-              alt="Humanoid robot working in a captured facility task"
+              alt="Generated preview: a mobile-base robot navigating a warehouse aisle and lifting a rigid tote — review support, not a captured photo"
               className="aspect-[16/9] w-full rounded-lg border border-slate-200 object-cover"
             />
           </div>
@@ -216,7 +235,7 @@ export default function Sites() {
               </h2>
               <p className="mt-3 max-w-2xl text-base leading-7 text-slate-600">
                 Blueprint only publishes inventory backed by the current capture and Pipeline record.
-                Request the exact workflow and site type you need, or join the capturer network to add supply.
+                Request the exact workflow and site type you need.
               </p>
               <div className="mt-6 flex flex-col gap-3 sm:flex-row">
                 {sites.length ? (

--- a/client/src/pages/Vision.tsx
+++ b/client/src/pages/Vision.tsx
@@ -10,6 +10,10 @@ import {
   MonochromeMedia,
 } from "@/components/site/editorial";
 import { TileGrid } from "@/components/site/TileGrid";
+import {
+  robotPolicyEvaluationBeachhead,
+  robotPolicyScreeningValue,
+} from "@/data/robotPolicyEvaluationClaims";
 
 const statStrip = [
   { label: "Robot data vs. text", value: "~1B×", caption: "Smaller than internet text (Bessemer)" },
@@ -23,14 +27,14 @@ const rungs = [
     step: "01",
     phase: "Today",
     title: "Know which policy will actually work — before field time.",
-    body: "Blueprint's Task Evaluation Runs compare robot policies on a real captured site against your task suite, success rate, cycle time, and intervention thresholds. Ranking is the honest unit. Third-party 2026 research — SC3-Eval from NVIDIA and Physical Intelligence, and OSCAR from Peking University and NVIDIA — reports that video world models can predict real policy ordering. SC3-Eval's published 0.929 closed-loop Pearson correlation is category evidence, not a Blueprint run result.",
-    proof: "Rank fidelity & predicted success — an estimate, never a guaranteed field outcome.",
+    body: `Blueprint's Task Evaluation Runs compare robot policies on a real captured site against your task suite, success rate, cycle time, and intervention thresholds. Ranking is the honest unit. ${robotPolicyEvaluationBeachhead} Third-party 2026 research — SC3-Eval from NVIDIA and Physical Intelligence, and OSCAR from Peking University and NVIDIA — reports that video world models can predict real policy ordering. SC3-Eval's published 0.929 closed-loop Pearson correlation is category evidence, not a Blueprint run result.`,
+    proof: "Rank fidelity & predicted success — an estimate, never a guaranteed field outcome or safety certification.",
   },
   {
     step: "02",
     phase: "Building",
     title: "Become the neutral standard both sides route decisions through.",
-    body: "Robot teams use our runs to prove readiness and win pilots; site operators require them before a robot reaches the floor. The goal is that a large share of deployment and pilot decisions pass through one trusted, neutral measurement — the way credit ratings, UL safety marks, and MLPerf became the scoreboard their industries transact against. This is a decision layer, not a marketplace.",
+    body: "The aspiration is that robot teams use our runs to prove readiness and win pilots, and that over time site operators come to ask for them before a robot reaches the floor. The goal is that a large share of deployment and pilot decisions eventually pass through one trusted, neutral measurement — the way credit ratings, UL safety marks, and MLPerf became the scoreboard their industries transact against. This is a decision layer we are building toward, not a marketplace and not a gate we operate today.",
     proof: "Neutrality is the asset. Visible methodology, re-validation, and a conflict-of-interest firewall.",
   },
   {
@@ -113,29 +117,26 @@ export default function Vision() {
                 The vision
               </Eyebrow>
               <h1 className="font-editorial mt-6 text-[clamp(2.6rem,5vw,4.2rem)] font-medium leading-[0.96] tracking-[-0.045em] text-ink">
-                Make sure the best robot runs at every site.
+                Know which robot policy works at a real site — before field time.
               </h1>
               <p className="mt-6 text-lg leading-[1.7] text-ink-600">
-                Robotics is heading toward millions of robots, dozens of vendors, and no neutral way
-                to know which one will actually work at a specific real place. Blueprint starts by
-                answering exactly that question — and earns the right to climb the stack from there.
+                For robot and foundation-model teams, Blueprint does one thing today:{" "}
+                {robotPolicyScreeningValue} It's an estimate and a decision-support screen — never a
+                guarantee, a safety certification, or a deployment-readiness claim.
               </p>
-              <p className="mt-4 text-lg leading-[1.7] text-ink-600">
-                We begin as the neutral measurement of policy performance on a captured site, grow
-                into the standard the market routes its deployment decisions through, and let the
-                proprietary data that produces open the door to prediction, site-specific policies,
-                and — where we can prove we're the best operator — deployment itself. Capture-first,
-                provenance-true, the whole way up.
+              <p className="mt-4 text-base leading-[1.7] text-ink-500">
+                Longer-horizon, that neutral measurement is the first rung of a climb — toward the
+                standard the market routes deployment decisions through, and the proprietary data
+                that opens the door to prediction, site-specific policies, and deployment itself.
+                Capture-first, provenance-true, the whole way up. Only rung one is a product you can
+                buy today; everything above it is where we're heading.
               </p>
               <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
                 <Button asChild variant="brass" size="lg">
-                  <a href="/how-it-works">
-                    See how it works today
+                  <a href="/contact/robot-team">
+                    Request an evaluation
                     <ArrowRight className="ml-2 h-5 w-5" />
                   </a>
-                </Button>
-                <Button asChild variant="secondary" size="lg">
-                  <a href="/sites">Explore site packages</a>
                 </Button>
               </div>
             </div>
@@ -207,47 +208,71 @@ export default function Vision() {
         <section className="mx-auto max-w-[88rem] px-5 py-12 sm:px-8 lg:px-10 lg:py-16">
           <EditorialSectionIntro
             eyebrow="The path up the stack"
-            title="Five rungs, each built on the data the last one produces."
-            description="We don't skip rungs. Each is a product we can sell, a moat we deepen, and the launchpad for the next. Today's product is rung one; everything above it is where the same capture-first foundation is taking us."
+            title="One product today. Four more rungs it's built to reach."
+            description="We don't skip rungs. Only rung one is a product you can buy today; each rung above it is a moat we'd deepen and the launchpad for the next. Everything above rung one is where the same capture-first foundation is taking us — a direction, not a shipped offer."
             className="max-w-3xl"
           />
-          <div className="mt-10 flex flex-col gap-px overflow-hidden rounded-sm border border-line bg-line">
-            {rungs.map((rung) => (
-              <div
-                key={rung.step}
-                className="grid gap-5 bg-white p-6 sm:grid-cols-[auto_1fr] sm:gap-8 lg:p-8"
-              >
-                <div className="flex flex-row items-center gap-4 sm:flex-col sm:items-start sm:gap-3">
-                  <span className="font-mono text-[2.2rem] font-medium leading-none tracking-tight text-ink">
+
+          {/* Rung 01 — the product today */}
+          <div className="mt-10 overflow-hidden rounded-sm border border-brass-deep/30 bg-white">
+            <div className="grid gap-5 p-6 sm:grid-cols-[auto_1fr] sm:gap-8 lg:p-8">
+              <div className="flex flex-row items-center gap-4 sm:flex-col sm:items-start sm:gap-3">
+                <span className="font-mono text-[2.2rem] font-medium leading-none tracking-tight text-ink">
+                  {rungs[0].step}
+                </span>
+                <span className="inline-flex items-center rounded-full border border-brass-deep/30 bg-brass-deep/10 px-2.5 py-0.5 font-mono text-[11px] uppercase tracking-[0.12em] text-brass-deep">
+                  {rungs[0].phase} · the product
+                </span>
+              </div>
+              <div>
+                <h3 className="font-editorial text-[1.6rem] leading-[1.05] tracking-[-0.03em] text-ink">
+                  {rungs[0].title}
+                </h3>
+                <p className="mt-3 max-w-[46rem] text-[15px] leading-[1.7] text-ink-500">
+                  {rungs[0].body}
+                </p>
+                <p className="mt-4 flex items-start gap-2 text-[13px] leading-snug text-ink-400">
+                  <span className="mt-[0.15rem] text-micro font-semibold uppercase tracking-eyebrow text-ink-400">
+                    Proof boundary
+                  </span>
+                  <span className="text-ink-500">{rungs[0].proof}</span>
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {/* Rungs 02–05 — where this goes over time, subordinate strip */}
+          <p className="mt-10 text-micro font-semibold uppercase tracking-eyebrow text-ink-400">
+            Where this goes over time — direction, not shipped product
+          </p>
+          <div className="mt-4 grid grid-cols-1 gap-px overflow-hidden rounded-sm border border-line bg-line sm:grid-cols-2 lg:grid-cols-4">
+            {rungs.slice(1).map((rung) => (
+              <div key={rung.step} className="flex flex-col gap-3 bg-white p-5">
+                <div className="flex items-center gap-3">
+                  <span className="font-mono text-[1.4rem] font-medium leading-none tracking-tight text-ink-500">
                     {rung.step}
                   </span>
                   <span
                     className={
-                      "inline-flex items-center rounded-full border px-2.5 py-0.5 font-mono text-[11px] uppercase tracking-[0.12em] " +
-                      (rung.phase === "Today"
-                        ? "border-brass-deep/30 bg-brass-deep/10 text-brass-deep"
-                        : rung.phase === "Building"
-                          ? "border-line bg-canvas text-ink-600"
-                          : "border-line bg-canvas text-ink-400")
+                      "inline-flex items-center rounded-full border px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.12em] " +
+                      (rung.phase === "Building"
+                        ? "border-line bg-canvas text-ink-600"
+                        : "border-line bg-canvas text-ink-400")
                     }
                   >
                     {rung.phase}
                   </span>
                 </div>
-                <div>
-                  <h3 className="font-editorial text-[1.6rem] leading-[1.05] tracking-[-0.03em] text-ink">
-                    {rung.title}
-                  </h3>
-                  <p className="mt-3 max-w-[46rem] text-[15px] leading-[1.7] text-ink-500">
-                    {rung.body}
-                  </p>
-                  <p className="mt-4 flex items-start gap-2 text-[13px] leading-snug text-ink-400">
-                    <span className="mt-[0.15rem] text-micro font-semibold uppercase tracking-eyebrow text-ink-400">
-                      Proof boundary
-                    </span>
-                    <span className="text-ink-500">{rung.proof}</span>
-                  </p>
-                </div>
+                <h3 className="font-editorial text-[1.15rem] leading-[1.1] tracking-[-0.02em] text-ink-700">
+                  {rung.title}
+                </h3>
+                <p className="text-[13px] leading-[1.6] text-ink-500">{rung.body}</p>
+                <p className="mt-auto flex items-start gap-1.5 pt-2 text-[12px] leading-snug text-ink-400">
+                  <span className="mt-[0.1rem] text-micro font-semibold uppercase tracking-eyebrow text-ink-400">
+                    Proof boundary
+                  </span>
+                  <span className="text-ink-500">{rung.proof}</span>
+                </p>
               </div>
             ))}
           </div>

--- a/client/tests/components/site/Header.test.tsx
+++ b/client/tests/components/site/Header.test.tsx
@@ -32,10 +32,11 @@ describe("Header", () => {
       "href",
       "/for-robot-teams",
     );
-    expect(screen.getByRole("link", { name: /^For Site Operators$/i })).toHaveAttribute(
-      "href",
-      "/for-site-operators",
-    );
+    // Site operators are demoted out of the primary header nav to the footer
+    // ("Site access partners"); the buyer-facing header stays robot-team focused.
+    expect(
+      screen.queryByRole("link", { name: /^For Site Operators$/i }),
+    ).not.toBeInTheDocument();
     expect(screen.getByRole("link", { name: /^How it works$/i })).toHaveAttribute(
       "href",
       "/how-it-works",

--- a/client/tests/pages/Contact.test.tsx
+++ b/client/tests/pages/Contact.test.tsx
@@ -87,10 +87,11 @@ describe("Contact page", () => {
       "href",
       "/contact/robot-team#contact-intake",
     );
-    expect(screen.getByRole("link", { name: /Supply or monitor a facility\./i })).toHaveAttribute(
-      "href",
-      "/contact/site-operator#contact-intake",
-    );
+    // The operator lane is demoted to a low-emphasis reachable link, but stays
+    // reachable at the same site-operator intake href.
+    expect(
+      screen.getByRole("link", { name: /Partner on lighthouse capture access/i }),
+    ).toHaveAttribute("href", "/contact/site-operator#contact-intake");
     expect(screen.getByRole("textbox", { name: /^Name$/i })).toBeInTheDocument();
     expect(screen.getByRole("textbox", { name: /Robot team \/ company/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Send message/i })).toBeInTheDocument();
@@ -159,7 +160,7 @@ describe("Contact page", () => {
     expect(screen.getByText(/Start a \$5,000\/site supply review or scope yearly monitoring\. Access, rights, and pricing are confirmed per scope/i)).toBeInTheDocument();
     expect(screen.getByRole("textbox", { name: /^Name$/i })).toBeInTheDocument();
     expect(screen.getByRole("textbox", { name: /Organization/i })).toBeInTheDocument();
-    expect(screen.getAllByText(/Supply or monitor a facility\./i)[0]).toBeInTheDocument();
+    expect(screen.getAllByText(/Partner on lighthouse capture access/i)[0]).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Send message/i })).toBeInTheDocument();
   });
 });

--- a/e2e/contact.spec.ts
+++ b/e2e/contact.spec.ts
@@ -33,7 +33,7 @@ test('contact page leads with a simple robot-team Policy Evaluation Run flow', a
     page.locator('main').getByRole('link', { name: /Compare policies on a real site\./i }).first(),
   ).toBeVisible();
   await expect(
-    page.locator('main').getByRole('link', { name: /Supply or monitor a facility\./i }).first(),
+    page.locator('main').getByRole('link', { name: /Partner on lighthouse capture access/i }).first(),
   ).toBeVisible();
   await expect(page.getByRole('textbox', { name: /^Name$/i })).toBeVisible();
   await expect(page.getByRole('textbox', { name: /Work email/i })).toBeVisible();
@@ -54,7 +54,7 @@ test('site-operator contact path keeps the low-cost access-boundary lane visible
   await expect(page.getByRole('textbox', { name: /^Name$/i })).toBeVisible();
   await expect(page.getByRole('textbox', { name: /Organization/i })).toBeVisible();
   await expect(
-    page.locator('main').getByRole('link', { name: /Supply or monitor a facility\./i }).first(),
+    page.locator('main').getByRole('link', { name: /Partner on lighthouse capture access/i }).first(),
   ).toBeVisible();
   await expect(page.getByRole('button', { name: /Send message/i })).toBeVisible();
 });

--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -10,9 +10,13 @@ test('homepage leads with the simple capture-backed policy evaluation story', as
   ).toBeVisible();
   const nav = page.getByRole('banner').getByRole('navigation');
   await expect(nav.getByRole('link', { name: /^For Robot Teams$/i })).toBeVisible();
-  await expect(nav.getByRole('link', { name: /^For Site Operators$/i })).toBeVisible();
+  // Site operators are demoted out of the primary header nav to the footer.
+  await expect(nav.getByRole('link', { name: /^For Site Operators$/i })).toHaveCount(0);
   await expect(nav.getByRole('link', { name: /^How it works$/i })).toBeVisible();
   await expect(nav.getByRole('link', { name: /^Pricing$/i })).toBeVisible();
+  await expect(
+    page.getByRole('contentinfo').getByRole('link', { name: /^Site access partners$/i }),
+  ).toBeVisible();
   await expect(page.getByRole('link', { name: /^Request evaluation$/i }).first()).toBeVisible();
   await expect(
     page.locator('main').getByText(/Compare your policy against earlier checkpoints/i),

--- a/scripts/qa/brand-polish.test.ts
+++ b/scripts/qa/brand-polish.test.ts
@@ -48,7 +48,7 @@ describe("brand polish QA harness contract", () => {
       expectedHeading: "Tell us what policies to compare.",
       requiredCtas: expect.arrayContaining([
         { label: "Compare policies on a real site.", hrefStartsWith: "/contact/robot-team" },
-        { label: "Supply or monitor a facility.", hrefStartsWith: "/contact/site-operator" },
+        { label: "Partner on lighthouse capture access.", hrefStartsWith: "/contact/site-operator" },
       ]),
     });
 

--- a/scripts/qa/brand-polish.ts
+++ b/scripts/qa/brand-polish.ts
@@ -185,7 +185,7 @@ export const publicQaRoutes: PublicQaRoute[] = [
     expectedHeading: "Tell us what policies to compare.",
     requiredCtas: [
       { label: "Compare policies on a real site.", hrefStartsWith: "/contact/robot-team" },
-      { label: "Supply or monitor a facility.", hrefStartsWith: "/contact/site-operator" },
+      { label: "Partner on lighthouse capture access.", hrefStartsWith: "/contact/site-operator" },
     ],
   },
   {
@@ -224,7 +224,7 @@ export const publicQaRoutes: PublicQaRoute[] = [
     expectedHeading: "Tell us what policies to compare.",
     requiredCtas: [
       { label: "Compare policies on a real site.", hrefStartsWith: "/contact/robot-team" },
-      { label: "Supply or monitor a facility.", hrefStartsWith: "/contact/site-operator" },
+      { label: "Partner on lighthouse capture access.", hrefStartsWith: "/contact/site-operator" },
     ],
   },
   {
@@ -234,7 +234,7 @@ export const publicQaRoutes: PublicQaRoute[] = [
     expectedHeading: "Tell us what policies to compare.",
     requiredCtas: [
       { label: "Compare policies on a real site.", hrefStartsWith: "/contact/robot-team" },
-      { label: "Supply or monitor a facility.", hrefStartsWith: "/contact/site-operator" },
+      { label: "Partner on lighthouse capture access.", hrefStartsWith: "/contact/site-operator" },
     ],
   },
   {

--- a/scripts/qa/brand-polish.ts
+++ b/scripts/qa/brand-polish.ts
@@ -204,7 +204,7 @@ export const publicQaRoutes: PublicQaRoute[] = [
     canonicalPath: "/proof",
     expectedHeading: "Proof stays scoped.",
     requiredCtas: [
-      { label: "Start", hrefStartsWith: "/contact" },
+      { label: "Request evaluation", hrefStartsWith: "/contact" },
     ],
   },
   {


### PR DESCRIPTION
## What this does

Streamlines the public marketing surface so it reads as **one thing done well** instead of a menu of co-equal services and audiences. The site already had strong honesty framing and already defaulted to robot teams as the buyer — the problem was **dilution**, so this is a focusing pass, not a rewrite.

Two decisions drove the scope (confirmed before implementing):
- **Re-weight in place** — make the robot-team **Task Evaluation Run (policy ranking)** the single front door on every page; demote everything else. Nothing is deleted.
- **Claim the beachhead explicitly** — name warehouse/logistics **navigation + mobile-base + rigid pick-and-place** as where the evidence is strongest, and state that dexterous, contact-rich manipulation is out of scope for now (this matches the repo's own approved lead story in `WORLD_MODEL_STRATEGY_CONTEXT.md`).

## Changes

- **New canonical copy source** in `client/src/data/robotPolicyEvaluationClaims.ts` (beachhead sentence, screening value-prop, sharpened proof boundary, external-evidence caveat) consumed across ~13 pages so the messaging is identical everywhere.
- **Chrome / nav**: primary nav and header/footer lead with the robot-team buyer; **site operators** demoted to a "Site access partners" link, **capturers** reframed as paid supply ("Get paid to capture").
- **Pricing**: leads with the cheap **quick-look screening wedge** (now the highlighted tier); the `$15k/mo` subscription, **Policy Improvement Runs**, **data packages**, and **operator tiers** all demoted to clearly-secondary / "later" (kept, not removed).
- **Per-page**: Home, HowItWorks, ForRobotTeams, RobotTeamEval, Proof, Vision, Governance, FAQ, About, Capture, Sites, Contact each re-weighted to the single service, with the beachhead surfaced and the value-prop ("rank which policy to field-test first, before you spend pilot time") pulled to the top.
- **Imagery**: dexterous / mislabeled hero images (humanoid-dishwasher, packing-cell, machine-tending, inspection-bench) re-pointed to warehouse mobile-base + rigid-pick scenes or given honest alt text; generated frames are never described as "captured".

## Constraints honored

- **Honesty framing preserved verbatim** — every rank-fidelity / proof-boundary / provenance / "review support, not real-world proof" / illustrative statement is kept (added honesty language like "never a guarantee or safety certification" only where it strengthens the boundary).
- **No doctrine services removed** — Task Evaluation *and* Policy Improvement Runs both remain; secondary offers are demoted, not deleted (per CLAUDE.md, removing primary services needs `blueprint-cto` sign-off).
- **World models stay internal support** — demoted the "world model" noun on Governance back to capture / evaluation run / listing.

## Verification

- `npm run check` (tsc): no type errors reference any edited file (the 5 reported errors are pre-existing env/config issues — missing `@types` in the sandbox).
- Adversarial pass over the diff confirmed no load-bearing honesty line was dropped; each was verified still present post-edit.
- Self-flagged inconsistencies fixed (Pricing FAQ that still called the subscription "primary"; RobotTeamEval step banner; a stale code comment).
- **Note:** the `graphify` architecture-graph refresh could not complete — the `graphifyy` Python package isn't installed in this environment. No graph outputs changed; only the corpus was staged (gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012a4ogdQ4yDD1G1oENAJ53j

---
_Generated by [Claude Code](https://claude.ai/code/session_012a4ogdQ4yDD1G1oENAJ53j)_