### PR TITLE
Restructure: merge the eval intake into /for-robot-teams + sharpen 3 headlines

### DIFF
--- a/client/src/app/routes.tsx
+++ b/client/src/app/routes.tsx
@@ -46,7 +46,8 @@ const CaptureLaunchAccess = lazyRoute(() => import("../pages/CaptureLaunchAccess
 const BusinessSignUpFlow = lazyRoute(() => import("../pages/BusinessSignUpFlow"));
 const CapturerSignUpFlow = lazyRoute(() => import("../pages/CapturerSignUpFlow"));
 const OnboardingChecklist = lazyRoute(() => import("../pages/OnboardingChecklist"));
-const RobotTeamEval = lazyRoute(() => import("../pages/RobotTeamEval"));
+// /robot-team/eval merged into /for-robot-teams (#intake); keep the URL as a redirect.
+const RobotTeamEvalRedirect = () => <MarketingRedirect to="/for-robot-teams#intake" />;
 const Sites = lazyRoute(() => import("../pages/Sites"));
 const SiteDetail = lazyRoute(() => import("../pages/SiteDetail"));
 const Pricing = lazyRoute(() => import("../pages/Pricing"));
@@ -242,7 +243,7 @@ export const appRoutes: AppRoute[] = [
   // Persona pages
   { path: "/for-site-operators", layout: "public", component: ForSiteOperators },
   { path: "/for-robot-teams", layout: "public", component: ForRobotTeams },
-  { path: "/robot-team/eval", layout: "public", component: RobotTeamEval },
+  { path: "/robot-team/eval", layout: "public", component: RobotTeamEvalRedirect },
   { path: "/for-robot-integrators", layout: "public", component: LegacyForRobotIntegratorsRedirect },
 
   // Core pages

--- a/client/src/pages/ForRobotTeams.tsx
+++ b/client/src/pages/ForRobotTeams.tsx
@@ -1,6 +1,7 @@
 import { ArrowRight, Check } from "lucide-react";
 
 import { SEO } from "@/components/SEO";
+import RobotTeamEval from "@/pages/RobotTeamEval";
 import { breadcrumbJsonLd, webPageJsonLd } from "@/lib/seoStructuredData";
 
 import {
@@ -184,7 +185,7 @@ export default function ForRobotTeams() {
                     For Robot Teams
                   </Eyebrow>
                   <h1 className="mt-6 max-w-[40rem] font-display text-[clamp(3rem,5.4vw,5rem)] font-medium leading-[0.95] tracking-[-0.045em] text-[color:var(--text-on-ink)]">
-                    Rank robot policies on real sites before field time.
+                    Rank your policies on a real site — before field time.
                   </h1>
                   <p className="mt-6 max-w-[34rem] text-[1.1rem] leading-[1.7] text-[color:var(--text-on-ink)] opacity-80">
                     Submit your checkpoints and compare them on a captured indoor
@@ -215,7 +216,7 @@ export default function ForRobotTeams() {
                   <p className="mt-4 text-sm text-[color:var(--text-on-ink)] opacity-75">
                     Already know the policy modalities and robot interface?{" "}
                     <a
-                      href="/robot-team/eval"
+                      href="#intake"
                       className="font-semibold underline underline-offset-4 hover:opacity-100"
                     >
                       Configure policy inputs
@@ -508,6 +509,9 @@ export default function ForRobotTeams() {
             </div>
           </div>
         </section>
+
+        {/* Robot-team evaluation intake — merged in from the former /robot-team/eval page */}
+        <RobotTeamEval embedded />
 
         {/* CTA band */}
         <section className="mx-auto max-w-[88rem] px-7 pb-20 pt-4">

--- a/client/src/pages/ForSiteOperators.tsx
+++ b/client/src/pages/ForSiteOperators.tsx
@@ -158,7 +158,7 @@ export default function ForSiteOperators() {
                     For Site Operators
                   </Eyebrow>
                   <h1 className="mt-6 max-w-[40rem] font-display text-[clamp(3rem,5.4vw,5rem)] font-medium leading-[0.95] tracking-[-0.045em] text-[color:var(--text-on-ink)]">
-                    Supply a real site without losing the boundary.
+                    Offer a site. Keep the boundary.
                   </h1>
                   <p className="mt-6 max-w-[34rem] text-[1.1rem] leading-[1.7] text-[color:var(--text-on-ink)] opacity-80">
                     Turn a facility into a captured evaluation site — and keep

--- a/client/src/pages/HowItWorks.tsx
+++ b/client/src/pages/HowItWorks.tsx
@@ -239,7 +239,7 @@ export default function HowItWorks() {
               How it works
             </Eyebrow>
             <h1 className="mt-5 font-display text-[clamp(2.6rem,5vw,4.4rem)] font-medium leading-[1.02] tracking-[-0.045em] text-[color:var(--text-on-ink)]">
-              Capture first. Package the proof. Decide the next test.
+              How a Task Evaluation Run works.
             </h1>
             <p className="mt-5 max-w-[34rem] text-[1.05rem] leading-[1.7] text-[color:var(--text-on-ink)] opacity-80">
               Blueprint turns one real indoor capture into a versioned, rights-attached

--- a/client/src/pages/MarketingRedirect.tsx
+++ b/client/src/pages/MarketingRedirect.tsx
@@ -10,10 +10,17 @@ export function MarketingRedirect({ to }: MarketingRedirectProps) {
 
   useEffect(() => {
     const search = typeof window !== "undefined" ? window.location.search : "";
-    const hash = typeof window !== "undefined" ? window.location.hash : "";
+    const incomingHash = typeof window !== "undefined" ? window.location.hash : "";
+    // Split the target so a forwarded query lands BEFORE any hash in `to`
+    // (e.g. `/for-robot-teams#intake` or `/#how-it-works`); appending the
+    // query after the hash would bury it in the fragment and break the anchor.
+    const [toBase, toHashRaw] = to.split("#");
+    const toHash = toHashRaw ? `#${toHashRaw}` : "";
     const query = search.replace(/^\?/, "");
-    const separator = query ? (to.includes("?") ? "&" : "?") : "";
-    setLocation(`${to}${separator}${query}${hash}`, { replace: true });
+    const separator = query ? (toBase.includes("?") ? "&" : "?") : "";
+    setLocation(`${toBase}${separator}${query}${toHash || incomingHash}`, {
+      replace: true,
+    });
   }, [setLocation, to]);
 
   return null;

--- a/client/src/pages/RobotTeamEval.tsx
+++ b/client/src/pages/RobotTeamEval.tsx
@@ -173,7 +173,7 @@ function intakeHref(params: {
   return `/contact/robot-team?${query.toString()}`;
 }
 
-export default function RobotTeamEval() {
+export default function RobotTeamEval({ embedded = false }: { embedded?: boolean } = {}) {
   const [requesterName, setRequesterName] = useState("");
   const [requesterEmail, setRequesterEmail] = useState("");
   const [requesterCompany, setRequesterCompany] = useState("");
@@ -406,6 +406,7 @@ export default function RobotTeamEval() {
 
   return (
     <>
+      {!embedded && (
       <SEO
         title="Policy Evaluation Run for Robot Teams | Blueprint"
         description="Create a capture-backed Policy Evaluation Run to compare your own checkpoints, other teams, or vendor policies on the same site/task envelope."
@@ -420,8 +421,10 @@ export default function RobotTeamEval() {
           url: "https://tryblueprint.io/for-robot-teams",
         }}
       />
+      )}
 
-      <div className="bg-white text-slate-950">
+      <div className="bg-white text-slate-950" id="intake">
+        {!embedded && (
         <section className="border-b border-slate-200">
           <div className="mx-auto grid max-w-[88rem] gap-10 px-5 py-12 md:grid-cols-[0.78fr_1.22fr] md:items-center md:px-8 md:py-16">
             <div>
@@ -455,6 +458,7 @@ export default function RobotTeamEval() {
             />
           </div>
         </section>
+        )}
 
         <section className="border-b border-slate-200 bg-slate-50">
           <div className="mx-auto grid max-w-[88rem] gap-3 px-5 py-6 sm:grid-cols-5 md:px-8">

--- a/client/tests/build-output.test.ts
+++ b/client/tests/build-output.test.ts
@@ -50,7 +50,6 @@ describe("build output", () => {
       "pricing/index.html",
       "proof/index.html",
       "for-robot-teams/index.html",
-      "robot-team/eval/index.html",
       "contact/robot-team/index.html",
       "contact/site-operator/index.html",
       "capture-app/index.html",
@@ -70,6 +69,7 @@ describe("build output", () => {
   it("does not prerender retired aliases or protected operations routes", () => {
     [
       "product/index.html",
+      "robot-team/eval/index.html",
       "readiness/index.html",
       "world-models/index.html",
       "contact/index.html",

--- a/client/tests/pages/ForRobotTeams.test.tsx
+++ b/client/tests/pages/ForRobotTeams.test.tsx
@@ -7,12 +7,12 @@ describe("ForRobotTeams", () => {
     render(<ForRobotTeams />);
 
     expect(
-      screen.getByRole("heading", { name: /Rank robot policies on real sites before field time/i }),
+      screen.getByRole("heading", { name: /Rank your policies on a real site — before field time/i }),
     ).toBeInTheDocument();
     expect(screen.getAllByRole("link", { name: /Request evaluation/i }).length).toBeGreaterThan(0);
     expect(screen.getByRole("link", { name: /Configure policy inputs/i })).toHaveAttribute(
       "href",
-      "/robot-team/eval",
+      "#intake",
     );
     const siteLinks = screen.getAllByRole("link", { name: /Browse site records/i });
     expect(siteLinks.length).toBeGreaterThan(0);

--- a/client/tests/pages/ForSiteOperators.test.tsx
+++ b/client/tests/pages/ForSiteOperators.test.tsx
@@ -9,7 +9,7 @@ describe("ForSiteOperators", () => {
     expect(screen.getAllByText(/^For Site Operators$/i).length).toBeGreaterThan(0);
     expect(
       screen.getByRole("heading", {
-        name: /Supply a real site without losing the boundary\./i,
+        name: /Offer a site\. Keep the boundary\./i,
       }),
     ).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: /From a facility to a controlled supply site\./i })).toBeInTheDocument();

--- a/client/tests/pages/HowItWorks.test.tsx
+++ b/client/tests/pages/HowItWorks.test.tsx
@@ -8,7 +8,7 @@ describe("HowItWorks", () => {
 
     expect(
       screen.getByRole("heading", {
-        name: /Capture first\. Package the proof\. Decide the next test\./i,
+        name: /How a Task Evaluation Run works\./i,
       }),
     ).toBeInTheDocument();
     expect(

--- a/client/tests/pages/Routes.test.ts
+++ b/client/tests/pages/Routes.test.ts
@@ -145,7 +145,7 @@ describe("Route registration", () => {
 
     expect(source).toContain('{ path: "/for-site-operators", layout: "public", component: ForSiteOperators }');
     expect(source).toContain('{ path: "/for-robot-teams", layout: "public", component: ForRobotTeams }');
-    expect(source).toContain('{ path: "/robot-team/eval", layout: "public", component: RobotTeamEval }');
+    expect(source).toContain('{ path: "/robot-team/eval", layout: "public", component: RobotTeamEvalRedirect }');
     expect(source).toContain('{ path: "/for-robot-integrators", layout: "public", component: LegacyForRobotIntegratorsRedirect }');
     expect(source).toContain('{ path: "/exact-site-hosted-review", layout: "public", component: LegacyHostedReviewRedirect }');
     expect(source).toContain('{ path: "/how-it-works", layout: "public", component: HowItWorks }');

--- a/e2e/robot-team-eval.spec.ts
+++ b/e2e/robot-team-eval.spec.ts
@@ -14,7 +14,17 @@ const policyApiFields = {
   "Policy API endpoint Owner contact": "robot-owner@example.com",
 };
 
-test("robot-team eval route is simple and submits normalized policy payload", async ({
+test("legacy /robot-team/eval redirects to the merged /for-robot-teams intake", async ({
+  page,
+}) => {
+  await page.goto("/robot-team/eval");
+  await expect(page).toHaveURL(/\/for-robot-teams/);
+  await expect(
+    page.getByRole("heading", { name: "Start with the essentials." }),
+  ).toBeVisible();
+});
+
+test("robot-team eval intake on /for-robot-teams submits a normalized policy payload", async ({
   page,
 }) => {
   await page.setViewportSize({ width: 1280, height: 900 });
@@ -29,13 +39,8 @@ test("robot-team eval route is simple and submits normalized policy payload", as
     });
   });
 
-  await page.goto("/robot-team/eval");
+  await page.goto("/for-robot-teams");
 
-  await expect(
-    page.getByRole("heading", {
-      name: "Compare policies on one site task.",
-    }),
-  ).toBeVisible();
   await expect(page.getByRole("heading", { name: "Start with the essentials." })).toBeVisible();
   await expect(page.getByText("API").first()).toBeVisible();
   await expect(page.getByText("Docker").first()).toBeVisible();
@@ -143,14 +148,12 @@ test("robot-team eval route is simple and submits normalized policy payload", as
   expect(submission.successCriteria).toBe("tote placed without safety event");
 });
 
-test("robot-team eval route is usable on mobile", async ({ page }) => {
+test("robot-team eval intake is usable on mobile", async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 844 });
-  await page.goto("/robot-team/eval");
+  await page.goto("/for-robot-teams");
 
   await expect(
-    page.getByRole("heading", {
-      name: "Compare policies on one site task.",
-    }),
+    page.getByRole("heading", { name: "Start with the essentials." }),
   ).toBeVisible();
   await expect(
     page.getByRole("button", { name: /Send request/i }),

--- a/scripts/prerender.tsx
+++ b/scripts/prerender.tsx
@@ -243,20 +243,6 @@ const PrerenderCaptureLaunchAccessSummary = () => (
   />
 );
 
-const PrerenderRobotTeamEvalSummary = () => (
-  <MinimalStaticPage
-    title="Robot Team Evaluation | Blueprint"
-    description="Start a four-step policy evaluation request for a captured task pack."
-    heading="Start an evaluation"
-    body="Pick a site task, add policies, tell us the robot, and choose 100 or 500 episodes."
-    primaryHref="/contact/robot-team?persona=robot-team&buyerType=robot_team&interest=policy-evaluation-run&path=policy-evaluation-run"
-    primaryLabel="Start"
-    // The live RobotTeamEval page canonicalizes to /for-robot-teams (the
-    // advertised citation target), so the prerendered shell must match.
-    canonical="/for-robot-teams"
-  />
-);
-
 const PrerenderFallbackSummary = () => (
   <MinimalStaticPage
     title="Blueprint"
@@ -285,7 +271,6 @@ const staticRoutes: StaticRoute[] = [
   // sitemap and llms.txt, so crawlers must see the real page, not a summary
   // shell whose canonical points elsewhere.
   { path: "/for-robot-teams", component: ForRobotTeams },
-  { path: "/robot-team/eval", component: PrerenderRobotTeamEvalSummary, shell: "bare" },
   // Live public pages (also advertised in the sitemap) prerender as their
   // real components so crawlers and no-JS agents see the actual content.
   { path: "/for-site-operators", component: ForSiteOperators },

--- a/server/routes/site-content.ts
+++ b/server/routes/site-content.ts
@@ -106,13 +106,7 @@ const pages = [
     path: "/for-robot-teams",
     title: "Start a Policy Evaluation",
     description:
-      "Simple four-step setup for choosing a site task, adding policies, naming the robot, choosing episodes, and attaching policy access details when available.",
-  },
-  {
-    path: "/robot-team/eval",
-    title: "Robot-Team Evaluation Submission",
-    description:
-      "Canonical structured submission route for robot teams to create an eligible hosted session or route request-gated modalities to contact intake without upgrading references into readiness proof.",
+      "The robot-team page and canonical structured submission route: read how a Task Evaluation Run works, then submit one on the same page — choose a site task, add policies, name the robot, choose episodes, and attach policy access details when available, without upgrading references into readiness proof.",
   },
   {
     path: "/sites",


### PR DESCRIPTION
## What this does

Follow-up to the streamline (#423), executing the approved subset of the restructure deck: **one structural merge** + **three headline sharpens**, with every copy-contract layer updated in lockstep so CI stays green.

## Structural merge — RobotTeamEval → ForRobotTeams

Robot teams now have **one page** instead of two. The `/robot-team/eval` intake form renders **embedded** on `/for-robot-teams` (`#intake`), and the old route redirects there.

- `RobotTeamEval` gains an `embedded` prop that skips its own `<SEO>` + hero; `ForRobotTeams` imports and renders `<RobotTeamEval embedded />` before its CTA band.
- `/robot-team/eval` → `MarketingRedirect` to `/for-robot-teams#intake`; the "Configure policy inputs" link now scrolls to `#intake`.
- The form ships **bundled with** `/for-robot-teams`, so the prerendered HTML and browser-JS strings the build-output test pins (`Source a warehouse-type site`, `Request received…`) stay intact.

## Headline sharpens (single-service)

- ForRobotTeams → **"Rank your policies on a real site — before field time."**
- HowItWorks → **"How a Task Evaluation Run works."**
- ForSiteOperators → **"Offer a site. Keep the boundary."**

Home, Pricing, Proof, Governance, About, Vision, Sites, FAQ, Capture, Contact H1s left verbatim (already strong / high contract cost).

## Contract layers updated in lockstep

`routes.tsx` (redirect) + `Routes.test.ts` (source literal) · `scripts/prerender.tsx` (removed the eval shell) · `build-output.test.ts` (moved `robot-team/eval` from the prerender exists-list to the retired-aliases list) · the three page unit tests · `ForRobotTeams.test.tsx` (`#intake` anchor) · `e2e/robot-team-eval.spec.ts` rewritten to cover the redirect + the embedded intake (desktop + mobile).

## Verification (local)

- `npm run check` (tsc): **0 errors**
- `npm run claims:guard`: **0 findings**
- `npx vitest run`: **1711/1711** pass, incl. `build-output` **7/7** on a forced fresh build
- Fresh build confirmed: `/robot-team/eval` no longer prerenders; the intake form + both new H1s are present in the built output; the pinned browser-JS strings remain bundled. (E2E isn't runnable in this environment — the pinned Playwright browser build isn't installable — so every expected e2e string was grepped against the built output instead.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012a4ogdQ4yDD1G1oENAJ53j

---
_Generated by [Claude Code](https://claude.ai/code/session_012a4ogdQ4yDD1G1oENAJ53j)_