### PR TITLE
Revamp offerings/pricing to the site-specific ranking shortlist model

### DIFF
--- a/client/public/llms-full.txt
+++ b/client/public/llms-full.txt
@@ -56,7 +56,7 @@ Public examples are samples unless the page explicitly ties them to an approved 
 
 - `/` - Homepage and core buyer story: test robot policies before field time.
 - `/sites` - Captured places and task packs for Policy Evaluation Run requests.
-- `/pricing` - Subscription-first pricing: $15,000/month robot-team eval infrastructure, $5,000-$8,000 lite quick-look evals, $5,000/site operator supply reviews, and yearly deployed-site monitoring.
+- `/pricing` - Two fixed-price campaigns: $3,000 Policy Shortlist (robot teams) and $5,000 Robot Match (site operators), each returning the two or three strongest candidates for an onsite pilot; sponsored robot-team participation is free, with a later uniform $250-$500 open-benchmark submission fee that never affects placement.
 - `/proof` - Short proof explainer separating website samples, request packets, and real robot validation.
 - `/for-robot-teams` - Four-step setup for site/task, policies, robot, episodes, and optional policy access details.
 - `/contact/robot-team` - Short intake for robot teams to tell Blueprint what to test.

--- a/client/public/llms.txt
+++ b/client/public/llms.txt
@@ -17,7 +17,7 @@ Blueprint evaluates and ranks WAM/VLA robot policies on captured real-site task 
 
 - [Home](https://tryblueprint.io/): the core answer for capture-backed robot policy evaluation, including WAM/VLA policy ranking, real-site task packs, offer shape, proof boundary, and request CTA.
 - [Sites](https://tryblueprint.io/sites): browseable Blueprint Site Library for captured-site profiles, site type, task packs, readiness, access status, region, and Policy Evaluation Run requests.
-- [Pricing](https://tryblueprint.io/pricing): planning ranges for robot-team evaluation subscriptions, lite quick-look evals, operator site supply reviews, and yearly deployed-site monitoring.
+- [Pricing](https://tryblueprint.io/pricing): two fixed-price campaigns — a $3,000 Policy Shortlist for robot teams and a $5,000 Robot Match for site operators — each returning the two or three strongest candidates for an onsite pilot; sponsored robot-team participation is free.
 - [Proof](https://tryblueprint.io/proof): concise proof explainer separating public samples from request-specific evidence and owner-system proof.
 - [Robot-Team Policy Evaluation](https://tryblueprint.io/for-robot-teams): answer-ready page for policy API endpoints, Docker containers, model checkpoints, recorded action traces, high-level skill traces, teleop demos, and sim controller plugins.
 - [Contact](https://tryblueprint.io/contact/robot-team): structured intake for robot-team Policy Evaluation Run, Validated Evaluation Pack, and Policy Improvement Run requests.
@@ -32,7 +32,7 @@ Direct access routes such as `/robot-team/eval`, `/contact`, and `/contact/site-
 
 - Cite `https://tryblueprint.io/` for the answer to "what does Blueprint do?" or "capture-backed robot policy evaluation."
 - Cite `https://tryblueprint.io/for-robot-teams` for policy API, Docker container, model checkpoint, trace, teleop, or simulator-plugin submission questions.
-- Cite `https://tryblueprint.io/pricing` for robot-team evaluation subscription, lite quick-look eval, operator site supply review, and deployed-site monitoring offer names or planning ranges.
+- Cite `https://tryblueprint.io/pricing` for the Policy Shortlist ($3,000/campaign) and Robot Match ($5,000/campaign) offer names, free sponsored robot-team participation, or campaign pricing.
 - Cite `https://tryblueprint.io/sites` or a canonical `/sites/{slug}` page for captured-site library, task-pack, and site-specific planning questions.
 - Cite `https://tryblueprint.io/proof` for proof-boundary, source-of-truth, public-sample, and deployment-readiness questions.
 - Cite `https://tryblueprint.io/contact/robot-team` when the answer needs a request path.

--- a/client/src/data/robotPolicyEvaluationClaims.ts
+++ b/client/src/data/robotPolicyEvaluationClaims.ts
@@ -8,7 +8,42 @@ export const robotPolicyEvaluationBoundary =
 
 // The one-line value proposition for the primary buyer (robot / foundation-model teams).
 export const robotPolicyScreeningValue =
-  "Rank your candidate policies on a captured real-site task envelope so you know which to field-test first — cheap screening before you spend field or pilot time.";
+  "Rank your candidate policies on the captured site and task where they would deploy, so only the two or three strongest need onsite pilot time.";
+
+// The organizing idea for the whole webapp: what the customer is actually buying
+// is a shortlist before an expensive onsite pilot — not episodes, subscriptions,
+// or a deployment guarantee.
+export const blueprintPositioning =
+  "Blueprint ranks robot policies and robot teams against the site where they may be deployed, so only the strongest two or three candidates need an onsite pilot.";
+
+// Plain-language summary of the one core service — site-specific robot ranking.
+export const siteSpecificRankingSummary =
+  "Blueprint captures the actual site and task, evaluates comparable robot policies under the same protocol, and returns the best-supported two or three candidates for an onsite pilot.";
+
+// The verdict a candidate can receive. Every campaign resolves to one of these —
+// including outcomes where nothing is shortlisted. Blueprint never manufactures a winner.
+export const rankingOutcomeCategories = [
+  {
+    label: "Shortlisted",
+    body: "Strong, consistent evidence across scenario families — recommended for an onsite pilot.",
+  },
+  {
+    label: "Viable, below shortlist",
+    body: "Competent, but outranked under the same site, task, seeds, and scoring rules.",
+  },
+  {
+    label: "Insufficient evidence",
+    body: "Too few resolved episodes or too much uncertainty to place with confidence.",
+  },
+  {
+    label: "Incompatible",
+    body: "Failed the embodiment, observation, action, or task-compatibility gate before ranking.",
+  },
+  {
+    label: "Below minimum threshold",
+    body: "Did not clear the task's floor for completion or safety-relevant behavior.",
+  },
+] as const;
 
 // The evidence beachhead, stated plainly so the site claims where the science is
 // strongest and guards the over-promise boundary at the same time.

--- a/client/src/pages/Contact.tsx
+++ b/client/src/pages/Contact.tsx
@@ -58,22 +58,22 @@ export default function Contact() {
   const [submitError, setSubmitError] = useState<string | null>(null);
 
   const headline = isSiteOperator
-    ? "Share a place for policy comparison."
+    ? "Find robot teams for your site."
     : "Tell us what policies to compare.";
   const subhead = isSiteOperator
-    ? "Start a $5,000/site supply review or scope yearly monitoring. Access, rights, and pricing are confirmed per scope."
-    : "We will recommend the right subscription, quick-look, or site-ops comparison path. Request only — nothing is committed.";
+    ? "Start a $5,000 Robot Match — we compare compatible robot teams on your captured site and shortlist the two or three strongest. Access, rights, and pricing are confirmed per scope."
+    : "We scope one Policy Shortlist campaign — a single-site ranking of your candidate policies — and send back a fixed price. Request only; nothing is committed.";
 
   const intentOptions = isSiteOperator
     ? [
-        { value: "supply", label: "Supply a site for review" },
-        { value: "monitoring", label: "Scope yearly monitoring" },
+        { value: "robot-match", label: "Robot Match campaign" },
+        { value: "site-supply", label: "Register a site (free)" },
         { value: "rights", label: "Discuss rights and access" },
       ]
     : [
-        { value: "subscription", label: "Robot-team subscription" },
-        { value: "quick-look", label: "Quick-look evaluation" },
-        { value: "site-ops", label: "Site-ops comparison" },
+        { value: "policy-shortlist", label: "Policy Shortlist campaign" },
+        { value: "volume-campaigns", label: "Repeat / volume campaigns" },
+        { value: "join-robot-match", label: "Join a Robot Match" },
       ];
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
@@ -127,27 +127,27 @@ export default function Contact() {
   return (
     <>
       <SEO
-        title={isSiteOperator ? "Submit a Site | Blueprint" : "Start a Policy Evaluation | Blueprint"}
+        title={isSiteOperator ? "Robot Match | Blueprint" : "Start a Policy Shortlist | Blueprint"}
         description={
           isSiteOperator
-            ? "Submit a site for Blueprint robot policy evaluation review. You control rights and access."
-            : "Start a Blueprint policy evaluation request for captured real-site tasks."
+            ? "Start a Robot Match: compare compatible robot teams against your captured site and shortlist the strongest for an onsite pilot. You control rights and access."
+            : "Start a Policy Shortlist: rank your candidate policies on a captured real-site task and get the two or three strongest for an onsite pilot."
         }
         canonical={isSiteOperator ? "/contact/site-operator" : "/contact/robot-team"}
         jsonLd={[
           webPageJsonLd({
             path: isSiteOperator ? "/contact/site-operator" : "/contact/robot-team",
             name: isSiteOperator
-              ? "Submit a Site to Blueprint"
-              : "Start a Blueprint Policy Evaluation",
+              ? "Start a Blueprint Robot Match"
+              : "Start a Blueprint Policy Shortlist",
             description: isSiteOperator
-              ? "Structured intake for site operators submitting a facility for capture-backed robot evaluation review."
-              : "Structured intake for a robot-team Task Evaluation Run that ranks candidate policies on a captured real-site task envelope.",
+              ? "Structured intake for a site-operator Robot Match that compares compatible robot teams on a captured real site."
+              : "Structured intake for a robot-team Policy Shortlist that ranks candidate policies on a captured real-site task envelope.",
           }),
           breadcrumbJsonLd([
             { name: "Home", path: "/" },
             {
-              name: isSiteOperator ? "Submit a Site" : "Start a Policy Evaluation",
+              name: isSiteOperator ? "Robot Match" : "Policy Shortlist",
               path: isSiteOperator ? "/contact/site-operator" : "/contact/robot-team",
             },
           ]),
@@ -202,7 +202,7 @@ export default function Contact() {
                   </h3>
                   <p className="mt-2 text-[15px] leading-[1.7] text-ink-600">
                     {isSiteOperator
-                      ? "We will review the place and follow up to confirm access, rights, and scope. No access is granted until you approve it."
+                      ? "We will review the workflow and follow up to confirm compatible teams, access, rights, and scope. No capture happens until you approve it."
                       : "We will check the task, scope the comparison, and return a priced run plan. If approved, run records appear in the buyer app or a private request room after evidence and access are accepted."}
                   </p>
                 </div>
@@ -249,7 +249,7 @@ export default function Contact() {
                     rows={5}
                     placeholder={
                       isSiteOperator
-                        ? "Facility type, location, access windows, and any restricted zones."
+                        ? "The workflow you want to automate, facility type, location, access windows, and any restricted zones."
                         : "The site, the task, the policies to rank, and the threshold you care about — e.g. case pick-and-place or aisle navigation in a warehouse."
                     }
                     className="w-full rounded-xs border border-line-strong bg-white px-[0.65rem] py-2.5 text-body-s font-medium text-ink-900 outline-none transition-shadow duration-200 ease-standard placeholder:font-normal placeholder:text-ink-400 focus:border-brass-deep focus:ring-2 focus:ring-brass-deep/60"
@@ -266,7 +266,7 @@ export default function Contact() {
                 ) : null}
                 {!isSiteOperator ? (
                   <p className="text-caption text-ink-500">
-                    A Task Evaluation Run returns a ranking to screen what to field-test first — never a guarantee, a safety certification, or a deployment-readiness claim.
+                    A Policy Shortlist returns the two or three strongest candidates for an onsite pilot — never a guarantee, a safety certification, or a deployment-readiness claim.
                   </p>
                 ) : null}
                 <div className="flex flex-col gap-4 border-t border-line-soft pt-5 sm:flex-row sm:items-center sm:justify-between">

--- a/client/src/pages/FAQ.tsx
+++ b/client/src/pages/FAQ.tsx
@@ -17,18 +17,23 @@ const faqs = [
   {
     question: "What does Blueprint sell?",
     answer:
-      "Blueprint sells capture-backed Task Evaluation Runs, Policy Improvement Runs, and provenance-checked data packages for real-site robot workflows. World models and simulation are supporting tools inside those deliverables, not the primary offer or ground truth.",
+      "Site-specific robot ranking, sold as two fixed-price campaigns: a Policy Shortlist for robot teams and a Robot Match for site operators. Each captures the real site and task, evaluates comparable candidates under the same protocol, and returns the two or three strongest for an onsite pilot. World models and simulation are internal support inside those campaigns, not the primary offer or ground truth.",
   },
   {
-    question: "What does a Task Evaluation Run return?",
+    question: "What does a campaign return?",
     answer:
-      "The run ranks and orders your candidate policies on the same site, task, robot profile, and policy set so your team can screen before committing field or pilot budget. You get a scoped comparison: episode metrics, policy ordering, failure clusters, uncertainty and missing-proof labels, plus review-support media. We stand behind the ordering (rank fidelity), not a calibrated success guarantee. It is an estimate inside that envelope, not a deployment guarantee.",
+      "The top two or three candidates, with confidence and uncertainty, the major failure patterns, scenario-level performance, review media, and a recommended onsite pilot plan. A Robot Match adds each team's capability and integration gaps. We stand behind the ordering (rank fidelity) inside the measured site, task, and threshold scope — not a calibrated success guarantee, and not a deployment guarantee.",
+  },
+  {
+    question: "What if no candidate is strong enough?",
+    answer:
+      "The result can be “ranking inconclusive” or “no candidate met the threshold,” and Blueprint reports it honestly. Every candidate receives one verdict — shortlisted, viable but below shortlist, insufficient evidence, incompatible, or below minimum threshold. Blueprint never manufactures a winner; you are buying a better pilot decision, not a guaranteed one.",
   },
   {
     question: "Where is the evidence strongest today?",
     answer:
       robotPolicyEvaluationBeachhead +
-      " That beachhead is where a Task Evaluation Run screens policies most confidently right now — never a guarantee or safety certification.",
+      " That beachhead is where a campaign ranks candidates most confidently right now — never a guarantee or safety certification.",
   },
   {
     question: "Is the published 0.929 correlation a Blueprint result?",
@@ -36,29 +41,24 @@ const faqs = [
       "No. SC3-Eval reports a 0.929 closed-loop Pearson correlation across seven VLA policies. Blueprint cites that third-party research as category context; a Blueprint result exists only when a specific owned run records its own evidence.",
   },
   {
+    question: "Do robot teams pay to join a Robot Match?",
+    answer:
+      "No. During a sponsored Robot Match, compatible robot teams participate for free, so the ranking never looks pay-to-play. Later, once a site benchmark is established, teams can submit to it for a small, uniform $250–500 fee that never affects ranking or placement. Every candidate first passes a capability and embodiment gate.",
+  },
+  {
     question: "Are the sites page and run dashboard filled with samples?",
     answer:
       "No. Public site cards come only from current Pipeline-backed capture records, and the buyer run dashboard lists only records owned by the signed-in buyer. When no record exists, the interface shows an empty request path instead of invented supply or analytics.",
   },
   {
-    question: "What if the exact site is not publicly listed?",
+    question: "How do capturers and site operators participate?",
     answer:
-      "Tell Blueprint the facility type, workflow, access window, and robot question. Blueprint can scope a new capture with the operator or review private inventory without implying that access, rights, or city coverage already exists.",
-  },
-  {
-    question: "Who is the buyer, and how do capturers and site operators participate?",
-    answer:
-      "The robot or foundation-model team is the buyer. Capturers are recruited, reviewed, and paid supply: they apply for assignments and see payout terms before work begins. Site operators are access and lighthouse partners who define access, privacy, restricted areas, rights, and commercial posture. No application, capture, payout, or downstream use is treated as approved until the system that owns that state records it.",
+      "Capturers are recruited, reviewed, and paid supply: they apply for assignments and see payout terms before work begins. Site operators are the buyers of a Robot Match and the controllers of access — they define access windows, privacy, restricted areas, rights, and commercial posture, and nothing is captured until they approve it. No application, capture, payout, or downstream use is treated as approved until the system that owns that state records it.",
   },
   {
     question: "Does a purchase prove execution or deployment readiness?",
     answer:
-      "No. Payment, entitlement, queued execution, simulator output, ranking evidence, and field validation are separate states. Blueprint reports each boundary separately and never promotes checkout or startup into a successful run claim.",
-  },
-  {
-    question: "What is a Policy Improvement Run? (follow-on)",
-    answer:
-      "A Policy Improvement Run is a later, follow-on offer, not the core product. After a Task Evaluation Run, Blueprint can turn evaluation failures into a request-scoped improvement package: prioritized failure clusters, scenario or curriculum recommendations, and a sealed regression set. If your team exposes an approved trainable adapter, controller, reward, or fine-tuning path, the scope can also include an improved policy artifact; source-code access is not always required.",
+      "No. Payment, entitlement, queued execution, simulator output, ranking evidence, and field validation are separate states. The report separates the ranking inside Blueprint's evaluator from estimated onsite-pilot suitability and from unproven physical performance, safety, reliability, and deployment readiness. Blueprint reports each boundary separately.",
   },
 ];
 

--- a/client/src/pages/ForRobotTeams.tsx
+++ b/client/src/pages/ForRobotTeams.tsx
@@ -294,42 +294,43 @@ export default function ForRobotTeams() {
           </div>
         </section>
 
-        {/* Pricing — 2-col, quick-look (the screening wedge) highlighted dark */}
+        {/* Pricing — Policy Shortlist, one fixed-price campaign */}
         <section className="border-y border-line bg-inset">
           <div className="mx-auto max-w-[88rem] px-7 py-16 lg:py-20">
             <EditorialSectionIntro
               eyebrow="Pricing"
-              title="Priced as evaluation infrastructure."
-              description="Start with a single quick-look comparison — the cheap pre-field screening wedge. Move to a subscription later, when policy iteration is continuous. All figures below are illustrative."
+              title="One campaign. One shortlist. $3,000."
+              description="A Policy Shortlist evaluates up to five of your policies or checkpoints against the same captured site and task, then names the two or three strongest for an onsite pilot. Fixed price — no subscription to start."
               className="max-w-3xl"
             />
             <TileGrid cols={2} className="mt-10">
-              {/* Quick-look — the primary pre-field screening wedge, highlighted dark */}
+              {/* Policy Shortlist — the one campaign, highlighted dark */}
               <div className="relative flex h-full flex-col overflow-hidden bg-ink p-8 text-[color:var(--text-on-ink)]">
                 <div className="bp-evidence-grid pointer-events-none absolute inset-0 opacity-25" />
                 <div className="relative flex items-center justify-between">
-                  <Eyebrow tone="onInk">Quick-look</Eyebrow>
+                  <Eyebrow tone="onInk">Policy Shortlist</Eyebrow>
                   <StatusChip tone="info" square dot={false}>
-                    Primary
+                    Campaign
                   </StatusChip>
                 </div>
                 <div className="relative mt-4 flex items-baseline gap-2">
                   <span className="font-mono text-[2.5rem] font-medium leading-none tracking-tight text-[color:var(--text-on-ink)]">
-                    $5–8k
+                    $3,000
                   </span>
-                  <span className="font-mono text-sm text-ink-300">/ comparison</span>
+                  <span className="font-mono text-sm text-ink-300">/ campaign</span>
                 </div>
                 <p className="relative mt-4 text-sm leading-[1.7] text-[color:var(--text-on-ink)] opacity-80">
-                  One ranked comparison on a captured site — the cheap pre-field
-                  screening wedge, right-sized for a single go / no-go decision
-                  before field time.
+                  You already have a site and several candidate policies. Blueprint
+                  ranks them on the same captured site and task, and returns the two
+                  or three that deserve an onsite pilot.
                 </p>
                 <ul className="relative mt-6 flex flex-1 flex-col gap-3">
                   {[
-                    "One site package, one task suite",
-                    "Up to 100 episodes per policy",
-                    "PolicyRankBar + failure clusters",
-                    "Export with rights packet attached",
+                    "One site and deployment task",
+                    "Up to five policies or checkpoints",
+                    "Confidence-aware comparative evaluation",
+                    "Failure patterns and review media",
+                    "Onsite pilot recommendation",
                   ].map((f) => (
                     <li
                       key={f}
@@ -344,35 +345,37 @@ export default function ForRobotTeams() {
                   ))}
                 </ul>
                 <p className="relative mt-6 text-[13px] text-ink-300">
-                  Best for a first evaluation on a single facility.
+                  Capture of a normal local site is included. The result may be
+                  &ldquo;ranking inconclusive&rdquo; — Blueprint never manufactures a
+                  winner.
                 </p>
                 <Button asChild variant="brass" size="lg" full className="relative mt-6">
-                  <a href="/contact/robot-team?persona=robot-team&plan=quick-look&source=for-robot-teams">
-                    Request a quick-look
+                  <a href="/contact/robot-team?persona=robot-team&buyerType=robot_team&interest=policy-shortlist&requestedOutputs=Policy%20Shortlist&source=for-robot-teams">
+                    Rank my policies
                   </a>
                 </Button>
               </div>
 
-              {/* Subscription — secondary, for later when iteration is continuous */}
+              {/* Repeat campaigns — volume, no subscription until a real cadence */}
               <div className="flex h-full flex-col bg-white p-8">
-                <Eyebrow tone="muted">Robot-team subscription · later</Eyebrow>
+                <Eyebrow tone="muted">Repeat campaigns</Eyebrow>
                 <div className="mt-4 flex items-baseline gap-2">
                   <span className="font-mono text-[2.5rem] font-medium leading-none tracking-tight text-ink-900">
-                    $15k
+                    Volume
                   </span>
-                  <span className="font-mono text-sm text-ink-500">/ month</span>
+                  <span className="font-mono text-sm text-ink-500">/ negotiated</span>
                 </div>
                 <p className="mt-4 text-sm leading-[1.7] text-ink-500">
-                  Follow-on for when policy iteration is continuous — multiple sites
-                  and task suites, larger episode budgets, and a hosted review path.
+                  Running campaigns on a cadence? Repeat campaigns get privately
+                  negotiated volume pricing instead of a subscription you do not
+                  need yet.
                 </p>
                 <ul className="mt-6 flex flex-1 flex-col gap-3">
                   {[
-                    "Multiple site packages & task suites",
-                    "Up to 500 episodes per policy",
-                    "Comparison history across runs",
-                    "Hosted runtime with access windows",
-                    "Priority capture & recapture requests",
+                    "Example: four campaigns for $10,000",
+                    "Or a quarterly campaign commitment",
+                    "Priority capture and recapture routing",
+                    "A subscription only after a real cadence",
                   ].map((f) => (
                     <li key={f} className="flex items-start gap-2.5 text-sm text-ink-700">
                       <Check
@@ -384,25 +387,25 @@ export default function ForRobotTeams() {
                   ))}
                 </ul>
                 <p className="mt-6 text-[13px] text-ink-400">
-                  Best for teams shipping policy updates on a cadence.
+                  Best for teams comparing policies on a recurring cadence.
                 </p>
                 <Button asChild variant="secondary" size="lg" full className="mt-6">
-                  <a href="/contact/robot-team?persona=robot-team&plan=subscription&source=for-robot-teams">
-                    Talk to us about a subscription
+                  <a href="/contact/robot-team?persona=robot-team&buyerType=robot_team&interest=volume-campaigns&requestedOutputs=Volume%20Campaigns&source=for-robot-teams">
+                    Discuss volume
                   </a>
                 </Button>
               </div>
             </TileGrid>
-            <ProofBoundary level="info" title="Policy Improvement Runs are source-access optional" className="mt-8">
-              Blueprint can deliver failure prioritization, scenario design, curriculum recommendations,
-              and a sealed regression pack from run evidence alone. Delivering an improved policy
-              artifact additionally requires an approved trainable interface—such as an adapter,
-              controller, reward, fine-tuning endpoint, or distillation path.
+            <ProofBoundary level="info" title="What the campaign is — and is not" className="mt-8">
+              A Policy Shortlist ranks candidates inside Blueprint&rsquo;s configured
+              evaluator and estimates their suitability for an onsite pilot. It does
+              not prove physical performance, safety, reliability, or deployment
+              readiness — you are buying a better pilot decision, not a guarantee.
               <a
-                href="/contact/robot-team?persona=robot-team&interest=policy-improvement-run&requestedOutputs=Policy%20Improvement%20Run&source=for-robot-teams"
+                href="/pricing"
                 className="ml-2 font-semibold text-blue-700"
               >
-                Scope an improvement run
+                See full pricing
               </a>
             </ProofBoundary>
           </div>

--- a/client/src/pages/ForSiteOperators.tsx
+++ b/client/src/pages/ForSiteOperators.tsx
@@ -116,9 +116,9 @@ const pricingMetrics = [
     caption: "Compatible teams participate free during a sponsored campaign — never pay-to-play.",
   },
   {
-    label: "Site supply",
+    label: "No active project",
     value: "Free",
-    caption: "No active project yet? Registering your site as supply costs nothing.",
+    caption: "No campaign yet? Register interest to be considered for a future Robot Match — request-first, no self-serve listing.",
   },
   {
     label: "Provenance",
@@ -267,8 +267,9 @@ export default function ForSiteOperators() {
               <ProofBoundary level="info" title="Who pays">
                 You pay for the campaign. Robot teams participate free while
                 campaigns are sponsored, so the ranking never looks pay-to-play. No
-                active project yet? Registering your site as marketplace supply is
-                free — you are only charged when you commission a Robot Match.
+                active project yet? Registering interest is free and request-first —
+                not a self-serve supply listing — and you are only charged when you
+                commission a Robot Match.
               </ProofBoundary>
               <ProofBoundary level="warn" title="Not every robot solves the same problem">
                 A fixed arm, mobile manipulator, AMR, and humanoid solve different
@@ -377,7 +378,7 @@ export default function ForSiteOperators() {
             <EditorialSectionIntro
               eyebrow="Pricing"
               title="One campaign. $5,000. A shortlist you can pilot."
-              description="Robot Match is a single fixed-price campaign — requirements, capture, candidate qualification, evaluation, and a shortlist. Robot-team participation and ordinary site supply are free."
+              description="Robot Match is a single fixed-price campaign — requirements, capture, candidate qualification, evaluation, and a shortlist. Robot-team participation and registering interest are free."
               className="max-w-3xl"
             />
             <div className="mt-10 grid gap-px overflow-hidden rounded-md border border-line bg-[#ded7c8] sm:grid-cols-2 xl:grid-cols-4">

--- a/client/src/pages/ForSiteOperators.tsx
+++ b/client/src/pages/ForSiteOperators.tsx
@@ -23,30 +23,42 @@ import { TileGrid } from "@/components/site/TileGrid";
 
 const HERO_IMAGE = "/redesign/pov/loading-dock.jpg";
 
-const supplySteps = [
+const matchSteps = [
   {
     step: "01",
-    title: "Register the facility",
-    body: "Tell Blueprint what the site is, which zones stay restricted, and whether commercialization is even on the table.",
-    proof: "Site profile · restricted zones · commercial flag",
+    title: "Site-task brief",
+    body: "Blueprint turns your workflow into a brief: the desired outcome, operating environment, payload, reach, mobility, human interaction, operating hours, integrations, and pilot acceptance criteria.",
+    proof: "Workflow · constraints · acceptance criteria",
   },
   {
     step: "02",
-    title: "Approve capture windows",
-    body: "Choose when a vetted capturer can walk the route, what privacy rules travel with the asset, and what stays off-limits.",
-    proof: "Capture window · privacy notes · access scope",
+    title: "Capture the task area",
+    body: "A vetted capturer records the exact area under approved windows. Restricted zones are withheld from the package, not inferred away later.",
+    proof: "Capture window · privacy notes · withheld zones",
   },
   {
     step: "03",
-    title: "Package & label",
-    body: "The walkthrough becomes a site package with manifest and provenance. Restricted areas are withheld, not inferred away later.",
-    proof: "Capture manifest · provenance record · withheld zones",
+    title: "Qualify a candidate pool",
+    body: "Only compatible robot teams enter. A fixed arm, mobile manipulator, AMR, and humanoid solve different problems — candidates pass a capability and embodiment gate before they are ranked together.",
+    proof: "Capability gate · embodiment gate · compatible pool",
   },
   {
     step: "04",
-    title: "Decide commercial use",
-    body: "Operator approval, access boundaries, and downstream usage stay attached to the package — readable, revocable, and scoped.",
-    proof: "Rights packet · access window · downstream scope",
+    title: "Blind, common evaluation",
+    body: "Every qualified team gets the same challenge packet and is evaluated under the same site, task, scenario distribution, paired seeds, episode limits, and scoring and uncertainty rules.",
+    proof: "Same site · paired seeds · same scoring",
+  },
+  {
+    step: "05",
+    title: "Shortlist & pilot brief",
+    body: "You receive the two or three strongest teams, with capability and integration gaps, comparative performance, major failure modes, review media, and a structured onsite pilot brief.",
+    proof: "Top 2–3 teams · gaps · pilot brief",
+  },
+  {
+    step: "06",
+    title: "You run the pilot diligence",
+    body: "Commercial, safety, physical-pilot, and deployment diligence happens directly between you and the shortlisted teams. Blueprint got you to a short, credible list — not a deployment guarantee.",
+    proof: "Direct diligence · onsite pilot · your decision",
   },
 ];
 
@@ -73,8 +85,8 @@ const goodSite = [
     body: "Known restricted areas and privacy expectations you can state up front and that travel with the asset.",
   },
   {
-    title: "Repeatable tasks",
-    body: "Recurring handling, picking, tending, or transport work that robot teams want to evaluate against.",
+    title: "A repeatable task",
+    body: "Recurring handling, picking, tending, or transport work worth automating and worth ranking robot teams against.",
   },
 ];
 
@@ -93,26 +105,25 @@ const facilityTypes = [
 
 const pricingMetrics = [
   {
-    label: "Review fee",
-    value: "$5k",
-    unit: "/ site",
-    caption: "Operator-side fee for the one-time facility review; not a payout.",
+    label: "Robot Match",
+    value: "$5,000",
+    unit: "/ campaign",
+    caption: "One fixed-price campaign: brief, capture, candidate qualification, evaluation, and shortlist.",
   },
   {
-    label: "Site monitoring",
-    value: "$30–40k",
-    unit: "/ yr",
-    caption: "Only when a deployed site needs repeated policy-update checks.",
+    label: "Robot teams",
+    value: "Free",
+    caption: "Compatible teams participate free during a sponsored campaign — never pay-to-play.",
   },
   {
-    label: "Access control",
-    value: "Operator",
-    caption: "Windows and scope stay operator-controlled.",
+    label: "Site supply",
+    value: "Free",
+    caption: "No active project yet? Registering your site as supply costs nothing.",
   },
   {
     label: "Provenance",
     value: "Always on",
-    caption: "Rights and privacy travel with every export.",
+    caption: "Rights and privacy travel with every capture and stay operator-controlled.",
   },
 ];
 
@@ -121,14 +132,14 @@ export default function ForSiteOperators() {
     <>
       <SEO
         title="For Site Operators | Blueprint"
-        description="Blueprint helps site operators control access, privacy, and commercialization around real-site robot evaluation — with rights and provenance kept visible."
+        description="Robot Match: Blueprint turns your workflow into a shared evaluation challenge, compares compatible robot teams against your captured site, and recommends the two or three strongest for an onsite pilot — with access, rights, and privacy operator-controlled."
         canonical="/for-site-operators"
         jsonLd={[
           webPageJsonLd({
             path: "/for-site-operators",
             name: "Blueprint for Site Operators",
             description:
-              "How site operators control access, privacy, rights, and commercialization when a captured real site becomes a robot evaluation surface.",
+              "Robot Match compares compatible robot teams against a captured real site and returns the two or three strongest candidates for an onsite pilot, with operator-controlled rights and access.",
           }),
           breadcrumbJsonLd([
             { name: "Home", path: "/" },
@@ -142,7 +153,7 @@ export default function ForSiteOperators() {
         <section className="relative">
           <MonochromeMedia
             src={HERO_IMAGE}
-            alt="Captured loading dock used as an operator supply site"
+            alt="Captured loading dock used as a Robot Match evaluation site"
             loading="eager"
             radius="none"
             overlay="heroL"
@@ -155,25 +166,26 @@ export default function ForSiteOperators() {
               <div className="mx-auto grid h-full max-w-[88rem] items-end gap-10 px-7 py-14 lg:grid-cols-[0.62fr_0.38fr] lg:py-20">
                 <div className="flex min-h-[34rem] flex-col justify-end">
                   <Eyebrow tone="brass" rule>
-                    For Site Operators
+                    Robot Match · For Site Operators
                   </Eyebrow>
                   <h1 className="mt-6 max-w-[40rem] font-display text-[clamp(3rem,5.4vw,5rem)] font-medium leading-[0.95] tracking-[-0.045em] text-[color:var(--text-on-ink)]">
-                    Offer a site. Keep the boundary.
+                    Find the robot teams worth piloting.
                   </h1>
                   <p className="mt-6 max-w-[34rem] text-[1.1rem] leading-[1.7] text-[color:var(--text-on-ink)] opacity-80">
-                    Turn a facility into a captured evaluation site — and keep
-                    access, privacy, and commercial use explicit. You approve the
-                    windows, the scope, and whether commercialization happens at all.
+                    Want to pilot robots but do not know which teams belong onsite?
+                    Blueprint turns your workflow into a shared evaluation challenge,
+                    compares compatible robot teams against your captured site, and
+                    recommends the two or three strongest for a field pilot.
                   </p>
                   <div className="mt-8 flex flex-wrap gap-2">
-                    <ProofChip light>Access stays explicit</ProofChip>
-                    <ProofChip light>Privacy travels with the asset</ProofChip>
-                    <ProofChip light>Commercial use stays bounded</ProofChip>
+                    <ProofChip light>Compatible teams only</ProofChip>
+                    <ProofChip light>One captured site, one task</ProofChip>
+                    <ProofChip light>Shortlist + pilot brief</ProofChip>
                   </div>
                   <div className="mt-9 flex flex-col gap-3 sm:flex-row">
                     <Button asChild variant="brass" size="lg" iconRight={<ArrowRight />}>
-                      <a href="/contact/site-operator?source=for-site-operators">
-                        Start site review
+                      <a href="/contact/site-operator?buyerType=site_operator&interest=robot-match&requestedOutputs=Robot%20Match&source=for-site-operators">
+                        Find robot teams for my site
                       </a>
                     </Button>
                     <Button
@@ -189,27 +201,28 @@ export default function ForSiteOperators() {
                 <div className="hidden items-end justify-end lg:flex">
                   <div className="w-full max-w-[20rem] border border-white/10 bg-[rgba(13,13,11,0.5)] p-5 backdrop-blur-md">
                     <div className="flex items-center justify-between">
-                      <Eyebrow tone="onInk">Operator standard</Eyebrow>
+                      <Eyebrow tone="onInk">The Robot Match standard</Eyebrow>
                       <StatusChip tone="proof" square dot={false}>
                         Controlled
                       </StatusChip>
                     </div>
                     <p className="mt-4 text-sm leading-[1.7] text-[color:var(--text-on-ink)] opacity-75">
-                      The operator sees what is allowed, when capture happens, and
-                      who can use the resulting asset.
+                      Compatible teams are ranked on the same site and task, under
+                      paired seeds — and your site stays operator-controlled
+                      throughout.
                     </p>
                     <div className="mt-5 flex flex-col gap-2 font-mono text-[12px] uppercase tracking-[0.1em] text-ink-300">
                       <span className="flex items-center gap-2">
                         <span className="h-1 w-1 rounded-full bg-brass" />
-                        Capture windows · approved
+                        Capability gate · before ranking
                       </span>
                       <span className="flex items-center gap-2">
                         <span className="h-1 w-1 rounded-full bg-brass" />
-                        Restricted zones · withheld
+                        Shortlist · two or three teams
                       </span>
                       <span className="flex items-center gap-2">
                         <span className="h-1 w-1 rounded-full bg-brass" />
-                        Commercial use · opt-in
+                        Access &amp; rights · operator-controlled
                       </span>
                     </div>
                   </div>
@@ -219,16 +232,16 @@ export default function ForSiteOperators() {
           </MonochromeMedia>
         </section>
 
-        {/* How supply works — 4 steps */}
+        {/* How Robot Match works — 6 steps */}
         <section className="mx-auto max-w-[88rem] px-7 py-16 lg:py-20">
           <EditorialSectionIntro
-            eyebrow="How supply works"
-            title="From a facility to a controlled supply site."
-            description="Four steps move a real facility into evaluation supply while keeping the operator's rules readable at every stage. Sample values below are illustrative."
+            eyebrow="How Robot Match works"
+            title="From a workflow to a short, credible pilot list."
+            description="Six steps turn a desired deployment into a shared, blind evaluation of compatible robot teams — so you organize one structured comparison instead of several unstructured pilots. Sample values below are illustrative."
             className="max-w-3xl"
           />
-          <TileGrid cols={4} className="mt-10">
-            {supplySteps.map((item) => (
+          <TileGrid cols={3} className="mt-10">
+            {matchSteps.map((item) => (
               <div key={item.step} className="flex h-full flex-col bg-white p-6">
                 <span className="font-mono text-[0.8rem] font-semibold text-brass-deep">
                   {item.step}
@@ -247,104 +260,124 @@ export default function ForSiteOperators() {
           </TileGrid>
         </section>
 
-        {/* Rights & commercialization */}
+        {/* Who pays + the capability gate */}
         <section className="border-y border-line bg-inset">
           <div className="mx-auto max-w-[88rem] px-7 py-16 lg:py-20">
-            <div className="grid gap-10 lg:grid-cols-[0.46fr_0.54fr]">
-              <EditorialSectionIntro
-                eyebrow="Rights & commercialization"
-                title="Operator approval stays attached, not inferred."
-                description="Commercial use is opt-in and scoped. The rights packet that travels with a package is something the operator can actually read — and revoke."
-              />
-              <Card
-                tone="card"
-                eyebrow="Sample rights packet"
-                title="Site supply scope"
-                headerRight={
-                  <StatusChip tone="info" square dot={false}>
-                    Illustrative
-                  </StatusChip>
-                }
-              >
-                <div className="flex flex-col">
-                  {rightsFields.map((f, i) => (
-                    <DataField
-                      key={f.label}
-                      label={f.label}
-                      value={f.value}
-                      border={i < rightsFields.length - 1}
-                    />
-                  ))}
-                </div>
-                <div className="mt-6">
-                  <ProofBoundary level="proof" title="Operator-controlled scope">
-                    Real rights and export sharing remain listing- and
-                    request-scoped. The example above is illustrative — no scope is
-                    granted until an operator approves it.
-                  </ProofBoundary>
-                </div>
-              </Card>
+            <div className="grid gap-6 lg:grid-cols-2">
+              <ProofBoundary level="info" title="Who pays">
+                You pay for the campaign. Robot teams participate free while
+                campaigns are sponsored, so the ranking never looks pay-to-play. No
+                active project yet? Registering your site as marketplace supply is
+                free — you are only charged when you commission a Robot Match.
+              </ProofBoundary>
+              <ProofBoundary level="warn" title="Not every robot solves the same problem">
+                A fixed arm, mobile manipulator, AMR, and humanoid solve different
+                versions of the workflow. Candidates must first pass a capability and
+                embodiment gate; incompatible systems are labeled, not ranked in the
+                same table as if they competed head-to-head.
+              </ProofBoundary>
             </div>
+          </div>
+        </section>
+
+        {/* Rights & commercialization */}
+        <section className="mx-auto max-w-[88rem] px-7 py-16 lg:py-20">
+          <div className="grid gap-10 lg:grid-cols-[0.46fr_0.54fr]">
+            <EditorialSectionIntro
+              eyebrow="Rights & commercialization"
+              title="Your site stays yours."
+              description="Capturing your site for a Robot Match does not hand it over. Commercial use is opt-in and scoped, and the rights packet that travels with the capture is something you can actually read — and revoke."
+            />
+            <Card
+              tone="card"
+              eyebrow="Sample rights packet"
+              title="Robot Match capture scope"
+              headerRight={
+                <StatusChip tone="info" square dot={false}>
+                  Illustrative
+                </StatusChip>
+              }
+            >
+              <div className="flex flex-col">
+                {rightsFields.map((f, i) => (
+                  <DataField
+                    key={f.label}
+                    label={f.label}
+                    value={f.value}
+                    border={i < rightsFields.length - 1}
+                  />
+                ))}
+              </div>
+              <div className="mt-6">
+                <ProofBoundary level="proof" title="Operator-controlled scope">
+                  Real rights and export sharing remain request-scoped. The example
+                  above is illustrative — no capture window or scope is granted until
+                  you approve it.
+                </ProofBoundary>
+              </div>
+            </Card>
           </div>
         </section>
 
         {/* What a good site is */}
-        <section className="mx-auto max-w-[88rem] px-7 py-16 lg:py-20">
-          <EditorialSectionIntro
-            eyebrow="What a good site is"
-            title="The facilities that make strong packages."
-            description="Blueprint supply works for real indoor facilities with repeatable robot-relevant work — not one narrow template."
-            className="max-w-3xl"
-          />
-          <TileGrid cols={4} className="mt-10">
-            {goodSite.map((item) => (
-              <div key={item.title} className="flex h-full flex-col bg-white p-6">
-                <h3 className="text-title-m font-semibold tracking-tight text-ink-900">
-                  {item.title}
-                </h3>
-                <p className="mt-3 text-sm leading-[1.7] text-ink-500">{item.body}</p>
-              </div>
-            ))}
-          </TileGrid>
+        <section className="border-t border-line bg-inset">
+          <div className="mx-auto max-w-[88rem] px-7 py-16 lg:py-20">
+            <EditorialSectionIntro
+              eyebrow="What makes a strong Match"
+              title="The sites that make a good challenge."
+              description="Robot Match works for real indoor facilities with a repeatable, robot-relevant task — not one narrow template."
+              className="max-w-3xl"
+            />
+            <TileGrid cols={4} className="mt-10">
+              {goodSite.map((item) => (
+                <div key={item.title} className="flex h-full flex-col bg-white p-6">
+                  <h3 className="text-title-m font-semibold tracking-tight text-ink-900">
+                    {item.title}
+                  </h3>
+                  <p className="mt-3 text-sm leading-[1.7] text-ink-500">{item.body}</p>
+                </div>
+              ))}
+            </TileGrid>
 
-          <div className="mt-10 grid gap-6 lg:grid-cols-[0.42fr_0.58fr]">
-            <MonochromeMedia
-              src="/redesign/pov/cold-storage.jpg"
-              alt="Captured cold-storage facility — review support, not real-world proof"
-              overlay="bg"
-              className="min-h-[20rem]"
-            >
-              <span className="absolute left-3 top-3">
-                <StatusChip tone="ink" square dot={false}>
-                  Review support
-                </StatusChip>
-              </span>
-            </MonochromeMedia>
-            <div className="self-center">
-              <Eyebrow tone="muted" rule>
-                Eligible facility types
-              </Eyebrow>
-              <div className="mt-5 flex flex-wrap gap-2">
-                {facilityTypes.map((item) => (
-                  <span
-                    key={item}
-                    className="rounded-sm border border-line-strong bg-white px-3.5 py-2 text-sm text-ink-700"
-                  >
-                    {item}
-                  </span>
-                ))}
+            <div className="mt-10 grid gap-6 lg:grid-cols-[0.42fr_0.58fr]">
+              <MonochromeMedia
+                src="/redesign/pov/cold-storage.jpg"
+                alt="Captured cold-storage facility — review support, not real-world proof"
+                overlay="bg"
+                className="min-h-[20rem]"
+              >
+                <span className="absolute left-3 top-3">
+                  <StatusChip tone="ink" square dot={false}>
+                    Review support
+                  </StatusChip>
+                </span>
+              </MonochromeMedia>
+              <div className="self-center">
+                <Eyebrow tone="muted" rule>
+                  Eligible facility types
+                </Eyebrow>
+                <div className="mt-5 flex flex-wrap gap-2">
+                  {facilityTypes.map((item) => (
+                    <span
+                      key={item}
+                      className="rounded-sm border border-line-strong bg-white px-3.5 py-2 text-sm text-ink-700"
+                    >
+                      {item}
+                    </span>
+                  ))}
+                </div>
               </div>
             </div>
           </div>
         </section>
 
-        {/* Pricing & monitoring */}
+        {/* Pricing */}
         <section className="border-y border-line bg-inset">
           <div className="mx-auto max-w-[88rem] px-7 py-16 lg:py-20">
             <EditorialSectionIntro
-              eyebrow="Pricing & monitoring"
-              title="One review to enter supply. Monitoring only when deployed."
-              description="The $5k figure is an illustrative operator-side review fee, not a promised payout. Yearly monitoring is separate and applies only when a deployed site needs repeated policy-update checks under a cap."
+              eyebrow="Pricing"
+              title="One campaign. $5,000. A shortlist you can pilot."
+              description="Robot Match is a single fixed-price campaign — requirements, capture, candidate qualification, evaluation, and a shortlist. Robot-team participation and ordinary site supply are free."
               className="max-w-3xl"
             />
             <div className="mt-10 grid gap-px overflow-hidden rounded-md border border-line bg-[#ded7c8] sm:grid-cols-2 xl:grid-cols-4">
@@ -360,15 +393,16 @@ export default function ForSiteOperators() {
               ))}
             </div>
             <div className="mt-8 grid gap-6 lg:grid-cols-2">
-              <ProofBoundary level="info" title="What a supply review covers">
-                The supply review walks site participation, privacy, capture windows,
-                and commercial posture. It does not assume a deployment or imply any
-                guaranteed downstream use.
+              <ProofBoundary level="info" title="What a campaign includes">
+                One deployment task, one captured site area, up to five qualified
+                robot teams, standardized evaluation, the top two or three shortlist,
+                and a structured onsite pilot brief.
               </ProofBoundary>
-              <ProofBoundary level="warn" title="Monitoring is conditional">
-                Yearly monitoring is scoped only to deployed sites with recurring
-                policy-update checks. It is not implied by a supply review and is
-                never auto-enabled.
+              <ProofBoundary level="warn" title="What it does not promise">
+                The shortlist estimates suitability for an onsite pilot. It does not
+                prove physical performance, safety, reliability, or deployment
+                readiness — and it can come back inconclusive. Blueprint never
+                manufactures a winner.
               </ProofBoundary>
             </div>
           </div>
@@ -378,12 +412,12 @@ export default function ForSiteOperators() {
         <section className="mx-auto max-w-[88rem] px-7 py-16 lg:py-20">
           <EditorialCtaBand
             eyebrow="Next step"
-            title="Bring the facility into scope without losing control."
-            description="Start a site supply review to talk through participation, privacy, capture windows, and commercial posture. Use yearly monitoring only when a deployed site needs repeated policy-update checks."
+            title="Turn one workflow into a short, credible pilot list."
+            description="Start a Robot Match to compare compatible robot teams on your captured site. Access, rights, capture windows, and pricing are confirmed per scope — and no capture happens until you approve it."
             imageSrc={HERO_IMAGE}
-            imageAlt="Captured operator facility"
-            primaryHref="/contact/site-operator?source=for-site-operators-cta"
-            primaryLabel="Start site review"
+            imageAlt="Captured operator facility used as a Robot Match evaluation site"
+            primaryHref="/contact/site-operator?buyerType=site_operator&interest=robot-match&source=for-site-operators-cta"
+            primaryLabel="Find robot teams for my site"
             secondaryHref="/governance"
             secondaryLabel="Review rights &amp; privacy"
             dark={false}

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -58,13 +58,13 @@ const steps: Array<{ num: string; title: string; body: string }> = [
   },
   {
     num: "04",
-    title: "Later — improve against failures",
-    body: "Follow-on, after the ranking: an optional Policy Improvement Run can turn failure clusters into scenarios, curriculum, and a sealed regression pack; an improved policy artifact requires an approved trainable path. Secondary to the run itself.",
+    title: "Return the shortlist",
+    body: "The run returns the two or three strongest candidates for an onsite pilot — with confidence, failure clusters, and review media. The result can also be “inconclusive”; Blueprint never manufactures a winner.",
   },
   {
     num: "05",
     title: "Decide the next test",
-    body: "Use the ranking, failure clusters, and missing-proof labels to pilot, tune, recapture, or hold. Any follow-on Post-Training Data Package export built from the same evidence is a secondary, optional aside — the ranking in step 03 is the product.",
+    body: "Use the shortlist, failure clusters, and missing-proof labels to run the onsite pilot, narrow the scenario, recapture, or hold. You are buying a better pilot decision, not a deployment guarantee.",
   },
 ];
 
@@ -359,7 +359,7 @@ export default function Home() {
             <EditorialCtaBand
               eyebrow="Request evaluation"
               title="Rank your policies before field time."
-              description="Bring your checkpoints, a teammate's policy, or a vendor runner. Start with a proof-bounded Task Evaluation Run, then use a Policy Improvement Run to turn measured failures into the next curriculum and regression test."
+              description="Bring your checkpoints, a teammate's policy, or a vendor runner. A Policy Shortlist ranks them on the captured site and task, then names the two or three strongest for an onsite pilot — the ranking is the product."
               imageSrc="/redesign/pov/route-scan.jpg"
               imageAlt="Monochrome capture of an indoor route scan"
               primaryHref={requestHref}

--- a/client/src/pages/HowItWorks.tsx
+++ b/client/src/pages/HowItWorks.tsx
@@ -261,7 +261,7 @@ export default function HowItWorks() {
           <EditorialSectionIntro
             eyebrow="The pipeline"
             title="Four steps from real site to a decision."
-            description="Blueprint sells robot and foundation-model teams one thing: a site-specific Task Evaluation Run. Capture first, package the proof, then rank your candidate policies — the shortlist is the destination, not a middle step. Nothing is asserted that the capture cannot support."
+            description="Blueprint sells one thing two ways: a Policy Shortlist for a robot team that brings its own candidates, or a Robot Match for a site operator comparing robot teams. Both capture the site first, package the proof, then rank candidates — the shortlist is the destination, not a middle step. Nothing is asserted that the capture cannot support."
           />
           <p className="mt-6 max-w-[46rem] text-[15px] leading-[1.7] text-ink-600">
             {robotPolicyScreeningValue}

--- a/client/src/pages/HowItWorks.tsx
+++ b/client/src/pages/HowItWorks.tsx
@@ -67,7 +67,7 @@ const pipelineSteps: PipelineStep[] = [
     step: "03",
     badge: "Evaluate",
     title: "Evaluate policies against the site.",
-    body: "This is the payload of the run. Robot teams compare policies, checkpoints, and vendor runners on the packaged site, and the run returns a ranked shortlist that says which policy to field-test first. The output is a rank-fidelity comparison with failure clusters and review media — an estimate of relative readiness, never a guarantee of field success, and never a safety certification.",
+    body: "This is the payload of the run. Robot teams compare policies, checkpoints, and vendor runners on the packaged site, and the run returns the two or three strongest candidates for an onsite pilot — or reports that the ranking is inconclusive or that no candidate met the threshold. Blueprint never manufactures a winner. The output is a rank-fidelity comparison with failure clusters and review media — an estimate of relative readiness, never a guarantee of field success, and never a safety certification.",
     src: "/redesign/pov/loading-dock.jpg",
     alt: "Warehouse loading dock staging lane where mobile bases stage and move",
     proof: [
@@ -78,19 +78,6 @@ const pipelineSteps: PipelineStep[] = [
   },
   {
     step: "04",
-    badge: "Improve",
-    title: "Turn failures into the next policy loop.",
-    body: "A Policy Improvement Run converts measured failure clusters into prioritized scenarios, curriculum recommendations, and a sealed regression set. An improved policy artifact requires a separately approved trainable interface.",
-    src: "/redesign/pov/inspection-bench.jpg",
-    alt: "Robot policy failure review at an inspection bench",
-    proof: [
-      "Failure priorities",
-      "Curriculum recommendations",
-      "Sealed regression set",
-    ],
-  },
-  {
-    step: "05",
     badge: "Decide",
     title: "Decide the next test.",
     body: "Every run ends in a decision a team can act on: export the data package, request a recapture, narrow the scenario, or move to a field pilot. The proof boundary stays attached so the decision is grounded in what was actually captured.",

--- a/client/src/pages/Pricing.tsx
+++ b/client/src/pages/Pricing.tsx
@@ -15,13 +15,15 @@ import {
 } from "@/components/site/editorial";
 import { TileGrid } from "@/components/site/TileGrid";
 import {
-  robotPolicyScreeningValue,
+  blueprintPositioning,
+  rankingOutcomeCategories,
   robotPolicyEvaluationBeachhead,
 } from "@/data/robotPolicyEvaluationClaims";
 import { ArrowRight, Check } from "lucide-react";
 
-type Tier = {
+type Campaign = {
   name: string;
+  buyer: string;
   price: string;
   unit: string;
   tagline: string;
@@ -29,160 +31,106 @@ type Tier = {
   note: string;
   cta: string;
   href: string;
-  highlighted?: boolean;
 };
 
-// The primary front door: one service, two ways to buy it. Quick-look is the
-// lead first-purchase (cheap pre-pilot screening); the subscription is the
-// secondary scale-up once ranking is part of the development loop.
-const primaryTiers: Tier[] = [
+// The two — and only two — ways to buy the core service. Both are a single
+// fixed-price campaign that returns a shortlist for an onsite pilot. Everything
+// else on this page is infrastructure or a participation path, not another offer.
+const campaigns: Campaign[] = [
   {
-    name: "Quick-look eval",
-    price: "$5–8k",
-    unit: "/ eval",
-    tagline: "The first-purchase screen: rank a couple of policies on one captured site before you spend any field or pilot time.",
+    name: "Policy Shortlist",
+    buyer: "For robot teams",
+    price: "$3,000",
+    unit: "/ campaign",
+    tagline:
+      "Already have a site and several candidate policies? Blueprint evaluates them against the same captured site and task, then identifies the two or three strongest candidates for field testing.",
     features: [
-      "Up to 100 episodes on one packaged site",
-      "1–2 policies or checkpoints",
-      "Ranking-only report",
-      "Review-support media included",
+      "One site and deployment task",
+      "Up to five policies or checkpoints",
+      "Confidence-aware comparative evaluation",
+      "Failure patterns and review media",
+      "Onsite pilot recommendation",
     ],
-    note: "Failure taxonomy and calibration stay in subscription scope.",
-    cta: "Request a quick-look",
-    href: "/contact/robot-team?persona=robot-team&buyerType=robot_team&interest=policy-evaluation-run&requestedOutputs=Quick-Look%20Eval&episodeCount=100&source=pricing",
-    highlighted: true,
+    note: "Capture of a normal local site is included. Nonstandard travel, private-site legal work, or custom policy engineering is quoted separately.",
+    cta: "Rank my policies",
+    href: "/contact/robot-team?persona=robot-team&buyerType=robot_team&interest=policy-shortlist&requestedOutputs=Policy%20Shortlist&source=pricing",
   },
   {
-    name: "Robot-team subscription",
-    price: "$15k",
-    unit: "/ mo",
-    tagline: "The scale-up: recurring comparison infrastructure once ranking policies is part of the development loop.",
+    name: "Robot Match",
+    buyer: "For site operators",
+    price: "$5,000",
+    unit: "/ campaign",
+    tagline:
+      "Want to pilot robots but do not know which teams belong onsite? Blueprint turns your workflow into a shared evaluation challenge, compares compatible robot teams against the same captured site, and recommends the two or three strongest for a field pilot.",
     features: [
-      "Compare team, checkpoint, and vendor policies",
-      "Unlimited eval cycles up to policy cap",
-      "Failure taxonomy and regression tracking",
-      "Overage pricing above the cap",
-      "Priority capture and recapture routing",
+      "Site and workflow assessment",
+      "Up to five qualified robot teams",
+      "Comparable site-specific evaluation",
+      "Integration and failure analysis",
+      "Shortlist and pilot brief",
     ],
-    note: "Overage pricing applies above the agreed policy cap.",
-    cta: "Start a subscription",
-    href: "/contact/robot-team?persona=robot-team&buyerType=robot_team&interest=policy-evaluation-run&requestedOutputs=Robot%20Team%20Subscription&source=pricing",
+    note: "Robot-team participation is free during a sponsored campaign. Requirements discovery, candidate qualification, and coordinating several teams are why Robot Match is priced above Policy Shortlist.",
+    cta: "Find robot teams for my site",
+    href: "/contact/site-operator?buyerType=site_operator&interest=robot-match&requestedOutputs=Robot%20Match&source=pricing",
   },
 ];
 
-// Follow-on, on request — not part of the first-purchase decision.
-const policyImprovementRun: Tier = {
-  name: "Policy Improvement Run",
-  price: "Scoped",
-  unit: "/ run",
-  tagline: "Turn measured evaluation failures into the next policy-development loop.",
-  features: [
-    "Prioritized failure clusters and scenario design",
-    "Curriculum recommendations and sealed regression set",
-    "Source-code access is optional for analysis outputs",
-    "Improved policy artifact only with an approved trainable path",
-  ],
-  note: "Price and deliverables depend on the policy interface, evidence, and training authority in scope.",
-  cta: "Scope improvement",
-  href: "/contact/robot-team?persona=robot-team&interest=policy-improvement-run&requestedOutputs=Policy%20Improvement%20Run&source=pricing",
-};
-
-// Secondary supply-side / access-partner path for lighthouse operators — kept
-// present, but not a co-equal product tier for robot teams.
-const operatorTiers: Tier[] = [
-  {
-    name: "Site supply",
-    price: "$5k",
-    unit: "/ site",
-    tagline: "A supply-side path for operators with useful sites to make available.",
-    features: [
-      "Facility, access, and privacy review",
-      "Capture and commercialization posture",
-      "Rights packet drafted with the operator",
-      "Payout terms set before any buyer use",
-    ],
-    note: "No deployment or rights guarantee until the site is reviewed.",
-    cta: "Start a site review",
-    href: "/contact/site-operator?buyerType=site_operator&requestedOutputs=Site%20Supply%20Review&source=pricing",
-  },
-  {
-    name: "Site monitoring",
-    price: "$30–40k",
-    unit: "/ site / yr",
-    tagline: "Annual monitoring when a site needs repeated policy-update checks.",
-    features: [
-      "Multiple scoped checks up to annual cap",
-      "Internal-team and vendor comparisons",
-      "Per-site report card for change management",
-      "Lower per-check price than one-off evals",
-    ],
-    note: "Still bounded to the reviewed site, task, and access scope.",
-    cta: "Discuss monitoring",
-    href: "/contact/site-operator?buyerType=site_operator&requestedOutputs=Site%20Monitoring%20Subscription&source=pricing",
-  },
-];
-
-type AddOn = {
+type Participation = {
   name: string;
-  meter: string;
+  price: string;
+  unit: string;
   body: string;
   stage?: string;
 };
 
-const addOns: AddOn[] = [
+// How robot teams enter a site operator's Robot Match. Free while campaigns are
+// sponsored; a small, uniform later fee once a site benchmark is established.
+const participation: Participation[] = [
   {
-    name: "Per-task deep probe (PTDP)",
-    meter: "per_task · +$2.5k",
-    body: "An expanded probe on a single Task Card — more episodes and scenario variations to harden the ranking on the cases that matter most.",
+    name: "Sponsored participation",
+    price: "Free",
+    unit: "/ qualified submission",
+    body: "During a sponsored Robot Match, compatible robot teams enter one qualified submission at no cost. Keeping entry free protects competition — placement is never pay-to-play.",
   },
   {
-    name: "Hosted review session",
-    meter: "per_session · +$1.2k",
-    body: "A guided walk through a run's rank-fidelity output, failure clusters, and review media with the Blueprint evaluation team.",
-  },
-  {
-    name: "Generated media pack",
-    meter: "per_pack · +$800",
-    body: "Rendered support clips that help reviewers reason about a run. Always labeled as review support, never as real-world proof of an outcome.",
-  },
-  {
-    name: "Provenance-checked data package",
-    meter: "per_export · +$3k",
-    body: "An export-ready data package with provenance, rights packet, and coverage flags attached, scoped to your access window.",
-    stage: "Second product, later",
+    name: "Open-benchmark submission",
+    price: "$250–500",
+    unit: "/ submission",
+    body: "Once a site benchmark is established, later teams can submit to the same challenge for a small, uniform fee. The fee never affects ranking or placement.",
+    stage: "Later",
   },
 ];
 
 const faqItems = [
   {
-    question: "Which tier should we start with?",
+    question: "Which campaign is for me?",
     answer:
-      "Start with a quick-look eval — the cheap pre-pilot screen that ranks your policies on one captured site before you spend field time. The robot-team subscription is the scale-up for teams comparing policies continuously, where regression tracking and failure taxonomy live.",
+      "If you are a robot team that already has a prospective site and several candidate policies or checkpoints, start with a Policy Shortlist. If you are a site operator who wants to automate a workflow but does not know which robot teams belong onsite, start with a Robot Match. Both return the two or three strongest candidates for an onsite pilot.",
   },
   {
-    question: "What exactly am I paying for in an eval?",
+    question: "What is in the shortlist report?",
     answer:
-      "A rank-fidelity comparison of policies against a real captured site — episode runs, failure clusters, and review media. It is an estimate of relative readiness, not a guarantee of field success or a deployment-ready claim.",
+      "The top two or three candidates, with confidence and uncertainty, the major failure patterns, scenario-level performance, review media, and a recommended onsite pilot plan. A Robot Match also includes capability and integration gaps for each team.",
   },
   {
-    question: "How does site supply pricing work?",
+    question: "What if no candidate is strong enough?",
     answer:
-      "The $5k operator-side figure is a review fee covering facility, access, privacy, and commercialization posture; it is not a promised payout. Any separate payout terms are confirmed before robot-team use. Monitoring is a separate, recurring option.",
+      "The result may be “ranking inconclusive” or “no candidate met the threshold.” Blueprint reports that honestly and never manufactures a winner. You can extend the episode budget, narrow the scenario, or stop — you are buying a better pilot decision, not a guaranteed one.",
   },
   {
-    question: "Is generated media ever counted as proof?",
+    question: "Do robot teams pay to join a Robot Match?",
     answer:
-      "No. Generated and simulated media are review support only and are always labeled as such. The raw capture is the single source of ground truth across every tier and add-on.",
+      "No. Robot-team participation is free during a sponsored campaign. Later, once a site benchmark is established, teams can submit to it for a small, uniform $250–500 fee that never affects ranking or placement.",
   },
   {
-    question: "Are episode counts and prices fixed?",
+    question: "Are these prices fixed?",
     answer:
-      "The figures here are illustrative ranges. Final episode counts, policy caps, and pricing are set per engagement against the reviewed site, task, robot profile, and access scope.",
+      "They are launch prices held for the first ten paid campaigns, then reviewed against real delivery cost, integration hours, compute per candidate, inconclusive-ranking rate, and the share of campaigns that advance to an onsite pilot. Running repeated campaigns? Volume pricing is privately negotiated — for example, four campaigns for $10,000.",
   },
   {
-    question: "What happens after an eval?",
+    question: "Who captures the site, and who owns the rights?",
     answer:
-      "Every run ends in an actionable decision: export the data package, request a recapture, narrow the scenario, or move toward a field pilot — with the proof boundary attached.",
+      "Blueprint captures the relevant area under approved windows, or reuses an existing rights-approved capture. Provenance, rights, and privacy travel with the package and stay operator-controlled. No access is granted until the operator approves it.",
   },
 ];
 
@@ -191,14 +139,14 @@ export default function Pricing() {
     <>
       <SEO
         title="Pricing | Blueprint"
-        description="Pricing for the Task Evaluation Run: rank your robot policies on a captured real-site task envelope before you spend field or pilot time. Buy it as a quick-look eval or a robot-team subscription — bounded to the reviewed site, task, and access scope."
+        description="Blueprint pricing: two fixed-price campaigns that rank candidates against the site where they may deploy. Policy Shortlist ($3,000) for robot teams; Robot Match ($5,000) for site operators. Each returns the two or three strongest candidates for an onsite pilot."
         canonical="/pricing"
         jsonLd={[
           webPageJsonLd({
             path: "/pricing",
             name: "Blueprint Pricing",
             description:
-              "Planning ranges for the robot-team Task Evaluation Run — a quick-look eval or a subscription that ranks policies on a captured real-site task envelope. Follow-on paths (policy improvement, operator site supply and monitoring) are secondary.",
+              "Two fixed-price site-specific ranking campaigns: Policy Shortlist ($3,000/campaign) for robot teams and Robot Match ($5,000/campaign) for site operators. Each returns the two or three strongest candidates for an onsite pilot.",
           }),
           breadcrumbJsonLd([
             { name: "Home", path: "/" },
@@ -216,19 +164,20 @@ export default function Pricing() {
               Pricing
             </Eyebrow>
             <h1 className="mt-5 font-display text-[clamp(2.6rem,5vw,4.4rem)] font-medium leading-[1.02] tracking-[-0.045em] text-ink-900">
-              Priced as evaluation infrastructure.
+              Priced per campaign, not per seat.
             </h1>
             <p className="mt-5 max-w-[34rem] text-[1.05rem] leading-[1.7] text-ink-500">
-              {robotPolicyScreeningValue}
+              {blueprintPositioning}
             </p>
             <p className="mt-4 max-w-[34rem] text-[0.95rem] leading-[1.65] text-ink-400">
-              {robotPolicyEvaluationBeachhead} You are buying rank fidelity inside that
-              scope — never a guarantee or safety certification.
+              You are buying a shortlist before an expensive onsite pilot — one
+              fixed-price campaign, one clear decision. Never a deployment
+              guarantee, a safety certification, or a readiness claim.
             </p>
             <div className="mt-7 flex flex-wrap gap-2">
-              <ProofChip>Capture-backed comparisons</ProofChip>
-              <ProofChip>Rank fidelity, not guarantees</ProofChip>
-              <ProofChip>Scope-bounded access</ProofChip>
+              <ProofChip>Fixed-price campaigns</ProofChip>
+              <ProofChip>Top two or three, or none</ProofChip>
+              <ProofChip>Better pilot decision, not a guarantee</ProofChip>
             </div>
           </div>
           <MonochromeMedia
@@ -242,252 +191,47 @@ export default function Pricing() {
         </div>
       </section>
 
-      {/* Tiers */}
+      {/* Two campaigns */}
       <section className="border-y border-line bg-paper">
         <div className="mx-auto max-w-[88rem] px-5 py-16 sm:px-8 lg:px-10 lg:py-24">
           <EditorialSectionIntro
-            eyebrow="How teams buy an evaluation run"
-            title="One service, two ways to buy it."
-            description="Start with a quick-look eval as your first purchase, then move to a subscription when ranking policies becomes part of the development loop. All figures are illustrative ranges, set per engagement."
+            eyebrow="The two ways to buy"
+            title="One service. Two ways to start a campaign."
+            description="A robot team ranks its own policies for a known site, or a site operator compares compatible robot teams for a desired deployment. Both end in the same place: the two or three candidates that deserve an onsite pilot."
           />
 
           <TileGrid cols={2} className="mt-12 rounded-lg">
-            {primaryTiers.map((tier) => {
-              const onInk = tier.highlighted;
-              return (
-                <article
-                  key={tier.name}
-                  className={
-                    onInk
-                      ? "flex h-full flex-col bg-ink p-6 text-[color:var(--text-on-ink)]"
-                      : "flex h-full flex-col bg-white p-6"
-                  }
-                >
-                  <div className="flex items-center justify-between gap-3">
-                    <Eyebrow tone={onInk ? "onInk" : "muted"}>Tier</Eyebrow>
-                    {onInk ? (
-                      <StatusChip
-                        tone="ink"
-                        square
-                        dot={false}
-                        className="border-brass/50 bg-transparent text-brass"
-                      >
-                        Primary
-                      </StatusChip>
-                    ) : null}
-                  </div>
-
-                  <h3
-                    className={
-                      onInk
-                        ? "mt-5 text-title-m font-semibold tracking-tight text-[color:var(--text-on-ink)]"
-                        : "mt-5 text-title-m font-semibold tracking-tight text-ink-900"
-                    }
-                  >
-                    {tier.name}
-                  </h3>
-
-                  <div className="mt-4 flex items-baseline gap-1">
-                    <span
-                      className={
-                        onInk
-                          ? "font-mono text-[2rem] font-medium leading-none tracking-[-0.02em] text-[color:var(--text-on-ink)]"
-                          : "font-mono text-[2rem] font-medium leading-none tracking-[-0.02em] text-ink-900"
-                      }
-                    >
-                      {tier.price}
-                    </span>
-                    <span
-                      className={
-                        onInk
-                          ? "font-mono text-[0.9rem] text-ink-300"
-                          : "font-mono text-[0.9rem] text-ink-400"
-                      }
-                    >
-                      {tier.unit}
-                    </span>
-                  </div>
-
-                  <p
-                    className={
-                      onInk
-                        ? "mt-4 text-sm leading-[1.6] text-[color:var(--text-on-ink)] opacity-80"
-                        : "mt-4 text-sm leading-[1.6] text-ink-500"
-                    }
-                  >
-                    {tier.tagline}
-                  </p>
-
-                  <ul className="mt-5 flex flex-col gap-2.5">
-                    {tier.features.map((feature) => (
-                      <li key={feature} className="flex items-start gap-2.5">
-                        <Check
-                          className="mt-0.5 h-4 w-4 shrink-0 text-brass"
-                          strokeWidth={2}
-                          aria-hidden="true"
-                        />
-                        <span
-                          className={
-                            onInk
-                              ? "text-[13px] leading-[1.5] text-[color:var(--text-on-ink)] opacity-90"
-                              : "text-[13px] leading-[1.5] text-ink-700"
-                          }
-                        >
-                          {feature}
-                        </span>
-                      </li>
-                    ))}
-                  </ul>
-
-                  <p
-                    className={
-                      onInk
-                        ? "mt-5 border-t border-white/10 pt-4 text-[12px] leading-[1.5] text-ink-300"
-                        : "mt-5 border-t border-line-soft pt-4 text-[12px] leading-[1.5] text-ink-400"
-                    }
-                  >
-                    {tier.note}
-                  </p>
-
-                  <div className="mt-auto pt-6">
-                    <Button
-                      asChild
-                      variant={onInk ? "brass" : "secondary"}
-                      size="md"
-                      full
-                    >
-                      <a href={tier.href}>
-                        {tier.cta}
-                        <ArrowRight className="h-4 w-4" aria-hidden="true" />
-                      </a>
-                    </Button>
-                  </div>
-                </article>
-              );
-            })}
-          </TileGrid>
-
-          {/* Follow-on, on request — demoted out of the primary grid */}
-          <div className="mt-8 flex flex-col gap-3 border border-line bg-inset p-6 sm:flex-row sm:items-center sm:justify-between">
-            <div>
-              <div className="flex flex-wrap items-center gap-3">
-                <Eyebrow tone="muted">Later / on request</Eyebrow>
-                <span className="font-mono text-[12px] uppercase tracking-[0.08em] text-ink-500">
-                  {policyImprovementRun.price} {policyImprovementRun.unit}
-                </span>
-              </div>
-              <h3 className="mt-2 text-title-s font-semibold tracking-tight text-ink-900">
-                {policyImprovementRun.name}
-              </h3>
-              <p className="mt-1 max-w-[42rem] text-sm leading-[1.6] text-ink-500">
-                {policyImprovementRun.tagline} {policyImprovementRun.note}
-              </p>
-            </div>
-            <Button asChild variant="secondary" size="md">
-              <a href={policyImprovementRun.href}>
-                {policyImprovementRun.cta}
-                <ArrowRight className="h-4 w-4" aria-hidden="true" />
-              </a>
-            </Button>
-          </div>
-        </div>
-      </section>
-
-      {/* Add-ons */}
-      <section className="bg-canvas">
-        <div className="mx-auto max-w-[88rem] px-5 py-16 sm:px-8 lg:px-10 lg:py-24">
-          <EditorialSectionIntro
-            eyebrow="Add-ons"
-            title="Extend a run when you need more depth."
-            description="Optional units layered onto any tier. Each is metered and priced per use, with the proof boundary intact."
-          />
-
-          <TileGrid cols={2} className="mt-12">
-            {addOns.map((addOn) => (
-              <div key={addOn.name} className="flex h-full flex-col gap-3 bg-white p-6">
-                <div className="flex flex-wrap items-center justify-between gap-3">
-                  <h3 className="text-title-m font-semibold tracking-tight text-ink-900">
-                    {addOn.name}
-                  </h3>
-                  <span className="inline-flex items-center gap-2 border border-line bg-inset px-[0.6rem] py-1 font-mono text-[11px] uppercase tracking-[0.08em] text-ink-600">
-                    <span
-                      aria-hidden="true"
-                      className="h-[0.4rem] w-[0.4rem] shrink-0 rounded-full bg-brass"
-                    />
-                    {addOn.meter}
-                  </span>
-                </div>
-                {addOn.stage ? (
-                  <span className="inline-flex w-fit items-center border border-brass/50 bg-transparent px-[0.6rem] py-1 font-mono text-[11px] uppercase tracking-[0.08em] text-brass">
-                    {addOn.stage}
-                  </span>
-                ) : null}
-                <p className="text-sm leading-[1.65] text-ink-500">{addOn.body}</p>
-              </div>
-            ))}
-          </TileGrid>
-
-          <ProofBoundary
-            level="info"
-            title="What you're buying"
-            className="mt-10"
-          >
-            <p>
-              Every tier and add-on buys a capture-backed comparison against a real,
-              packaged site — rank fidelity, failure clusters, and review-support media.
-              It is an estimate of relative readiness, not a deployment-ready claim or a
-              guarantee of field success.
-            </p>
-            <p className="mt-3 font-mono text-[13px] text-ink-700">
-              All access is bounded to the reviewed site, task, robot profile,
-              policy-access mode, and proof boundary. Figures shown are illustrative
-              ranges; the final episode count, access mode, and price are written into the request.
-            </p>
-          </ProofBoundary>
-        </div>
-      </section>
-
-      {/* Operator / access partnership — secondary supply-side path */}
-      <section className="bg-canvas">
-        <div className="mx-auto max-w-[88rem] px-5 pb-8 sm:px-8 lg:px-10 lg:pb-12">
-          <EditorialSectionIntro
-            eyebrow="Operator / access partnership"
-            title="Have a site instead of a policy?"
-            description="A separate, secondary path for lighthouse operators who can make a useful site available. This is paid supply and access partnership — not a co-equal product tier for robot teams, and it opens only after a facility, access, and privacy review."
-          />
-
-          <TileGrid cols={2} className="mt-10">
-            {operatorTiers.map((tier) => (
+            {campaigns.map((campaign) => (
               <article
-                key={tier.name}
-                className="flex h-full flex-col bg-white p-6"
+                key={campaign.name}
+                className="flex h-full flex-col bg-white p-6 lg:p-8"
               >
                 <div className="flex items-center justify-between gap-3">
-                  <Eyebrow tone="muted">Access partner</Eyebrow>
-                  <StatusChip tone="neutral" square dot={false}>
-                    Secondary
+                  <Eyebrow tone="muted">{campaign.buyer}</Eyebrow>
+                  <StatusChip tone="info" square dot={false}>
+                    Campaign
                   </StatusChip>
                 </div>
 
-                <h3 className="mt-5 text-title-m font-semibold tracking-tight text-ink-900">
-                  {tier.name}
+                <h3 className="mt-5 text-title-l font-semibold tracking-tight text-ink-900">
+                  {campaign.name}
                 </h3>
 
                 <div className="mt-4 flex items-baseline gap-1">
-                  <span className="font-mono text-[2rem] font-medium leading-none tracking-[-0.02em] text-ink-900">
-                    {tier.price}
+                  <span className="font-mono text-[2.4rem] font-medium leading-none tracking-[-0.02em] text-ink-900">
+                    {campaign.price}
                   </span>
                   <span className="font-mono text-[0.9rem] text-ink-400">
-                    {tier.unit}
+                    {campaign.unit}
                   </span>
                 </div>
 
-                <p className="mt-4 text-sm leading-[1.6] text-ink-500">
-                  {tier.tagline}
+                <p className="mt-4 text-sm leading-[1.65] text-ink-500">
+                  {campaign.tagline}
                 </p>
 
                 <ul className="mt-5 flex flex-col gap-2.5">
-                  {tier.features.map((feature) => (
+                  {campaign.features.map((feature) => (
                     <li key={feature} className="flex items-start gap-2.5">
                       <Check
                         className="mt-0.5 h-4 w-4 shrink-0 text-brass"
@@ -502,13 +246,13 @@ export default function Pricing() {
                 </ul>
 
                 <p className="mt-5 border-t border-line-soft pt-4 text-[12px] leading-[1.5] text-ink-400">
-                  {tier.note}
+                  {campaign.note}
                 </p>
 
                 <div className="mt-auto pt-6">
-                  <Button asChild variant="secondary" size="md" full>
-                    <a href={tier.href}>
-                      {tier.cta}
+                  <Button asChild variant="brass" size="md" full>
+                    <a href={campaign.href}>
+                      {campaign.cta}
                       <ArrowRight className="h-4 w-4" aria-hidden="true" />
                     </a>
                   </Button>
@@ -516,15 +260,136 @@ export default function Pricing() {
               </article>
             ))}
           </TileGrid>
+
+          {/* Repeat campaigns — no subscription until a real cadence exists */}
+          <div className="mt-8 flex flex-col gap-3 border border-line bg-inset p-6 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <Eyebrow tone="muted">Repeat campaigns</Eyebrow>
+              <h3 className="mt-2 text-title-s font-semibold tracking-tight text-ink-900">
+                Volume pricing is negotiated, not subscribed.
+              </h3>
+              <p className="mt-1 max-w-[46rem] text-sm leading-[1.6] text-ink-500">
+                Teams running repeated campaigns get privately negotiated volume
+                pricing — for example, four campaigns for $10,000 or a quarterly
+                commitment. Blueprint introduces a subscription only after a
+                customer shows a real recurring cadence.
+              </p>
+            </div>
+            <Button asChild variant="secondary" size="md">
+              <a href="/contact/robot-team?persona=robot-team&buyerType=robot_team&interest=volume-campaigns&requestedOutputs=Volume%20Campaigns&source=pricing">
+                Discuss volume
+                <ArrowRight className="h-4 w-4" aria-hidden="true" />
+              </a>
+            </Button>
+          </div>
+        </div>
+      </section>
+
+      {/* Robot-team participation in a Robot Match */}
+      <section className="bg-canvas">
+        <div className="mx-auto max-w-[88rem] px-5 py-16 sm:px-8 lg:px-10 lg:py-24">
+          <EditorialSectionIntro
+            eyebrow="For robot teams joining a Match"
+            title="Getting compared on a site costs a robot team nothing today."
+            description="Site operators pay for the Robot Match campaign. Robot teams enter the shared evaluation for free while campaigns are sponsored, so rankings never look pay-to-play."
+          />
+
+          <TileGrid cols={2} className="mt-12">
+            {participation.map((tier) => (
+              <div key={tier.name} className="flex h-full flex-col gap-3 bg-white p-6">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <h3 className="text-title-m font-semibold tracking-tight text-ink-900">
+                    {tier.name}
+                  </h3>
+                  <span className="inline-flex items-center gap-2 border border-line bg-inset px-[0.6rem] py-1 font-mono text-[11px] uppercase tracking-[0.08em] text-ink-600">
+                    <span
+                      aria-hidden="true"
+                      className="h-[0.4rem] w-[0.4rem] shrink-0 rounded-full bg-brass"
+                    />
+                    {tier.price} {tier.unit}
+                  </span>
+                </div>
+                {tier.stage ? (
+                  <span className="inline-flex w-fit items-center border border-brass/50 bg-transparent px-[0.6rem] py-1 font-mono text-[11px] uppercase tracking-[0.08em] text-brass">
+                    {tier.stage}
+                  </span>
+                ) : null}
+                <p className="text-sm leading-[1.65] text-ink-500">{tier.body}</p>
+              </div>
+            ))}
+          </TileGrid>
+
+          <div className="mt-8 flex flex-col gap-3 border border-line bg-inset p-6 sm:flex-row sm:items-center sm:justify-between">
+            <p className="max-w-[52rem] text-sm leading-[1.6] text-ink-500">
+              To be compared, a candidate provides one standard interface — a
+              Blueprint-compatible policy API, a sealed container implementing the
+              evaluation contract, or an approved private runner exposing the same
+              observation and action interface. No source code is required.
+            </p>
+            <Button asChild variant="secondary" size="md">
+              <a href="/contact/robot-team?persona=robot-team&buyerType=robot_team&interest=robot-match-participation&requestedOutputs=Robot%20Match%20Participation&source=pricing">
+                Join a Match
+                <ArrowRight className="h-4 w-4" aria-hidden="true" />
+              </a>
+            </Button>
+          </div>
+        </div>
+      </section>
+
+      {/* Methodology & honesty */}
+      <section className="border-y border-line bg-paper">
+        <div className="mx-auto max-w-[88rem] px-5 py-16 sm:px-8 lg:px-10 lg:py-24">
+          <EditorialSectionIntro
+            eyebrow="How the ranking is called"
+            title="A confidence-aware verdict — not a guessed order."
+            description="Blueprint runs candidates against paired scenarios and seeds, spends more episodes only where the ranking is close, and stops when the result is confident or the campaign cap is reached. Every candidate receives one verdict."
+          />
+
+          <div className="mt-12 grid gap-px overflow-hidden rounded-md border border-line bg-[#ded7c8] sm:grid-cols-2 xl:grid-cols-3">
+            {rankingOutcomeCategories.map((row) => (
+              <div key={row.label} className="flex flex-col gap-2 bg-white p-6">
+                <h3 className="text-title-s font-semibold tracking-tight text-ink-900">
+                  {row.label}
+                </h3>
+                <p className="text-sm leading-[1.6] text-ink-500">{row.body}</p>
+              </div>
+            ))}
+            <div className="flex flex-col justify-center gap-2 bg-inset p-6">
+              <p className="font-mono text-[11px] uppercase tracking-[0.12em] text-brass-deep">
+                Where the evidence is strongest today
+              </p>
+              <p className="text-sm leading-[1.6] text-ink-600">
+                {robotPolicyEvaluationBeachhead}
+              </p>
+            </div>
+          </div>
+
+          <ProofBoundary level="info" title="What you're buying" className="mt-10">
+            <p>
+              Every campaign buys a capture-backed comparison against the real
+              site where a robot may deploy — the two or three best-supported
+              candidates for an onsite pilot, with failure patterns and review
+              media. The result can be &ldquo;ranking inconclusive&rdquo; or
+              &ldquo;no candidate met the threshold.&rdquo; Blueprint never
+              manufactures a winner.
+            </p>
+            <p className="mt-3 font-mono text-[13px] text-ink-700">
+              The report separates the ranking inside Blueprint&rsquo;s configured
+              evaluator from estimated suitability for an onsite pilot — and from
+              unproven physical performance, safety, reliability, and deployment
+              readiness. You are buying a better pilot decision, not a deployment
+              guarantee.
+            </p>
+          </ProofBoundary>
         </div>
       </section>
 
       {/* FAQ */}
-      <section className="border-y border-line bg-paper">
+      <section className="bg-canvas">
         <div className="mx-auto max-w-[88rem] px-5 py-16 sm:px-8 lg:px-10 lg:py-24">
           <EditorialFaq
             title="Pricing FAQ"
-            description="The model, the boundaries, and what the numbers do and do not promise."
+            description="The two campaigns, what a shortlist includes, and what the numbers do and do not promise."
             items={faqItems}
           />
         </div>
@@ -534,15 +399,15 @@ export default function Pricing() {
       <section className="bg-canvas">
         <div className="mx-auto max-w-[88rem] px-5 pb-20 sm:px-8 lg:px-10 lg:pb-28">
           <EditorialCtaBand
-            eyebrow="Pick your on-ramp"
-            title="Start with a quick-look or scope a subscription."
-            description="Tell us the site, task, and policies you want to compare. We'll come back with episode counts, a policy cap, and pricing for your scope."
+            eyebrow="Start a campaign"
+            title="Get to a shortlist before you spend a pilot season."
+            description="Tell us the site, the task, and the candidates — policies you already have, or robot teams you want compared. We come back with a scoped campaign and the fixed price for it."
             imageSrc="/redesign/pov/loading-dock.jpg"
             imageAlt="Warehouse loading dock — mobile-base navigation and rigid tote handling"
-            primaryHref="/contact/robot-team?persona=robot-team&interest=policy-evaluation-run&source=pricing"
-            primaryLabel="Request evaluation"
-            secondaryHref="/sites"
-            secondaryLabel="Browse site records"
+            primaryHref="/contact/robot-team?persona=robot-team&buyerType=robot_team&interest=policy-shortlist&source=pricing"
+            primaryLabel="Rank my policies"
+            secondaryHref="/for-site-operators"
+            secondaryLabel="Find robot teams for my site"
           />
         </div>
       </section>

--- a/client/src/pages/Pricing.tsx
+++ b/client/src/pages/Pricing.tsx
@@ -406,7 +406,7 @@ export default function Pricing() {
             imageAlt="Warehouse loading dock — mobile-base navigation and rigid tote handling"
             primaryHref="/contact/robot-team?persona=robot-team&buyerType=robot_team&interest=policy-shortlist&source=pricing"
             primaryLabel="Rank my policies"
-            secondaryHref="/for-site-operators"
+            secondaryHref="/contact/site-operator?buyerType=site_operator&interest=robot-match&source=pricing"
             secondaryLabel="Find robot teams for my site"
           />
         </div>

--- a/client/src/pages/RobotTeamEval.tsx
+++ b/client/src/pages/RobotTeamEval.tsx
@@ -628,14 +628,14 @@ export default function RobotTeamEval({ embedded = false }: { embedded?: boolean
           >
             <h2 className="text-3xl font-semibold">Start with the essentials.</h2>
             <p className="mt-2 text-sm leading-6 text-slate-600">
-              Add the minimum now and we scope one cheap comparative screening
-              run — a single-site ranking of your candidate policies before you
-              spend field time.
+              Add the minimum now and we scope one Policy Shortlist campaign — a
+              single-site ranking of up to five of your candidate policies that
+              returns the two or three strongest for an onsite pilot.
             </p>
             <p className="mt-2 text-xs leading-5 text-slate-500">
-              Later: if you run policies on a cadence, you can expand to a
-              subscription. Quick-look scope stays available on request — both
-              are follow-ons to the first screening run, not the starting point.
+              Fixed price, $3,000 per campaign. Run campaigns on a cadence and we
+              negotiate volume pricing — a subscription only comes later, once the
+              cadence is real.
             </p>
 
             <div className="mt-6 grid gap-4 md:grid-cols-2">

--- a/client/tests/build-output.test.ts
+++ b/client/tests/build-output.test.ts
@@ -208,15 +208,14 @@ describe("build output", () => {
     expect(homeHtml).toContain('type="application/ld+json"');
     // /pricing prerenders the real page so crawlers and no-JS agents see the
     // actual tiers, prices, and correct persona intake links.
-    expect(pricingHtml).toContain("Priced as evaluation infrastructure.");
-    expect(pricingHtml).toContain("Quick-look eval");
-    expect(pricingHtml).toContain("Robot-team subscription");
-    expect(pricingHtml).toContain("Site supply");
-    expect(pricingHtml).toContain("Site monitoring");
-    expect(pricingHtml).toContain("$15k");
+    expect(pricingHtml).toContain("Priced per campaign, not per seat.");
+    expect(pricingHtml).toContain("Policy Shortlist");
+    expect(pricingHtml).toContain("Robot Match");
+    expect(pricingHtml).toContain("$3,000");
+    expect(pricingHtml).toContain("$5,000");
     expect(pricingHtml).toContain("/contact/site-operator?buyerType=site_operator");
-    expect(pricingHtml).toContain("illustrative ranges");
-    expect(pricingHtml).not.toContain("Pick a run");
+    expect(pricingHtml).not.toContain("Quick-look eval");
+    expect(pricingHtml).not.toContain("Robot-team subscription");
     expect(proofHtml).toContain("Proof stays scoped");
     expect(proofHtml).toContain(
       "Generated clips help review. Real-world validation requires the matched robot, task, and site envelope.",

--- a/client/tests/pages/Contact.test.tsx
+++ b/client/tests/pages/Contact.test.tsx
@@ -82,7 +82,7 @@ describe("Contact page", () => {
     expect(
       screen.getByRole("heading", { name: /Tell us what policies to compare\./i }),
     ).toBeInTheDocument();
-    expect(screen.getByText(/We will recommend the right subscription, quick-look, or site-ops comparison path/i)).toBeInTheDocument();
+    expect(screen.getByText(/We scope one Policy Shortlist campaign/i)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Compare policies on a real site\./i })).toHaveAttribute(
       "href",
       "/contact/robot-team#contact-intake",
@@ -112,7 +112,7 @@ describe("Contact page", () => {
     expect(
       screen.getByRole("heading", { name: /Tell us what policies to compare\./i }),
     ).toBeInTheDocument();
-    expect(screen.getByText(/We will recommend the right subscription, quick-look, or site-ops comparison path/i)).toBeInTheDocument();
+    expect(screen.getByText(/We scope one Policy Shortlist campaign/i)).toBeInTheDocument();
     expect(screen.queryByDisplayValue("Harborview Grocery Distribution Annex")).not.toBeInTheDocument();
     expect(screen.queryByDisplayValue("Unitree G1")).not.toBeInTheDocument();
   });
@@ -155,9 +155,9 @@ describe("Contact page", () => {
     render(<Contact />);
 
     expect(
-      screen.getByRole("heading", { name: /Share a place for policy comparison\./i }),
+      screen.getByRole("heading", { name: /Find robot teams for your site\./i }),
     ).toBeInTheDocument();
-    expect(screen.getByText(/Start a \$5,000\/site supply review or scope yearly monitoring\. Access, rights, and pricing are confirmed per scope/i)).toBeInTheDocument();
+    expect(screen.getByText(/Start a \$5,000 Robot Match — we compare compatible robot teams on your captured site/i)).toBeInTheDocument();
     expect(screen.getByRole("textbox", { name: /^Name$/i })).toBeInTheDocument();
     expect(screen.getByRole("textbox", { name: /Organization/i })).toBeInTheDocument();
     expect(screen.getAllByText(/Partner on lighthouse capture access/i)[0]).toBeInTheDocument();

--- a/client/tests/pages/FAQ.test.tsx
+++ b/client/tests/pages/FAQ.test.tsx
@@ -12,12 +12,12 @@ describe("FAQ", () => {
       }),
     ).toBeInTheDocument();
     expect(screen.getByText(/What does Blueprint sell\?/i)).toBeInTheDocument();
-    expect(screen.getByText(/What does a Task Evaluation Run return\?/i)).toBeInTheDocument();
-    expect(screen.getByText(/What is a Policy Improvement Run\?/i)).toBeInTheDocument();
+    expect(screen.getByText(/What does a campaign return\?/i)).toBeInTheDocument();
+    expect(screen.getByText(/Do robot teams pay to join a Robot Match\?/i)).toBeInTheDocument();
     expect(screen.getByText(/Is the published 0.929 correlation a Blueprint result\?/i)).toBeInTheDocument();
     expect(screen.getByText(/How do capturers and site operators participate\?/i)).toBeInTheDocument();
     expect(screen.getByText(/Are the sites page and run dashboard filled with samples\?/i)).toBeInTheDocument();
-    expect(screen.getByText(/capture-backed Task Evaluation Runs, Policy Improvement Runs/i)).toBeInTheDocument();
+    expect(screen.getByText(/a Policy Shortlist for robot teams and a Robot Match for site operators/i)).toBeInTheDocument();
     expect(screen.getByText(/shows an empty request path instead of invented supply or analytics/i)).toBeInTheDocument();
     const robotTeamLinks = screen.getAllByRole("link", {
       name: /Talk to Blueprint about a real site/i,

--- a/client/tests/pages/ForSiteOperators.test.tsx
+++ b/client/tests/pages/ForSiteOperators.test.tsx
@@ -3,26 +3,44 @@ import { describe, expect, it } from "vitest";
 import ForSiteOperators from "@/pages/ForSiteOperators";
 
 describe("ForSiteOperators", () => {
-  it("renders the simplified site-operator persona page", () => {
+  it("renders the Robot Match site-operator offering", () => {
     render(<ForSiteOperators />);
 
-    expect(screen.getAllByText(/^For Site Operators$/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/For Site Operators/i).length).toBeGreaterThan(0);
     expect(
       screen.getByRole("heading", {
-        name: /Offer a site\. Keep the boundary\./i,
+        name: /Find the robot teams worth piloting\./i,
       }),
     ).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: /From a facility to a controlled supply site\./i })).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: /Operator approval stays attached, not inferred\./i })).toBeInTheDocument();
-    expect(screen.getByText(/Register the facility/i)).toBeInTheDocument();
-    expect(screen.getByText(/Approve capture windows/i)).toBeInTheDocument();
-    expect(screen.getByText(/Turn a facility into a captured evaluation site — and keep/i)).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: /The facilities that make strong packages\./i })).toBeInTheDocument();
-    expect(screen.getAllByRole("link", { name: /Start site review/i })[0]).toHaveAttribute(
-      "href",
-      "/contact/site-operator?source=for-site-operators",
-    );
-    expect(screen.queryByText(/^Revenue share$/i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/Any indoor facility qualifies/i)).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        name: /From a workflow to a short, credible pilot list\./i,
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /^Site-task brief$/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /^Qualify a candidate pool$/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /^Shortlist & pilot brief$/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /Your site stays yours\./i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        name: /One campaign\. \$5,000\. A shortlist you can pilot\./i,
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/^\$5,000$/)).toBeInTheDocument();
+
+    const matchLinks = screen.getAllByRole("link", {
+      name: /Find robot teams for my site/i,
+    });
+    expect(matchLinks.length).toBeGreaterThan(0);
+    matchLinks.forEach((link) => {
+      expect(link).toHaveAttribute(
+        "href",
+        expect.stringContaining("/contact/site-operator"),
+      );
+    });
+
+    // The retired supply-review / monitoring model is gone.
+    expect(screen.queryByText(/Site monitoring/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/\$30–40k/)).not.toBeInTheDocument();
   });
 });

--- a/client/tests/pages/HowItWorks.test.tsx
+++ b/client/tests/pages/HowItWorks.test.tsx
@@ -21,11 +21,13 @@ describe("HowItWorks", () => {
       screen.getByRole("heading", { name: /^Evaluate policies against the site\.$/i }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("heading", { name: /^Turn failures into the next policy loop\.$/i }),
-    ).toBeInTheDocument();
-    expect(
       screen.getByRole("heading", { name: /^Decide the next test\.$/i }),
     ).toBeInTheDocument();
+    // Policy Improvement Run is no longer a mainline pipeline step; it lives only
+    // in the demoted "After the run (later)" follow-on note.
+    expect(
+      screen.queryByRole("heading", { name: /^Turn failures into the next policy loop\.$/i }),
+    ).not.toBeInTheDocument();
     expect(
       screen.getByText(/Four steps from real site to a decision\./i),
     ).toBeInTheDocument();

--- a/client/tests/pages/Pricing.test.tsx
+++ b/client/tests/pages/Pricing.test.tsx
@@ -3,48 +3,54 @@ import { describe, expect, it } from "vitest";
 import Pricing from "@/pages/Pricing";
 
 describe("Pricing", () => {
-  it("renders the subscription-first robot-team pricing ladder", () => {
+  it("renders the two-campaign shortlist pricing model", () => {
     render(<Pricing />);
 
     expect(
       screen.getByRole("heading", {
-        name: /Priced as evaluation infrastructure\./i,
+        name: /Priced per campaign, not per seat\./i,
       }),
     ).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: /^Robot-team subscription$/i })).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: /^Quick-look eval$/i })).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: /^Site supply$/i })).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: /^Site monitoring$/i })).toBeInTheDocument();
-    expect(screen.getByText(/^\$15k$/i)).toBeInTheDocument();
-    expect(screen.getByText(/^\/ mo$/i)).toBeInTheDocument();
-    expect(screen.getByText(/^\$5–8k$/i)).toBeInTheDocument();
-    expect(screen.getByText(/^\/ eval$/i)).toBeInTheDocument();
-    expect(screen.getByText(/^\$5k$/i)).toBeInTheDocument();
-    expect(screen.getByText(/^\/ site$/i)).toBeInTheDocument();
-    expect(screen.getByText(/^\$30–40k$/i)).toBeInTheDocument();
-    expect(screen.getByText(/^\/ site \/ yr$/i)).toBeInTheDocument();
-    expect(screen.getByText(/Overage pricing above the cap/i)).toBeInTheDocument();
-    expect(screen.getByText(/^Ranking-only report$/i)).toBeInTheDocument();
-    expect(screen.getByText(/Failure taxonomy and calibration stay in subscription scope\./i)).toBeInTheDocument();
-    expect(screen.getByText(/Multiple scoped checks up to annual cap/i)).toBeInTheDocument();
-    expect(screen.getByText(/Monitoring is a separate, recurring option\./i)).toBeInTheDocument();
-    expect(
-      screen.getByText(/not a deployment-ready claim or a\s+guarantee of field success/i),
-    ).toBeInTheDocument();
-    // Site-operator tiers must land on the site-operator intake form, not the
-    // generic /contact redirect (which routes to the robot-team form).
-    expect(screen.getByRole("link", { name: /Start a site review/i })).toHaveAttribute(
+
+    // The two — and only two — campaigns.
+    expect(screen.getByRole("heading", { name: /^Policy Shortlist$/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /^Robot Match$/i })).toBeInTheDocument();
+    expect(screen.getByText(/^\$3,000$/)).toBeInTheDocument();
+    expect(screen.getByText(/^\$5,000$/)).toBeInTheDocument();
+    expect(screen.getAllByText(/^\/ campaign$/).length).toBeGreaterThanOrEqual(2);
+    expect(screen.getByText(/Up to five policies or checkpoints/i)).toBeInTheDocument();
+    expect(screen.getByText(/Up to five qualified robot teams/i)).toBeInTheDocument();
+    expect(screen.getByText(/Onsite pilot recommendation/i)).toBeInTheDocument();
+
+    // Participation paths for robot teams entering a Robot Match.
+    expect(screen.getByRole("heading", { name: /^Sponsored participation$/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /^Open-benchmark submission$/i })).toBeInTheDocument();
+    expect(screen.getAllByText(/\$250–500/).length).toBeGreaterThan(0);
+    expect(screen.getByText(/placement is never pay-to-play/i)).toBeInTheDocument();
+
+    // Ranking honesty — no manufactured winner.
+    expect(screen.getByText(/^Shortlisted$/i)).toBeInTheDocument();
+    expect(screen.getByText(/^Insufficient evidence$/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/never\s+manufactures a winner/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/better pilot decision, not a deployment\s+guarantee/i)).toBeInTheDocument();
+
+    // CTAs land on the correct persona intake.
+    const rankLinks = screen.getAllByRole("link", { name: /Rank my policies/i });
+    expect(rankLinks[0]).toHaveAttribute(
+      "href",
+      expect.stringContaining("/contact/robot-team"),
+    );
+    const matchLinks = screen.getAllByRole("link", { name: /Find robot teams for my site/i });
+    expect(matchLinks[0]).toHaveAttribute(
       "href",
       expect.stringContaining("/contact/site-operator"),
     );
-    expect(screen.getByRole("link", { name: /Discuss monitoring/i })).toHaveAttribute(
-      "href",
-      expect.stringContaining("/contact/site-operator"),
-    );
-    expect(screen.getByRole("link", { name: /Browse site records/i })).toHaveAttribute(
-      "href",
-      "/sites",
-    );
+
+    // The retired subscription / supply-review / monitoring model is gone.
+    expect(screen.queryByText(/Quick-look/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Robot-team subscription/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Site monitoring/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/^\$15k$/)).not.toBeInTheDocument();
     expect(screen.queryByText(/Site Data Package/i)).not.toBeInTheDocument();
   });
 });

--- a/e2e/contact.spec.ts
+++ b/e2e/contact.spec.ts
@@ -42,14 +42,14 @@ test('contact page leads with a simple robot-team Policy Evaluation Run flow', a
   await expect(page.getByText(/Site data package/i)).toHaveCount(0);
 });
 
-test('site-operator contact path keeps the low-cost access-boundary lane visible', async ({ page }) => {
+test('site-operator contact path presents the Robot Match lane', async ({ page }) => {
   await page.goto('/contact/site-operator', { waitUntil: 'domcontentloaded' });
 
   await expect(
-    page.getByRole('heading', { name: /Share a place for policy comparison\./i }),
+    page.getByRole('heading', { name: /Find robot teams for your site\./i }),
   ).toBeVisible();
   await expect(
-    page.getByText(/Start a \$5,000\/site supply review or scope yearly monitoring\. Access, rights, and pricing are confirmed per scope\./i),
+    page.getByText(/Start a \$5,000 Robot Match — we compare compatible robot teams on your captured site/i),
   ).toBeVisible();
   await expect(page.getByRole('textbox', { name: /^Name$/i })).toBeVisible();
   await expect(page.getByRole('textbox', { name: /Organization/i })).toBeVisible();

--- a/e2e/pricing.spec.ts
+++ b/e2e/pricing.spec.ts
@@ -1,43 +1,34 @@
 import { expect, test } from "@playwright/test";
 
-test("pricing page presents the subscription-first robot-team pricing ladder", async ({
+test("pricing page presents the two-campaign shortlist model", async ({
   page,
 }) => {
   await page.goto("/pricing");
 
   await expect(
     page.getByRole("heading", {
-      name: "Priced as evaluation infrastructure.",
+      name: "Priced per campaign, not per seat.",
     }),
   ).toBeVisible();
   await expect(
-    page.getByRole("heading", { name: "Robot-team subscription" }),
+    page.getByRole("heading", { name: "Policy Shortlist", exact: true }),
   ).toBeVisible();
   await expect(
-    page.getByRole("heading", { name: "Quick-look eval" }),
+    page.getByRole("heading", { name: "Robot Match", exact: true }),
   ).toBeVisible();
+  await expect(page.getByText(/^\$3,000$/)).toBeVisible();
+  await expect(page.getByText(/^\$5,000$/)).toBeVisible();
+  await expect(page.getByText(/\$250–500/).first()).toBeVisible();
+  await expect(page.getByText(/never\s+manufactures a winner/i).first()).toBeVisible();
+  // Each campaign CTA lands on the correct persona intake.
   await expect(
-    page.getByRole("heading", { name: "Site supply", exact: true }),
-  ).toBeVisible();
+    page.getByRole("link", { name: /Rank my policies/i }).first(),
+  ).toHaveAttribute("href", /\/contact\/robot-team/);
   await expect(
-    page.getByRole("heading", { name: "Site monitoring", exact: true }),
-  ).toBeVisible();
-  await expect(page.getByText(/^\$15k$/i)).toBeVisible();
-  await expect(page.getByText(/^\$5–8k$/i)).toBeVisible();
-  await expect(page.getByText(/^\$5k$/i)).toBeVisible();
-  await expect(page.getByText(/^\$30–40k$/i)).toBeVisible();
-  await expect(page.getByText(/Overage pricing above the cap/i)).toBeVisible();
-  await expect(page.getByText(/Multiple scoped checks up to annual cap/i)).toBeVisible();
-  await expect(page.getByText(/Monitoring is a separate, recurring option\./i)).toBeVisible();
-  await expect(
-    page.getByText(/not a deployment-ready claim or a/i),
-  ).toBeVisible();
-  // Site-operator tiers must land on the site-operator intake form, not the
-  // generic /contact redirect (which routes to the robot-team form).
-  await expect(
-    page.getByRole("link", { name: /Start a site review/i }).first(),
+    page.getByRole("link", { name: /Find robot teams for my site/i }).first(),
   ).toHaveAttribute("href", /\/contact\/site-operator/);
-  await expect(
-    page.getByRole("link", { name: /Discuss monitoring/i }).first(),
-  ).toHaveAttribute("href", /\/contact\/site-operator/);
+  // The retired subscription / supply-review / monitoring model is gone.
+  await expect(page.getByText(/Robot-team subscription/i)).toHaveCount(0);
+  await expect(page.getByText(/Quick-look/i)).toHaveCount(0);
+  await expect(page.getByText(/Site monitoring/i)).toHaveCount(0);
 });

--- a/scripts/qa/brand-polish.ts
+++ b/scripts/qa/brand-polish.ts
@@ -192,10 +192,10 @@ export const publicQaRoutes: PublicQaRoute[] = [
     label: "Pricing",
     path: "/pricing",
     canonicalPath: "/pricing",
-    expectedHeading: "Priced as evaluation infrastructure.",
+    expectedHeading: "Priced per campaign, not per seat.",
     requiredCtas: [
-      { label: "Start a subscription", hrefStartsWith: "/contact" },
-      { label: "Start a site review", hrefStartsWith: "/contact" },
+      { label: "Rank my policies", hrefStartsWith: "/contact" },
+      { label: "Find robot teams for my site", hrefStartsWith: "/" },
     ],
   },
   {

--- a/server/retrieval/agentAsk.ts
+++ b/server/retrieval/agentAsk.ts
@@ -199,7 +199,7 @@ const AGENT_KNOWLEDGE_ENTRIES: AgentKnowledgeEntry[] = [
       "fees",
     ],
     answer:
-      "Public planning ranges: $15,000/month robot-team eval infrastructure subscriptions, $5,000-$8,000 lite quick-look evals, $5,000/site operator supply reviews, and yearly deployed-site monitoring. Agent-purchasable SKUs are quoted per site world through /api/agent-access/commerce/quote (hosted-session rental hours or site-world package access); the server-side quote is authoritative and live checkout rejects client-supplied prices. These are planning ranges, not custom-scope quotes.",
+      "Public pricing is two fixed-price campaigns, each returning the two or three strongest candidates for an onsite pilot: a $3,000/campaign Policy Shortlist for a robot team that already has a site and candidate policies (ranks up to five policies or checkpoints), and a $5,000/campaign Robot Match for a site operator comparing compatible robot teams. Robot-team participation in a sponsored Robot Match is free; a uniform $250-$500 open-benchmark submission fee applies only later and never affects placement. Repeat work uses privately negotiated volume pricing, not a subscription. Agent-purchasable SKUs are quoted per site world through /api/agent-access/commerce/quote (hosted-session rental hours or site-world package access); the server-side quote is authoritative and live checkout rejects client-supplied prices. Every campaign can return 'ranking inconclusive'; the price buys a better pilot decision, not a deployment guarantee.",
     citations: [`${CANONICAL_ORIGIN}/pricing`],
     actions: [
       { description: "Quote a specific site world", method: "GET", endpoint: "/api/agent-access/commerce/quote?siteWorldId={id}", mcpTool: "blueprint.commerce.quote" },

--- a/server/routes/site-content.ts
+++ b/server/routes/site-content.ts
@@ -142,7 +142,7 @@ const pages = [
     path: "/pricing",
     title: "Pricing",
     description:
-      "Subscription-first pricing for robot-team eval infrastructure, lite quick-look evals, $5,000/site operator supply reviews, and yearly deployed-site monitoring.",
+      "Two fixed-price campaigns: a $3,000 Policy Shortlist for robot teams and a $5,000 Robot Match for site operators, each returning the two or three strongest candidates for an onsite pilot. Robot-team participation in a sponsored Robot Match is free.",
   },
   {
     path: "/contact",


### PR DESCRIPTION
## What & why

Reframes the public offerings/pricing around a single organizing idea from the deep‑research analysis: **the customer is buying a shortlist before an expensive onsite pilot** — not episodes, subscriptions, world models, or a deployment guarantee.

> Blueprint ranks robot policies and robot teams against the site where they may be deployed, so only the strongest two or three candidates need an onsite pilot.

The old ladder (quick‑look eval, $15k robot‑team subscription, $5k site‑supply review, $30–40k monitoring, Policy Improvement Run, and the metered add‑ons) is replaced by **two fixed‑price campaigns**.

## The two campaigns

| Offering | Buyer | Price | Returns |
|---|---|---:|---|
| **Policy Shortlist** | Robot team (has a site + candidate policies) | **$3,000 / campaign** | Ranks up to 5 policies → 2–3 strongest for an onsite pilot |
| **Robot Match** | Site operator (wants to pilot robots) | **$5,000 / campaign** | Compares up to 5 compatible robot teams → 2–3 strongest |

- Robot‑team participation in a Robot Match is **free during a sponsored campaign**; a uniform **$250–500** open‑benchmark submission fee only comes **later** and never affects placement.
- Repeat work uses **privately negotiated volume pricing** (e.g. four campaigns for $10,000) — **no subscription** until a real recurring cadence exists.

## Changes by surface

- **`Pricing.tsx`** — full rewrite: two campaign cards, participation paths, volume note, the five ranking verdicts (shortlisted / viable‑below / insufficient‑evidence / incompatible / below‑threshold), the standard‑interface requirement, and pricing FAQ.
- **`ForRobotTeams.tsx`** — pricing section → Policy Shortlist $3k; embedded intake copy updated off the subscription/quick‑look framing.
- **`ForSiteOperators.tsx`** — reframed from paid supply into the **Robot Match** buyer offering; the capability/embodiment gate, blind common evaluation, and the pilot brief are the new spine, with rights/access/privacy kept as the trust layer (ordinary site supply is free).
- **`Home.tsx`, `FAQ.tsx`, `Contact.tsx`, `HowItWorks.tsx`, `robotPolicyEvaluationClaims.ts`** — realigned to the shortlist positioning; Policy Improvement Run demoted out of public pricing.

## Honesty / proof boundary (kept first‑class)

Every campaign can return **"ranking inconclusive"** or **"no candidate met the threshold"** — Blueprint never manufactures a winner. Copy separates the ranking inside the evaluator from estimated onsite‑pilot suitability and from unproven physical performance, safety, reliability, and deployment readiness. You are buying **a better pilot decision, not a deployment guarantee**. The marketplace is presented as managed/request‑first, not an open self‑serve marketplace with pre‑existing supply.

## Scope notes

- Header IA stays robot‑team‑led (site operators remain out of the primary nav, reachable via footer / Pricing / Contact) to match existing information architecture; Pricing presents both campaigns side by side.
- `graphify-out/` is gitignored, so no architecture‑graph refresh is included in this copy‑only change.

## Testing

- `npm run check` (tsc) ✅
- Full client + QA vitest suite — **189 tests** ✅ (incl. Pricing, ForSiteOperators, Home, FAQ, Contact, HowItWorks, PublicCopy, Header, Routes, brand‑polish contract)
- `npm run build` + `build-output.test.ts` (prerendered `/pricing` HTML) ✅
- Coupled e2e specs (`pricing.spec.ts`, `contact.spec.ts`) and the brand‑polish QA route contract updated to the new copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WuSoqbQ88ujj7cXFJ9cMs5

---
_Generated by [Claude Code](https://claude.ai/code/session_01WuSoqbQ88ujj7cXFJ9cMs5)_