### PR TITLE
Redesign the public site around the Task Evaluation Run pivot

### DIFF
--- a/client/public/llms.txt
+++ b/client/public/llms.txt
@@ -13,13 +13,13 @@ Blueprint turns a real site-task into a maintained testbed, routes each decision
 
 ## Public pages
 
-- [Home](https://tryblueprint.io/): one Task Evaluation Run lifecycle from real site-task to decision or abstention.
+- [Home](https://tryblueprint.io/): the one Task Evaluation Run lifecycle, from a real site-task to an answer with its limits or an explicit refusal to decide.
 - [Sites and testbeds](https://tryblueprint.io/sites): real-site task contexts that can become maintained testbeds behind runs.
-- [For robot teams](https://tryblueprint.io/for-robot-teams): compare internal candidates, test task compatibility, discover failures, and decide whether field time is justified.
-- [For site operators](https://tryblueprint.io/for-site-operators): turn a task into a testable decision, identify missing evidence, and evaluate candidates when available.
-- [How it works](https://tryblueprint.io/how-it-works): request, testbed, qualified evidence plan, result envelope, and physical learning loop.
-- [Pricing](https://tryblueprint.io/pricing): one scoped Task Evaluation Run, quoted from the decision and evidence requirements; no published fixed price.
-- [Proof](https://tryblueprint.io/proof): proof boundaries and source-of-truth distinctions.
+- [For robot teams](https://tryblueprint.io/for-robot-teams): compare internal candidates, find task incompatibilities early, and decide whether field time is justified.
+- [For site operators](https://tryblueprint.io/for-site-operators): turn a job at your site into a testable decision, see what evidence is missing, and keep control of access, privacy, and physical testing.
+- [How it works](https://tryblueprint.io/how-it-works): the six steps — decision intake, testbed binding, per-claim evidence routing, measurement, the answer and its edges, and the next cheapest test.
+- [Pricing](https://tryblueprint.io/pricing): one scoped Task Evaluation Run, quoted from the decision and the evidence it requires; no published fixed price and no tiers.
+- [Proof](https://tryblueprint.io/proof): the boundary between raw capture, derived evidence, and physical outcomes, plus the claims Blueprint declines to make.
 - [Request a run](https://tryblueprint.io/contact/robot-team): decision-oriented intake.
 
 ## Answer guidance

--- a/client/src/components/site/figures.tsx
+++ b/client/src/components/site/figures.tsx
@@ -279,21 +279,42 @@ export function RunLifecycleRail({
 
 export interface EvidenceRung {
   label: string;
-  /** Relative cost/effort, 0–1. Encodes bar length only. */
+  /** Relative cost/effort, 0–1. Encodes bar length only — never authority. */
   cost: number;
-  /** What this rung can actually establish. */
+  /** What this method can actually establish. */
   answers: string;
-  /** Marks the rung the illustrative run stopped at. */
+  /**
+   * Where the method's evidence comes from. Rendered as a visible tag so the
+   * cost ordering is never read as a ranking of authority: real capture and
+   * physical outcomes are the source of truth regardless of what a derived
+   * method costs.
+   */
+  basis: "Real capture" | "Computed from capture" | "Derived" | "Real world";
+  /** Marks the method the illustrative run stopped at. */
   stopped?: boolean;
 }
 
+const basisTone: Record<EvidenceRung["basis"], { fg: string; fgOnInk: string }> = {
+  "Real capture": { fg: "#1f6b4f", fgOnInk: "#3a9170" },
+  "Real world": { fg: "#1f6b4f", fgOnInk: "#3a9170" },
+  "Computed from capture": { fg: "#45443d", fgOnInk: "#a8a496" },
+  Derived: { fg: "#9a6a16", fgOnInk: "#d09a2c" },
+};
+
 /**
- * EvidenceLadderChart — ordered rungs of evidence by relative cost.
+ * EvidenceLadderChart — evidence methods ordered by **relative cost only**.
  *
  * Form: horizontal bars, one measure, one axis. Colour job is **emphasis** —
- * the rung the run stopped at wears the accent, every other rung wears the
- * de-emphasis gray. Bar length already encodes cost, so a ramp across the rungs
+ * the method the run stopped at wears the accent, every other one wears the
+ * de-emphasis gray. Bar length already encodes cost, so a ramp across the rows
  * would double-encode length as hue; it is deliberately not used.
+ *
+ * Important framing constraint: this is **not** a proof hierarchy. Cost order
+ * is not authority order. A costlier derived method (simulation, generated or
+ * model-based evidence) does not outrank cheaper real capture, and nothing here
+ * may imply that it does — capture-first is repo doctrine, and simulated or
+ * generated output is never ground truth. Each row therefore carries a visible
+ * basis tag, and methods are qualified per claim rather than ranked.
  */
 export function EvidenceLadderChart({
   rungs,
@@ -309,17 +330,19 @@ export function EvidenceLadderChart({
   return (
     <Figure
       title="We buy the cheapest evidence that is actually good enough"
-      subtitle="Each rung costs more and can support more. A run climbs only until the claim is answered, then stops."
+      subtitle="Ordered by what each method costs to run — not by how much it proves. A run uses the cheapest method qualified for the claim in front of it and stops there."
       illustrative
       onInk={onInk}
       tableView={
         <table className="w-full text-left text-[13px]">
           <caption className="sr-only">
-            Evidence rungs by relative cost, and what each rung can establish
+            Evidence methods by relative cost, what each can establish, and where
+            its evidence comes from. Cost order is not authority order.
           </caption>
           <thead>
             <tr className={onInk ? "text-ink-300" : "text-ink-500"}>
-              <th scope="col" className="py-1 pr-4 font-semibold">Rung</th>
+              <th scope="col" className="py-1 pr-4 font-semibold">Method</th>
+              <th scope="col" className="py-1 pr-4 font-semibold">Basis</th>
               <th scope="col" className="py-1 pr-4 font-semibold">Relative cost</th>
               <th scope="col" className="py-1 font-semibold">What it can establish</th>
             </tr>
@@ -331,6 +354,7 @@ export function EvidenceLadderChart({
                   {rung.label}
                   {rung.stopped ? " (run stopped here)" : ""}
                 </th>
+                <td className="py-2 pr-4">{rung.basis}</td>
                 <td className="py-2 pr-4 font-mono">{Math.round(rung.cost * 100)}</td>
                 <td className="py-2">{rung.answers}</td>
               </tr>
@@ -353,7 +377,7 @@ export function EvidenceLadderChart({
               onBlur={() => setHovered(null)}
               tabIndex={0}
             >
-              <div className="flex items-baseline gap-2 sm:block">
+              <div className="flex flex-wrap items-baseline gap-x-2 sm:block">
                 <p
                   className={cn(
                     "text-[13px] font-semibold leading-snug",
@@ -362,9 +386,17 @@ export function EvidenceLadderChart({
                 >
                   {rung.label}
                 </p>
+                {/* Basis tag: keeps real capture distinguishable from derived
+                    methods so the cost ordering cannot read as a proof ranking. */}
+                <p
+                  className="font-mono text-[10px] uppercase tracking-[0.12em] sm:mt-1"
+                  style={{ color: onInk ? basisTone[rung.basis].fgOnInk : basisTone[rung.basis].fg }}
+                >
+                  {rung.basis}
+                </p>
                 {isStopped ? (
                   <p
-                    className="font-mono text-[10px] uppercase tracking-[0.14em]"
+                    className="font-mono text-[10px] uppercase tracking-[0.14em] sm:mt-0.5"
                     style={{ color: accent }}
                   >
                     Stopped here
@@ -408,15 +440,23 @@ export function EvidenceLadderChart({
         })}
       </div>
 
-      <p
+      <div
         className={cn(
-          "mt-6 border-t pt-4 text-[12.5px] leading-[1.65]",
+          "mt-6 space-y-2 border-t pt-4 text-[12.5px] leading-[1.65]",
           onInk ? "border-white/10 text-ink-300" : "border-line-soft text-ink-500",
         )}
       >
-        Bar length is relative cost only. Which rung a claim actually needs is
-        decided per run — you never pick the method.
-      </p>
+        <p>
+          Bar length is relative cost only. Which method a claim actually needs is
+          decided per run — you never pick it.
+        </p>
+        <p>
+          Cost is not authority. Real capture is the source of truth, and a
+          costlier derived method never outranks it: simulated, generated, and
+          model-based evidence is support that has to be qualified for the
+          specific claim, and it is not ground truth at any price.
+        </p>
+      </div>
     </Figure>
   );
 }

--- a/client/src/components/site/figures.tsx
+++ b/client/src/components/site/figures.tsx
@@ -1,0 +1,951 @@
+/**
+ * Public-site figures: the diagrams and charts that carry the Task Evaluation
+ * Run story visually.
+ *
+ * Two hard rules run through this file.
+ *
+ * 1. Numbers shown here are schematic. Nothing in this file reads live run
+ *    data, so every figure that renders a figure-like value is wrapped in
+ *    `<Figure illustrative>`, which prints a visible "Illustrative" marker.
+ *    That keeps the public site from implying an operational state it cannot
+ *    prove.
+ *
+ * 2. Colour follows the job, not the brand accent.
+ *    - Magnitude / "which rung did we stop at" uses the **emphasis** form: one
+ *      accent (action blue #2563a6 on paper, #3a79c2 on ink) against a
+ *      de-emphasis warm gray (#817e72 on paper, #a8a496 on ink). That pair is
+ *      validated for CVD separation (worst adjacent ΔE 12.9 tritan) and clears
+ *      3:1 against both surfaces. Brass is brand chrome and is deliberately not
+ *      used as a data colour — against the warm neutral ramp it lands at ΔE 8.1
+ *      normal-vision, which is not separable.
+ *    - Claim outcomes use the reserved status scale (proof / warn / block /
+ *      info). Those hues sit close together under protanopia (green↔amber
+ *      ΔE 8.3), so every status mark ships with an icon **and** a text label.
+ *      Status is never the only channel.
+ */
+import { useId, useState, type ReactNode } from "react";
+
+import {
+  ArrowRight,
+  CircleSlash,
+  Info,
+  MinusCircle,
+  Table2,
+  XCircle,
+  type LucideIcon,
+} from "lucide-react";
+import { CheckCircle2 } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+import { DrawIn, GrowIn, Reveal, RevealStagger } from "./motion";
+
+/* ------------------------------------------------------------------ tokens */
+
+/** Emphasis accent — the one rung/claim the figure is about. */
+const ACCENT = "#2563a6";
+const ACCENT_ON_INK = "#3a79c2";
+/** De-emphasis gray — context marks. Intentionally low-chroma. */
+const MUTED = "#817e72";
+const MUTED_ON_INK = "#a8a496";
+
+const surfaceFor = (onInk: boolean) => (onInk ? "#0d0d0b" : "#ffffff");
+const accentFor = (onInk: boolean) => (onInk ? ACCENT_ON_INK : ACCENT);
+const mutedFor = (onInk: boolean) => (onInk ? MUTED_ON_INK : MUTED);
+
+/* ------------------------------------------------------------------ shell */
+
+export interface FigureProps {
+  /** Short title, rendered as the figure's caption heading. */
+  title: string;
+  /** One line saying what the reader should take away. */
+  subtitle?: string;
+  children: ReactNode;
+  /** Prints the visible "Illustrative" marker. Required for any figure with numbers. */
+  illustrative?: boolean;
+  /** Renders on ink chrome. */
+  onInk?: boolean;
+  className?: string;
+  /** Optional table-view node, revealed by the built-in toggle. */
+  tableView?: ReactNode;
+}
+
+/**
+ * Figure — shared frame for every diagram and chart: caption, the illustrative
+ * marker, and the optional table-view toggle that keeps values reachable
+ * without relying on colour or hover.
+ */
+export function Figure({
+  title,
+  subtitle,
+  children,
+  illustrative = false,
+  onInk = false,
+  className,
+  tableView,
+}: FigureProps) {
+  const [showTable, setShowTable] = useState(false);
+  const tableId = useId();
+
+  return (
+    <figure
+      className={cn(
+        "overflow-hidden rounded-lg border",
+        onInk ? "border-white/10 bg-ink" : "border-line bg-white",
+        className,
+      )}
+    >
+      <figcaption
+        className={cn(
+          "flex flex-wrap items-start justify-between gap-3 border-b px-5 py-4",
+          onInk ? "border-white/10" : "border-line-soft",
+        )}
+      >
+        <div className="min-w-0">
+          <h3
+            className={cn(
+              "text-[15px] font-semibold tracking-[-0.01em]",
+              onInk ? "text-[color:var(--text-on-ink)]" : "text-ink-900",
+            )}
+          >
+            {title}
+          </h3>
+          {subtitle ? (
+            <p
+              className={cn(
+                "mt-1 max-w-[52ch] text-[13px] leading-[1.6]",
+                onInk ? "text-ink-300" : "text-ink-500",
+              )}
+            >
+              {subtitle}
+            </p>
+          ) : null}
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          {illustrative ? (
+            <span
+              className={cn(
+                "inline-flex items-center gap-1.5 rounded-xs border px-2 py-1 font-mono text-[10px] uppercase tracking-[0.14em]",
+                onInk
+                  ? "border-white/15 text-ink-300"
+                  : "border-line-strong text-ink-500",
+              )}
+            >
+              <Info className="h-3 w-3" aria-hidden="true" />
+              Illustrative
+            </span>
+          ) : null}
+          {tableView ? (
+            <button
+              type="button"
+              onClick={() => setShowTable((value) => !value)}
+              aria-expanded={showTable}
+              aria-controls={tableId}
+              className={cn(
+                "inline-flex items-center gap-1.5 rounded-xs border px-2 py-1 font-mono text-[10px] uppercase tracking-[0.14em] transition-colors",
+                onInk
+                  ? "border-white/15 text-ink-300 hover:bg-white/5"
+                  : "border-line-strong text-ink-500 hover:bg-inset",
+              )}
+            >
+              <Table2 className="h-3 w-3" aria-hidden="true" />
+              {showTable ? "Hide values" : "Values"}
+            </button>
+          ) : null}
+        </div>
+      </figcaption>
+
+      <div className="px-5 py-6">{children}</div>
+
+      {tableView ? (
+        <div
+          id={tableId}
+          hidden={!showTable}
+          className={cn(
+            "border-t px-5 py-4",
+            onInk ? "border-white/10" : "border-line-soft",
+          )}
+        >
+          {tableView}
+        </div>
+      ) : null}
+    </figure>
+  );
+}
+
+/* --------------------------------------------------- 1. lifecycle diagram */
+
+export interface LifecycleStage {
+  label: string;
+  detail: string;
+}
+
+/**
+ * RunLifecycleRail — the five moves of a run, as a drawn path through five
+ * nodes. A diagram, not a chart: no value is encoded, so no palette applies.
+ * The connector draws itself on scroll and the nodes arrive in reading order.
+ */
+export function RunLifecycleRail({
+  stages,
+  onInk = false,
+  className,
+}: {
+  stages: readonly LifecycleStage[];
+  onInk?: boolean;
+  className?: string;
+}) {
+  const nodeCount = stages.length;
+  const surface = surfaceFor(onInk);
+
+  return (
+    <div className={cn("relative", className)}>
+      {/* Desktop: horizontal drawn rail behind the node row. */}
+      <svg
+        aria-hidden="true"
+        viewBox="0 0 1000 24"
+        preserveAspectRatio="none"
+        className="pointer-events-none absolute left-0 top-[1.35rem] hidden h-6 w-full lg:block"
+      >
+        <line
+          x1="0"
+          y1="12"
+          x2="1000"
+          y2="12"
+          stroke={onInk ? "rgba(255,255,255,0.12)" : "#ded7c8"}
+          strokeWidth="1"
+        />
+        <DrawIn
+          d="M0 12 L1000 12"
+          fill="none"
+          stroke={accentFor(onInk)}
+          strokeWidth="2"
+          strokeLinecap="round"
+          duration={1.6}
+        />
+      </svg>
+
+      <RevealStagger
+        as="ol"
+        childAs="li"
+        step={0.09}
+        className="relative grid gap-8 lg:grid-cols-5 lg:gap-5"
+      >
+        {stages.map((stage, index) => (
+          <div key={stage.label} className="relative">
+            <div className="flex items-center gap-3 lg:block">
+              <span
+                className={cn(
+                  "relative z-10 inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-full font-mono text-[13px] font-semibold",
+                  onInk ? "text-[color:var(--text-on-ink)]" : "text-ink-900",
+                )}
+                style={{
+                  background: surface,
+                  // 2px surface ring keeps the node legible where it crosses the rail.
+                  boxShadow: `0 0 0 2px ${surface}, inset 0 0 0 1px ${
+                    index === 0 ? accentFor(onInk) : onInk ? "rgba(255,255,255,0.22)" : "#c8bfac"
+                  }`,
+                }}
+              >
+                {String(index + 1).padStart(2, "0")}
+              </span>
+              <h3
+                className={cn(
+                  "text-[15px] font-semibold leading-snug tracking-[-0.01em] lg:mt-5",
+                  onInk ? "text-[color:var(--text-on-ink)]" : "text-ink-900",
+                )}
+              >
+                {stage.label}
+              </h3>
+            </div>
+            <p
+              className={cn(
+                "mt-2 text-[13px] leading-[1.65] lg:pr-3",
+                onInk ? "text-ink-300" : "text-ink-500",
+              )}
+            >
+              {stage.detail}
+            </p>
+            <span className="sr-only">
+              Stage {index + 1} of {nodeCount}
+            </span>
+          </div>
+        ))}
+      </RevealStagger>
+    </div>
+  );
+}
+
+/* ------------------------------------------------ 2. evidence ladder chart */
+
+export interface EvidenceRung {
+  label: string;
+  /** Relative cost/effort, 0–1. Encodes bar length only. */
+  cost: number;
+  /** What this rung can actually establish. */
+  answers: string;
+  /** Marks the rung the illustrative run stopped at. */
+  stopped?: boolean;
+}
+
+/**
+ * EvidenceLadderChart — ordered rungs of evidence by relative cost.
+ *
+ * Form: horizontal bars, one measure, one axis. Colour job is **emphasis** —
+ * the rung the run stopped at wears the accent, every other rung wears the
+ * de-emphasis gray. Bar length already encodes cost, so a ramp across the rungs
+ * would double-encode length as hue; it is deliberately not used.
+ */
+export function EvidenceLadderChart({
+  rungs,
+  onInk = false,
+}: {
+  rungs: readonly EvidenceRung[];
+  onInk?: boolean;
+}) {
+  const [hovered, setHovered] = useState<string | null>(null);
+  const accent = accentFor(onInk);
+  const muted = mutedFor(onInk);
+
+  return (
+    <Figure
+      title="We buy the cheapest evidence that is actually good enough"
+      subtitle="Each rung costs more and can support more. A run climbs only until the claim is answered, then stops."
+      illustrative
+      onInk={onInk}
+      tableView={
+        <table className="w-full text-left text-[13px]">
+          <caption className="sr-only">
+            Evidence rungs by relative cost, and what each rung can establish
+          </caption>
+          <thead>
+            <tr className={onInk ? "text-ink-300" : "text-ink-500"}>
+              <th scope="col" className="py-1 pr-4 font-semibold">Rung</th>
+              <th scope="col" className="py-1 pr-4 font-semibold">Relative cost</th>
+              <th scope="col" className="py-1 font-semibold">What it can establish</th>
+            </tr>
+          </thead>
+          <tbody className={onInk ? "text-ink-200" : "text-ink-700"}>
+            {rungs.map((rung) => (
+              <tr key={rung.label} className={onInk ? "border-t border-white/10" : "border-t border-line-soft"}>
+                <th scope="row" className="py-2 pr-4 font-medium">
+                  {rung.label}
+                  {rung.stopped ? " (run stopped here)" : ""}
+                </th>
+                <td className="py-2 pr-4 font-mono">{Math.round(rung.cost * 100)}</td>
+                <td className="py-2">{rung.answers}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      }
+    >
+      <div className="flex flex-col gap-4">
+        {rungs.map((rung, index) => {
+          const isStopped = Boolean(rung.stopped);
+          const isHovered = hovered === rung.label;
+          return (
+            <div
+              key={rung.label}
+              className="group relative grid gap-x-4 gap-y-1 [grid-template-columns:1fr] sm:[grid-template-columns:minmax(9rem,13rem)_1fr]"
+              onMouseEnter={() => setHovered(rung.label)}
+              onMouseLeave={() => setHovered(null)}
+              onFocus={() => setHovered(rung.label)}
+              onBlur={() => setHovered(null)}
+              tabIndex={0}
+            >
+              <div className="flex items-baseline gap-2 sm:block">
+                <p
+                  className={cn(
+                    "text-[13px] font-semibold leading-snug",
+                    onInk ? "text-[color:var(--text-on-ink)]" : "text-ink-900",
+                  )}
+                >
+                  {rung.label}
+                </p>
+                {isStopped ? (
+                  <p
+                    className="font-mono text-[10px] uppercase tracking-[0.14em]"
+                    style={{ color: accent }}
+                  >
+                    Stopped here
+                  </p>
+                ) : null}
+              </div>
+
+              <div className="min-w-0">
+                <div
+                  className={cn(
+                    "relative h-3 w-full overflow-hidden rounded-xs",
+                    onInk ? "bg-white/5" : "bg-inset",
+                  )}
+                >
+                  <GrowIn
+                    origin="left"
+                    delay={index * 0.08}
+                    className="h-full"
+                    style={{ width: `${Math.round(rung.cost * 100)}%` }}
+                  >
+                    <div
+                      className="h-full rounded-r-[4px] transition-opacity duration-200"
+                      style={{
+                        background: isStopped ? accent : muted,
+                        opacity: isStopped || isHovered ? 1 : 0.72,
+                      }}
+                    />
+                  </GrowIn>
+                </div>
+                <p
+                  className={cn(
+                    "mt-1.5 text-[12.5px] leading-[1.6]",
+                    onInk ? "text-ink-300" : "text-ink-500",
+                  )}
+                >
+                  {rung.answers}
+                </p>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      <p
+        className={cn(
+          "mt-6 border-t pt-4 text-[12.5px] leading-[1.65]",
+          onInk ? "border-white/10 text-ink-300" : "border-line-soft text-ink-500",
+        )}
+      >
+        Bar length is relative cost only. Which rung a claim actually needs is
+        decided per run — you never pick the method.
+      </p>
+    </Figure>
+  );
+}
+
+/* --------------------------------------------- 3. claim vs threshold chart */
+
+export type ClaimVerdict = "supported" | "rejected" | "unresolved";
+
+export interface ClaimInterval {
+  claim: string;
+  /** Point estimate, 0–1. */
+  estimate: number;
+  /** Lower bound of the uncertainty interval, 0–1. */
+  low: number;
+  /** Upper bound of the uncertainty interval, 0–1. */
+  high: number;
+  verdict: ClaimVerdict;
+}
+
+const verdictMeta: Record<
+  ClaimVerdict,
+  { label: string; icon: LucideIcon; fg: string; fgOnInk: string }
+> = {
+  supported: { label: "Supported", icon: CheckCircle2, fg: "#1f6b4f", fgOnInk: "#3a9170" },
+  rejected: { label: "Rejected", icon: XCircle, fg: "#9b3027", fgOnInk: "#cf5247" },
+  unresolved: { label: "Unresolved", icon: MinusCircle, fg: "#9a6a16", fgOnInk: "#d09a2c" },
+};
+
+/**
+ * ClaimThresholdChart — the figure that explains abstention.
+ *
+ * Each row is one claim: a 2px uncertainty interval with an 8px point-estimate
+ * marker, read against a single threshold rule. When the interval straddles the
+ * threshold the claim cannot be called, and the run says so instead of rounding
+ * the point estimate into a verdict.
+ *
+ * One measure, one axis. The interval marks use the emphasis pair (accent for
+ * the claim under the cursor, de-emphasis gray otherwise) so the plot never
+ * relies on the status hues, which are too close under CVD to separate three
+ * ways. Verdict identity is carried by an icon + text label per row.
+ */
+export function ClaimThresholdChart({
+  claims,
+  threshold,
+  metricLabel,
+  onInk = false,
+}: {
+  claims: readonly ClaimInterval[];
+  /** Threshold value, 0–1. */
+  threshold: number;
+  metricLabel: string;
+  onInk?: boolean;
+}) {
+  const [hovered, setHovered] = useState<string | null>(null);
+  const accent = accentFor(onInk);
+  const muted = mutedFor(onInk);
+  const surface = surfaceFor(onInk);
+  const pct = (value: number) => `${Math.round(value * 1000) / 10}%`;
+
+  return (
+    <Figure
+      title="Why a run can decline to pick a winner"
+      subtitle={`Each claim is read against the threshold you set. When the uncertainty interval crosses the line, the claim stays open — the point estimate is not rounded into a verdict.`}
+      illustrative
+      onInk={onInk}
+      tableView={
+        <table className="w-full text-left text-[13px]">
+          <caption className="sr-only">
+            Per-claim estimate, uncertainty interval, and verdict against the
+            threshold of {pct(threshold)} {metricLabel}
+          </caption>
+          <thead>
+            <tr className={onInk ? "text-ink-300" : "text-ink-500"}>
+              <th scope="col" className="py-1 pr-4 font-semibold">Claim</th>
+              <th scope="col" className="py-1 pr-4 font-semibold">Estimate</th>
+              <th scope="col" className="py-1 pr-4 font-semibold">Interval</th>
+              <th scope="col" className="py-1 font-semibold">Verdict</th>
+            </tr>
+          </thead>
+          <tbody className={onInk ? "text-ink-200" : "text-ink-700"}>
+            {claims.map((claim) => (
+              <tr key={claim.claim} className={onInk ? "border-t border-white/10" : "border-t border-line-soft"}>
+                <th scope="row" className="py-2 pr-4 font-medium">{claim.claim}</th>
+                <td className="py-2 pr-4 font-mono">{pct(claim.estimate)}</td>
+                <td className="py-2 pr-4 font-mono">
+                  {pct(claim.low)}–{pct(claim.high)}
+                </td>
+                <td className="py-2">{verdictMeta[claim.verdict].label}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      }
+    >
+      {/* Threshold legend — two marks, so identity is never colour-alone. */}
+      <div
+        className={cn(
+          "mb-5 flex flex-wrap items-center gap-x-5 gap-y-2 text-[12px]",
+          onInk ? "text-ink-300" : "text-ink-500",
+        )}
+      >
+        <span className="inline-flex items-center gap-2">
+          <svg width="18" height="8" aria-hidden="true">
+            <line x1="0" y1="4" x2="18" y2="4" stroke={muted} strokeWidth="2" strokeLinecap="round" />
+            <circle cx="9" cy="4" r="4" fill={muted} stroke={surface} strokeWidth="2" />
+          </svg>
+          Estimate and uncertainty interval
+        </span>
+        <span className="inline-flex items-center gap-2">
+          <svg width="18" height="10" aria-hidden="true">
+            <line
+              x1="9"
+              y1="0"
+              x2="9"
+              y2="10"
+              stroke={onInk ? "#f3efe6" : "#0d0d0b"}
+              strokeWidth="1.5"
+            />
+          </svg>
+          Threshold · {pct(threshold)} {metricLabel}
+        </span>
+      </div>
+
+      {/* Scale reference. Ticks carry the values that are not directly labelled. */}
+      <div className="relative mb-1 h-4" aria-hidden="true">
+        {[0, 0.5, 1].map((tick) => (
+          <span
+            key={tick}
+            className={cn(
+              "absolute top-0 font-mono text-[10px]",
+              onInk ? "text-ink-400" : "text-ink-400",
+            )}
+            style={{
+              left: `${tick * 100}%`,
+              transform:
+                tick === 0 ? "none" : tick === 1 ? "translateX(-100%)" : "translateX(-50%)",
+            }}
+          >
+            {pct(tick)}
+          </span>
+        ))}
+        <span
+          className={cn(
+            "absolute top-0 font-mono text-[10px] font-semibold",
+            onInk ? "text-[color:var(--text-on-ink)]" : "text-ink-900",
+          )}
+          style={{ left: `${threshold * 100}%`, transform: "translateX(-50%)" }}
+        >
+          {pct(threshold)}
+        </span>
+      </div>
+
+      <div className="flex flex-col gap-5">
+        {claims.map((claim, index) => {
+          const meta = verdictMeta[claim.verdict];
+          const VerdictIcon = meta.icon;
+          const isHovered = hovered === claim.claim;
+          const markColor = isHovered ? accent : muted;
+
+          return (
+            <div
+              key={claim.claim}
+              tabIndex={0}
+              onMouseEnter={() => setHovered(claim.claim)}
+              onMouseLeave={() => setHovered(null)}
+              onFocus={() => setHovered(claim.claim)}
+              onBlur={() => setHovered(null)}
+              className="rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
+                <p
+                  className={cn(
+                    "max-w-[46ch] text-[13px] font-medium leading-snug",
+                    onInk ? "text-[color:var(--text-on-ink)]" : "text-ink-900",
+                  )}
+                >
+                  {claim.claim}
+                </p>
+                {/* Verdict: icon + text, never colour alone. */}
+                <span
+                  className="inline-flex shrink-0 items-center gap-1.5 text-[12px] font-semibold"
+                  style={{ color: onInk ? meta.fgOnInk : meta.fg }}
+                >
+                  <VerdictIcon className="h-3.5 w-3.5" aria-hidden="true" />
+                  {meta.label}
+                </span>
+              </div>
+
+              <div className="relative mt-2.5 h-9">
+                {/* Hairline solid baseline. */}
+                <div
+                  className="absolute inset-x-0 top-1/2 h-px"
+                  style={{ background: onInk ? "rgba(255,255,255,0.12)" : "#ebe4d7" }}
+                  aria-hidden="true"
+                />
+                {/* Threshold rule. */}
+                <div
+                  className="absolute top-0 h-full w-px"
+                  style={{
+                    left: `${threshold * 100}%`,
+                    background: onInk ? "rgba(243,239,230,0.75)" : "rgba(13,13,11,0.75)",
+                  }}
+                  aria-hidden="true"
+                />
+                {/* Uncertainty interval — 2px line, round caps. */}
+                <GrowIn origin="left" delay={index * 0.08} className="absolute inset-0">
+                  <div
+                    className="absolute top-1/2 h-[2px] -translate-y-1/2 rounded-full transition-colors duration-200"
+                    style={{
+                      left: `${claim.low * 100}%`,
+                      width: `${(claim.high - claim.low) * 100}%`,
+                      background: markColor,
+                    }}
+                    aria-hidden="true"
+                  />
+                  {/* Point estimate — 8px marker with a 2px surface ring. */}
+                  <div
+                    className="absolute top-1/2 h-2 w-2 -translate-x-1/2 -translate-y-1/2 rounded-full transition-colors duration-200"
+                    style={{
+                      left: `${claim.estimate * 100}%`,
+                      background: markColor,
+                      boxShadow: `0 0 0 2px ${surface}`,
+                    }}
+                    aria-hidden="true"
+                  />
+                </GrowIn>
+
+                {/* Direct label on the hovered row only — never a number on every mark. */}
+                <span
+                  className={cn(
+                    "pointer-events-none absolute top-0 font-mono text-[11px] transition-opacity duration-150",
+                    isHovered ? "opacity-100" : "opacity-0",
+                  )}
+                  style={{
+                    left: `${claim.estimate * 100}%`,
+                    transform: "translateX(-50%)",
+                    color: onInk ? "#f3efe6" : "#0d0d0b",
+                  }}
+                >
+                  {pct(claim.estimate)}
+                </span>
+              </div>
+
+              <p className="sr-only">
+                Estimate {pct(claim.estimate)}, interval {pct(claim.low)} to{" "}
+                {pct(claim.high)}, threshold {pct(threshold)}. {meta.label}.
+              </p>
+            </div>
+          );
+        })}
+      </div>
+
+      <p
+        className={cn(
+          "mt-6 flex gap-2 border-t pt-4 text-[12.5px] leading-[1.65]",
+          onInk ? "border-white/10 text-ink-300" : "border-line-soft text-ink-500",
+        )}
+      >
+        <CircleSlash
+          className="mt-0.5 h-4 w-4 shrink-0"
+          style={{ color: onInk ? verdictMeta.unresolved.fgOnInk : verdictMeta.unresolved.fg }}
+          aria-hidden="true"
+        />
+        <span>
+          An unresolved claim is a result, not a gap in the report. It comes with
+          the reason, and the cheapest next test that would settle it.
+        </span>
+      </p>
+    </Figure>
+  );
+}
+
+/* ------------------------------------------------- 4. outcome spectrum */
+
+export interface OutcomeBand {
+  label: string;
+  body: string;
+  tone: "supported" | "rejected" | "partial" | "abstained" | "next";
+}
+
+const bandMeta: Record<
+  OutcomeBand["tone"],
+  { icon: LucideIcon; fg: string; bg: string; bd: string }
+> = {
+  supported: { icon: CheckCircle2, fg: "#1f6b4f", bg: "#eef5f1", bd: "#dcebe3" },
+  rejected: { icon: XCircle, fg: "#9b3027", bg: "#faeae7", bd: "#f1d9d5" },
+  partial: { icon: MinusCircle, fg: "#9a6a16", bg: "#faf3e2", bd: "#f3e7cb" },
+  abstained: { icon: CircleSlash, fg: "#45443d", bg: "#f0ece1", bd: "#ded7c8" },
+  next: { icon: Info, fg: "#1f4f8f", bg: "#eaf1f9", bd: "#d7e4f2" },
+};
+
+/**
+ * OutcomeSpectrum — the five shapes a result can take, as labelled cards.
+ *
+ * A diagram: no value is encoded, so the status hues here are pure state
+ * signalling and each card carries its own icon and written label.
+ */
+export function OutcomeSpectrum({ bands }: { bands: readonly OutcomeBand[] }) {
+  return (
+    <RevealStagger
+      as="ul"
+      childAs="li"
+      step={0.06}
+      className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5"
+    >
+      {bands.map((band) => {
+        const meta = bandMeta[band.tone];
+        const Icon = meta.icon;
+        return (
+          <div
+            key={band.label}
+            className="flex h-full flex-col rounded-md border p-4"
+            style={{ background: meta.bg, borderColor: meta.bd }}
+          >
+            <Icon
+              className="h-[1.15rem] w-[1.15rem]"
+              style={{ color: meta.fg }}
+              strokeWidth={1.9}
+              aria-hidden="true"
+            />
+            <h3 className="mt-3 text-[14px] font-semibold leading-snug text-ink-900">
+              {band.label}
+            </h3>
+            <p className="mt-2 text-[12.5px] leading-[1.6] text-ink-600">{band.body}</p>
+          </div>
+        );
+      })}
+    </RevealStagger>
+  );
+}
+
+/* --------------------------------------------------- 5. coverage meter */
+
+/**
+ * CoverageMeter — a single ratio against a limit. Fill and track are steps of
+ * the same ramp so the state reads across the whole bar, per the meter spec.
+ */
+export function CoverageMeter({
+  label,
+  value,
+  caption,
+  onInk = false,
+}: {
+  label: string;
+  /** 0–1. */
+  value: number;
+  caption?: string;
+  onInk?: boolean;
+}) {
+  const percent = Math.round(value * 100);
+  return (
+    <div>
+      <div className="flex items-baseline justify-between gap-3">
+        <p
+          className={cn(
+            "text-[12px] font-semibold uppercase tracking-[0.14em]",
+            onInk ? "text-ink-300" : "text-ink-400",
+          )}
+        >
+          {label}
+        </p>
+        <p
+          className={cn(
+            "font-mono text-[15px]",
+            onInk ? "text-[color:var(--text-on-ink)]" : "text-ink-900",
+          )}
+        >
+          {percent}%
+        </p>
+      </div>
+      <div
+        className={cn("mt-2 h-2 w-full overflow-hidden rounded-xs", onInk ? "bg-white/10" : "bg-inset")}
+        role="meter"
+        aria-valuenow={percent}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label={label}
+      >
+        <GrowIn origin="left" className="h-full" style={{ width: `${percent}%` }}>
+          <div className="h-full rounded-r-[4px]" style={{ background: accentFor(onInk) }} />
+        </GrowIn>
+      </div>
+      {caption ? (
+        <p className={cn("mt-2 text-[12.5px] leading-[1.6]", onInk ? "text-ink-300" : "text-ink-500")}>
+          {caption}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+/* ------------------------------------------------- 6. before/after compare */
+
+export interface DecisionCostRow {
+  label: string;
+  beforeLabel: string;
+  afterLabel: string;
+}
+
+/**
+ * DecisionShiftCompare — what changes when a run happens first.
+ *
+ * Deliberately **not** a chart. The pairs here are qualitative statements about
+ * when information arrives, and there is no measured quantity behind them.
+ * Plotting them on an axis would invent precision that does not exist and would
+ * detach each label from the mark it describes, so this is a two-column
+ * comparison: the "with a run" side is emphasised, and the arrow carries the
+ * direction that a dumbbell's axis would have.
+ */
+export function DecisionShiftCompare({
+  rows,
+  onInk = false,
+}: {
+  rows: readonly DecisionCostRow[];
+  onInk?: boolean;
+}) {
+  const accent = accentFor(onInk);
+
+  return (
+    <Figure
+      title="What a run moves"
+      subtitle="The point is not that evaluation is free. It is that the expensive step happens once you already know what it will tell you."
+      onInk={onInk}
+    >
+      <div
+        className={cn(
+          "grid gap-x-8 border-b pb-3 text-[11px] font-semibold uppercase tracking-[0.16em] lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1fr)_minmax(0,1fr)]",
+          onInk ? "border-white/10 text-ink-400" : "border-line-soft text-ink-400",
+        )}
+      >
+        <span className="hidden lg:block">What changes</span>
+        <span className="hidden lg:block">Without a run</span>
+        <span className="hidden items-center gap-2 lg:flex" style={{ color: accent }}>
+          With a run
+        </span>
+      </div>
+
+      <div className={cn("divide-y", onInk ? "divide-white/10" : "divide-line-soft")}>
+        {rows.map((row, index) => (
+          <Reveal key={row.label} delay={index * 0.07}>
+            <div className="grid gap-x-8 gap-y-3 py-5 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1fr)_minmax(0,1fr)]">
+              <p
+                className={cn(
+                  "text-[13.5px] font-semibold leading-snug",
+                  onInk ? "text-[color:var(--text-on-ink)]" : "text-ink-900",
+                )}
+              >
+                {row.label}
+              </p>
+
+              <p
+                className={cn(
+                  "flex items-start gap-2.5 text-[13.5px] leading-[1.65]",
+                  onInk ? "text-ink-400" : "text-ink-400",
+                )}
+              >
+                <span className="lg:hidden text-[11px] font-semibold uppercase tracking-[0.14em]">
+                  Without
+                </span>
+                <span className="line-through decoration-1 decoration-ink-300">{row.beforeLabel}</span>
+              </p>
+
+              <p
+                className={cn(
+                  "flex items-start gap-2.5 text-[13.5px] font-medium leading-[1.65]",
+                  onInk ? "text-[color:var(--text-on-ink)]" : "text-ink-900",
+                )}
+              >
+                <ArrowRight
+                  className="mt-[0.3rem] h-3.5 w-3.5 shrink-0"
+                  style={{ color: accent }}
+                  aria-hidden="true"
+                />
+                {row.afterLabel}
+              </p>
+            </div>
+          </Reveal>
+        ))}
+      </div>
+    </Figure>
+  );
+}
+
+/* ------------------------------------------------------- 7. big stat row */
+
+export interface StatTile {
+  label: string;
+  value: string;
+  detail: string;
+}
+
+/**
+ * StatRow — a KPI row of stat tiles. Values here are definitional (what a run
+ * returns), not measured outcomes, so they carry no chart and no ramp.
+ */
+export function StatRow({ tiles, onInk = false }: { tiles: readonly StatTile[]; onInk?: boolean }) {
+  return (
+    <RevealStagger as="ul" childAs="li" step={0.07} className="grid gap-px sm:grid-cols-2 lg:grid-cols-4">
+      {tiles.map((tile) => (
+        <div
+          key={tile.label}
+          className={cn(
+            "flex h-full flex-col justify-between gap-5 p-5",
+            onInk ? "bg-ink" : "bg-white",
+          )}
+        >
+          <p
+            className={cn(
+              "text-[11px] font-semibold uppercase tracking-[0.2em]",
+              onInk ? "text-ink-300" : "text-ink-400",
+            )}
+          >
+            {tile.label}
+          </p>
+          <div>
+            <p
+              className={cn(
+                "font-display text-[2.6rem] font-medium leading-none tracking-[-0.04em]",
+                onInk ? "text-[color:var(--text-on-ink)]" : "text-ink-900",
+              )}
+            >
+              {tile.value}
+            </p>
+            <p className={cn("mt-2 text-[13px] leading-[1.6]", onInk ? "text-ink-300" : "text-ink-500")}>
+              {tile.detail}
+            </p>
+          </div>
+        </div>
+      ))}
+    </RevealStagger>
+  );
+}

--- a/client/src/components/site/motion.tsx
+++ b/client/src/components/site/motion.tsx
@@ -1,0 +1,356 @@
+/**
+ * Public-site motion primitives.
+ *
+ * Two invariants, because the public pages are prerendered to static HTML by
+ * `scripts/prerender.tsx` and must be readable with no JavaScript at all:
+ *
+ * 1. **Never ship hidden content.** These helpers render their children plainly
+ *    and fully visible on the server and on the first client paint. The enter
+ *    animation is only armed after mount, and only for elements that are still
+ *    outside the viewport at that moment — so above-the-fold content is never
+ *    animated from `opacity: 0` (which would flash) and prerendered HTML never
+ *    contains invisible text.
+ * 2. **Reduced motion wins outright.** Under `prefers-reduced-motion: reduce`
+ *    nothing here animates; every helper stays in its static branch.
+ *
+ * Transforms and opacity only, so nothing here triggers layout.
+ */
+import {
+  Children,
+  isValidElement,
+  useEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type ReactNode,
+} from "react";
+
+import {
+  motion,
+  useInView,
+  useReducedMotion,
+  useScroll,
+  useSpring,
+  useTransform,
+  type MotionStyle,
+  type SVGMotionProps,
+} from "framer-motion";
+
+import { cn } from "@/lib/utils";
+
+const EASE_OUT_BP = [0.16, 1, 0.3, 1] as const;
+
+/**
+ * useArmedReveal — decides whether an element may animate in.
+ *
+ * Returns a ref to attach to the static element, and `armed`. `armed` starts
+ * false (server render, first paint, reduced motion, and anything already on
+ * screen) and only flips true after mount for elements still below the fold.
+ * Callers render plain markup while `armed` is false.
+ */
+function useArmedReveal<T extends Element>() {
+  const ref = useRef<T | null>(null);
+  const shouldReduce = useReducedMotion();
+  const [armed, setArmed] = useState(false);
+
+  useEffect(() => {
+    if (shouldReduce || typeof window === "undefined") return;
+    const node = ref.current;
+    if (!node) return;
+    const rect = node.getBoundingClientRect();
+    const alreadyVisible = rect.top < window.innerHeight && rect.bottom > 0;
+    // Only arm what the reader has not seen yet; anything on screen stays put.
+    if (!alreadyVisible) setArmed(true);
+  }, [shouldReduce]);
+
+  return { ref, armed };
+}
+
+type RevealDirection = "up" | "left" | "right" | "none";
+
+export interface RevealProps {
+  children: ReactNode;
+  className?: string;
+  /** Seconds of delay before the reveal starts. */
+  delay?: number;
+  /** Seconds the reveal takes. */
+  duration?: number;
+  /** Offset direction the element travels from. */
+  from?: RevealDirection;
+  /** Travel distance in px. */
+  distance?: number;
+  /** Render as a different element (default `div`). */
+  as?: "div" | "li" | "section" | "article" | "span";
+}
+
+const offsetFor = (from: RevealDirection, distance: number) => {
+  switch (from) {
+    case "left":
+      return { x: -distance, y: 0 };
+    case "right":
+      return { x: distance, y: 0 };
+    case "none":
+      return { x: 0, y: 0 };
+    default:
+      return { x: 0, y: distance };
+  }
+};
+
+/**
+ * Reveal — fades and slides a block in the first time it enters the viewport.
+ */
+export function Reveal({
+  children,
+  className,
+  delay = 0,
+  duration = 0.7,
+  from = "up",
+  distance = 22,
+  as = "div",
+}: RevealProps) {
+  const { ref, armed } = useArmedReveal<HTMLElement>();
+  const offset = offsetFor(from, distance);
+
+  // Static branch: server render, first paint, reduced motion, and anything
+  // already on screen. Content is fully visible here.
+  if (!armed) {
+    const Tag = as;
+    return (
+      <Tag ref={ref as React.Ref<never>} className={className}>
+        {children}
+      </Tag>
+    );
+  }
+
+  const MotionTag = motion[as];
+  return (
+    <MotionTag
+      className={className}
+      initial={{ opacity: 0, ...offset }}
+      whileInView={{ opacity: 1, x: 0, y: 0 }}
+      viewport={{ once: true, margin: "-12% 0px -8% 0px" }}
+      transition={{ duration, delay, ease: EASE_OUT_BP }}
+    >
+      {children}
+    </MotionTag>
+  );
+}
+
+export interface RevealStaggerProps {
+  children: ReactNode;
+  className?: string;
+  /** Seconds between each child. */
+  step?: number;
+  /** Seconds before the first child. */
+  delay?: number;
+  from?: RevealDirection;
+  distance?: number;
+  /** Element for the wrapper and each child slot. */
+  as?: "div" | "ol" | "ul";
+  childAs?: "div" | "li" | "article";
+}
+
+/**
+ * RevealStagger — wraps each direct child in a Reveal with an increasing delay,
+ * so grids and lists arrive in reading order instead of all at once.
+ */
+export function RevealStagger({
+  children,
+  className,
+  step = 0.07,
+  delay = 0,
+  from = "up",
+  distance = 18,
+  as: Wrapper = "div",
+  childAs = "div",
+}: RevealStaggerProps) {
+  const items = Children.toArray(children).filter(isValidElement);
+
+  return (
+    <Wrapper className={className}>
+      {items.map((child, index) => (
+        <Reveal
+          key={child.key ?? index}
+          as={childAs}
+          from={from}
+          distance={distance}
+          delay={delay + index * step}
+        >
+          {child}
+        </Reveal>
+      ))}
+    </Wrapper>
+  );
+}
+
+/**
+ * ParallaxMedia — nudges large media against the scroll direction. The shift is
+ * deliberately small (default 40px total) so the frame never detaches from its
+ * caption. Under reduced motion the child renders in place.
+ */
+export function ParallaxMedia({
+  children,
+  className,
+  shift = 40,
+}: {
+  children: ReactNode;
+  className?: string;
+  shift?: number;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+  const shouldReduce = useReducedMotion();
+  const { scrollYProgress } = useScroll({
+    target: ref,
+    offset: ["start end", "end start"],
+  });
+  const y = useTransform(scrollYProgress, [0, 1], [shift, -shift]);
+
+  return (
+    <div ref={ref} className={cn("overflow-hidden", className)}>
+      <motion.div
+        className="h-full w-full"
+        style={shouldReduce ? undefined : ({ y } as MotionStyle)}
+      >
+        {children}
+      </motion.div>
+    </div>
+  );
+}
+
+/**
+ * ScrollProgressRail — a vertical hairline whose brass fill tracks how far the
+ * reader has scrolled through the wrapped section. Used to bind long stepped
+ * sections together. Renders a static full rail under reduced motion.
+ */
+export function ScrollProgressRail({
+  children,
+  className,
+  railClassName,
+}: {
+  children: ReactNode;
+  className?: string;
+  railClassName?: string;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+  const shouldReduce = useReducedMotion();
+  const { scrollYProgress } = useScroll({
+    target: ref,
+    offset: ["start 70%", "end 60%"],
+  });
+  const scaleY = useSpring(scrollYProgress, { stiffness: 120, damping: 30, mass: 0.4 });
+
+  return (
+    <div ref={ref} className={cn("relative", className)}>
+      <div
+        aria-hidden="true"
+        className={cn("absolute bottom-0 top-0 w-px bg-line", railClassName)}
+      >
+        <motion.div
+          className="h-full w-full origin-top bg-brass-deep"
+          style={shouldReduce ? { transform: "scaleY(1)" } : ({ scaleY } as MotionStyle)}
+        />
+      </div>
+      {children}
+    </div>
+  );
+}
+
+/**
+ * DrawIn — animates an SVG path's `stroke-dashoffset` from hidden to drawn once
+ * the path scrolls into view. The path renders fully drawn under reduced motion.
+ *
+ * Callers pass the same props they would give `<path>`; `pathLength={1}`
+ * normalises the dash math so no measurement pass is needed.
+ */
+export function DrawIn({
+  d,
+  className,
+  delay = 0,
+  duration = 1.4,
+  ...pathProps
+}: {
+  d: string;
+  className?: string;
+  delay?: number;
+  duration?: number;
+} & Omit<SVGMotionProps<SVGPathElement>, "d" | "className" | "ref">) {
+  const { ref, armed } = useArmedReveal<SVGPathElement>();
+  const inView = useInView(ref, { once: true, margin: "-10% 0px" });
+
+  // Static branch renders the path fully drawn, so prerendered SVG is never blank.
+  if (!armed) {
+    return <path ref={ref} d={d} className={className} {...(pathProps as object)} />;
+  }
+
+  return (
+    <motion.path
+      d={d}
+      className={className}
+      pathLength={1}
+      initial={{ pathLength: 0, opacity: 0 }}
+      animate={{ pathLength: inView ? 1 : 0, opacity: inView ? 1 : 0 }}
+      transition={{
+        pathLength: { duration, delay, ease: EASE_OUT_BP },
+        opacity: { duration: 0.2, delay },
+      }}
+      {...pathProps}
+    />
+  );
+}
+
+/**
+ * GrowIn — scales a mark from its baseline when scrolled into view. `origin`
+ * picks which edge stays pinned, so bars grow out of their axis rather than
+ * out of their own centre.
+ */
+export function GrowIn({
+  children,
+  className,
+  delay = 0,
+  duration = 0.75,
+  origin = "left",
+  style,
+}: {
+  children: ReactNode;
+  className?: string;
+  delay?: number;
+  duration?: number;
+  origin?: "left" | "bottom";
+  style?: CSSProperties;
+}) {
+  const { ref, armed } = useArmedReveal<HTMLDivElement>();
+  const axis = origin === "left" ? "scaleX" : "scaleY";
+
+  // Static branch renders the mark at full size, so a prerendered bar is not
+  // collapsed to zero width.
+  if (!armed) {
+    return (
+      <div ref={ref} className={className} style={style}>
+        {children}
+      </div>
+    );
+  }
+
+  return (
+    <motion.div
+      className={className}
+      style={{ ...style, transformOrigin: origin === "left" ? "left center" : "bottom center" }}
+      initial={{ [axis]: 0, opacity: 0.35 }}
+      whileInView={{ [axis]: 1, opacity: 1 }}
+      viewport={{ once: true, margin: "-8% 0px" }}
+      transition={{ duration, delay, ease: EASE_OUT_BP }}
+    >
+      {children}
+    </motion.div>
+  );
+}
+
+/**
+ * useHasMounted — guards client-only motion so prerendered HTML and the first
+ * client paint agree. The prerender pass ships the resolved layout.
+ */
+export function useHasMounted(): boolean {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+  return mounted;
+}

--- a/client/src/components/site/motion.tsx
+++ b/client/src/components/site/motion.tsx
@@ -27,7 +27,6 @@ import {
 
 import {
   motion,
-  useInView,
   useReducedMotion,
   useScroll,
   useSpring,
@@ -275,20 +274,24 @@ export function DrawIn({
   duration?: number;
 } & Omit<SVGMotionProps<SVGPathElement>, "d" | "className" | "ref">) {
   const { ref, armed } = useArmedReveal<SVGPathElement>();
-  const inView = useInView(ref, { once: true, margin: "-10% 0px" });
 
   // Static branch renders the path fully drawn, so prerendered SVG is never blank.
   if (!armed) {
     return <path ref={ref} d={d} className={className} {...(pathProps as object)} />;
   }
 
+  // `whileInView` is deliberate: arming swaps the plain <path> for this
+  // motion.path, which unmounts the node `ref` pointed at. Driving the animation
+  // from an external useInView(ref) would leave the ref null and the path stuck
+  // invisible, so viewport detection is left to framer's own internal ref.
   return (
     <motion.path
       d={d}
       className={className}
       pathLength={1}
       initial={{ pathLength: 0, opacity: 0 }}
-      animate={{ pathLength: inView ? 1 : 0, opacity: inView ? 1 : 0 }}
+      whileInView={{ pathLength: 1, opacity: 1 }}
+      viewport={{ once: true, margin: "-10% 0px" }}
       transition={{
         pathLength: { duration, delay, ease: EASE_OUT_BP },
         opacity: { duration: 0.2, delay },

--- a/client/src/components/site/publicSections.tsx
+++ b/client/src/components/site/publicSections.tsx
@@ -1,0 +1,504 @@
+/**
+ * Layout pieces for the redesigned public pages.
+ *
+ * The previous public site was built almost entirely from one device — a
+ * hairline grid of equal white tiles — which flattened every section into the
+ * same rhythm. These pieces exist to give the pages a shape: a hero whose media
+ * runs to the edge of the viewport, alternating ink and paper bands, numbered
+ * section headers at a real display size, and editorial splits that are
+ * deliberately asymmetric.
+ *
+ * Media stays large on purpose. Every image here is sized in viewport units or
+ * wide aspect ratios rather than being boxed into a card.
+ */
+import type { ReactNode } from "react";
+
+import { ArrowRight } from "lucide-react";
+
+import { Button } from "@/components/blueprint";
+import { cn } from "@/lib/utils";
+
+import { MonochromeMedia, ProofChip, RouteTraceOverlay } from "./editorial";
+import { ParallaxMedia, Reveal } from "./motion";
+
+/* ------------------------------------------------------------------- bands */
+
+type Tone = "canvas" | "paper" | "ink" | "white";
+
+const toneClass: Record<Tone, string> = {
+  canvas: "bg-canvas",
+  paper: "bg-paper",
+  ink: "bg-ink",
+  white: "bg-white",
+};
+
+/**
+ * Band — a full-width page section. `tone` alternates the page rhythm; `rule`
+ * adds the hairline that separates two light bands.
+ */
+export function Band({
+  children,
+  tone = "canvas",
+  rule = false,
+  className,
+  id,
+}: {
+  children: ReactNode;
+  tone?: Tone;
+  rule?: boolean;
+  className?: string;
+  id?: string;
+}) {
+  return (
+    <section
+      id={id}
+      className={cn(
+        toneClass[tone],
+        rule && tone !== "ink" && "border-y border-line",
+        tone === "ink" && "border-y border-white/10",
+        className,
+      )}
+    >
+      {children}
+    </section>
+  );
+}
+
+/** Inner — the shared 88rem measure and page gutters. */
+export function Inner({
+  children,
+  className,
+  size = "default",
+}: {
+  children: ReactNode;
+  className?: string;
+  size?: "default" | "narrow" | "prose";
+}) {
+  return (
+    <div
+      className={cn(
+        "mx-auto px-5 sm:px-8 lg:px-10",
+        size === "default" && "max-w-[88rem]",
+        size === "narrow" && "max-w-[72rem]",
+        size === "prose" && "max-w-[58rem]",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------- hero */
+
+export interface PageHeroProps {
+  eyebrow: string;
+  title: string;
+  body: string;
+  chips?: readonly string[];
+  ctaHref: string;
+  ctaLabel: string;
+  secondaryHref?: string;
+  secondaryLabel?: string;
+  imageSrc: string;
+  imageAlt: string;
+  /** Caption chip rendered over the media. */
+  imageCaption?: string;
+  /** Draws the brass capture-route motif over the media. */
+  routeTrace?: boolean;
+}
+
+/**
+ * PageHero — headline left, large media right, running to the right edge of the
+ * viewport on desktop rather than sitting inside a card. The media is the
+ * biggest thing on the page by a wide margin, which is the point.
+ */
+export function PageHero({
+  eyebrow,
+  title,
+  body,
+  chips,
+  ctaHref,
+  ctaLabel,
+  secondaryHref,
+  secondaryLabel,
+  imageSrc,
+  imageAlt,
+  imageCaption,
+  routeTrace = false,
+}: PageHeroProps) {
+  return (
+    <section className="relative overflow-hidden bg-canvas">
+      <div className="mx-auto grid max-w-[110rem] items-center gap-10 lg:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)] lg:gap-14">
+        <div className="px-5 pb-4 pt-14 sm:px-8 lg:py-28 lg:pl-[max(2.5rem,calc((100vw-88rem)/2+2.5rem))] lg:pr-0">
+          <Reveal from="up" distance={14}>
+            <p className="inline-flex items-center gap-[0.6rem] text-[11px] font-semibold uppercase tracking-[0.2em] leading-none text-brass-deep">
+              <span aria-hidden="true" className="h-px w-6 shrink-0 bg-current opacity-50" />
+              {eyebrow}
+            </p>
+          </Reveal>
+
+          <Reveal from="up" distance={20} delay={0.06}>
+            <h1 className="mt-6 max-w-[18ch] font-display text-[clamp(2.9rem,6.2vw,5.6rem)] font-medium leading-[0.95] tracking-[-0.05em] text-ink-900">
+              {title}
+            </h1>
+          </Reveal>
+
+          <Reveal from="up" distance={18} delay={0.14}>
+            <p className="mt-7 max-w-[46ch] text-[1.06rem] leading-[1.75] text-ink-600">
+              {body}
+            </p>
+          </Reveal>
+
+          <Reveal from="up" distance={16} delay={0.22}>
+            <div className="mt-9 flex flex-col gap-3 sm:flex-row sm:items-center">
+              <Button asChild variant="brass" size="lg">
+                <a href={ctaHref}>
+                  {ctaLabel} <ArrowRight className="h-4 w-4" />
+                </a>
+              </Button>
+              {secondaryHref && secondaryLabel ? (
+                <Button asChild variant="ghost" size="lg">
+                  <a href={secondaryHref}>{secondaryLabel}</a>
+                </Button>
+              ) : null}
+            </div>
+          </Reveal>
+
+          {chips && chips.length > 0 ? (
+            <Reveal from="up" distance={14} delay={0.3}>
+              <div className="mt-8 flex flex-wrap gap-2">
+                {chips.map((chip) => (
+                  <ProofChip key={chip}>{chip}</ProofChip>
+                ))}
+              </div>
+            </Reveal>
+          ) : null}
+        </div>
+
+        <Reveal from="right" distance={28} delay={0.1} className="relative">
+          <ParallaxMedia
+            shift={26}
+            className="relative h-[58vw] max-h-[42rem] min-h-[20rem] lg:h-[80vh] lg:max-h-[52rem] lg:rounded-l-xl"
+          >
+            <MonochromeMedia
+              src={imageSrc}
+              alt={imageAlt}
+              loading="eager"
+              radius="none"
+              overlay="soft"
+              className="h-[calc(100%+3.5rem)] w-full"
+              imageClassName="h-full"
+            >
+              {routeTrace ? <RouteTraceOverlay /> : null}
+            </MonochromeMedia>
+          </ParallaxMedia>
+          {imageCaption ? (
+            <span className="pointer-events-none absolute bottom-4 left-4 inline-flex items-center gap-2 rounded-xs border border-white/15 bg-black/40 px-2.5 py-1.5 font-mono text-[10px] uppercase tracking-[0.16em] text-[color:var(--text-on-ink)] backdrop-blur-sm">
+              <span aria-hidden="true" className="h-[0.35rem] w-[0.35rem] rounded-full bg-brass" />
+              {imageCaption}
+            </span>
+          ) : null}
+        </Reveal>
+      </div>
+    </section>
+  );
+}
+
+/* -------------------------------------------------------- section headers */
+
+/**
+ * SectionHeader — numbered, at a real display size, with the lede set beside
+ * the heading rather than under it so long sections do not open with a wall.
+ */
+export function SectionHeader({
+  index,
+  eyebrow,
+  title,
+  lede,
+  onInk = false,
+  className,
+}: {
+  /** Two-digit section index, e.g. "02". Omit for unnumbered sections. */
+  index?: string;
+  eyebrow: string;
+  title: string;
+  lede?: string;
+  onInk?: boolean;
+  className?: string;
+}) {
+  return (
+    <Reveal className={cn("grid gap-x-12 gap-y-5 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]", className)}>
+      <div>
+        <div className="flex items-baseline gap-4">
+          {index ? (
+            <span
+              className={cn(
+                "font-mono text-[11px] tracking-[0.2em]",
+                onInk ? "text-brass" : "text-brass-deep",
+              )}
+            >
+              {index}
+            </span>
+          ) : null}
+          <p
+            className={cn(
+              "text-[11px] font-semibold uppercase tracking-[0.2em]",
+              onInk ? "text-ink-300" : "text-ink-500",
+            )}
+          >
+            {eyebrow}
+          </p>
+        </div>
+        <h2
+          className={cn(
+            "mt-5 max-w-[26ch] font-display text-[clamp(2.1rem,3.8vw,3.5rem)] font-medium leading-[1.02] tracking-[-0.035em]",
+            onInk ? "text-[color:var(--text-on-ink)]" : "text-ink-900",
+          )}
+        >
+          {title}
+        </h2>
+      </div>
+      {lede ? (
+        <p
+          className={cn(
+            "max-w-[46ch] self-end text-[15.5px] leading-[1.75]",
+            onInk ? "text-ink-300" : "text-ink-500",
+          )}
+        >
+          {lede}
+        </p>
+      ) : null}
+    </Reveal>
+  );
+}
+
+/* ------------------------------------------------------------ media split */
+
+/**
+ * MediaSplit — a tall image beside a block of content, with the image allowed to
+ * be the dominant element. `flip` puts the media on the left.
+ */
+export function MediaSplit({
+  imageSrc,
+  imageAlt,
+  imageCaption,
+  children,
+  flip = false,
+  className,
+}: {
+  imageSrc: string;
+  imageAlt: string;
+  imageCaption?: string;
+  children: ReactNode;
+  flip?: boolean;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "grid items-center gap-10 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] lg:gap-16",
+        className,
+      )}
+    >
+      <Reveal
+        from={flip ? "left" : "right"}
+        distance={24}
+        className={cn("relative", flip ? "lg:order-first" : "lg:order-last")}
+      >
+        <ParallaxMedia shift={22} className="rounded-lg">
+          <MonochromeMedia
+            src={imageSrc}
+            alt={imageAlt}
+            radius="lg"
+            overlay="soft"
+            className="aspect-[4/5] w-full border border-line sm:aspect-[16/12] lg:aspect-[4/5]"
+            imageClassName="h-[calc(100%+2.75rem)]"
+          />
+        </ParallaxMedia>
+        {imageCaption ? (
+          <span className="pointer-events-none absolute bottom-4 left-4 inline-flex items-center gap-2 rounded-xs border border-white/15 bg-black/40 px-2.5 py-1.5 font-mono text-[10px] uppercase tracking-[0.16em] text-[color:var(--text-on-ink)]">
+            <span aria-hidden="true" className="h-[0.35rem] w-[0.35rem] rounded-full bg-brass" />
+            {imageCaption}
+          </span>
+        ) : null}
+      </Reveal>
+      <Reveal from={flip ? "right" : "left"} distance={20}>
+        {children}
+      </Reveal>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------ full bleed */
+
+/**
+ * FullBleedMedia — an edge-to-edge image band with an overlaid line of copy.
+ * Used to break up long pages with something other than another card grid.
+ */
+export function FullBleedMedia({
+  src,
+  alt,
+  eyebrow,
+  title,
+  body,
+  className,
+}: {
+  src: string;
+  alt: string;
+  eyebrow?: string;
+  title: string;
+  body?: string;
+  className?: string;
+}) {
+  return (
+    <section className={cn("relative isolate overflow-hidden bg-ink", className)}>
+      <ParallaxMedia shift={34} className="absolute inset-0">
+        <MonochromeMedia
+          src={src}
+          alt={alt}
+          radius="none"
+          overlay="heroL"
+          className="h-[calc(100%+4.25rem)] w-full"
+          imageClassName="h-full"
+        />
+      </ParallaxMedia>
+      <Inner className="relative py-24 lg:py-36">
+        <Reveal className="max-w-[34rem]">
+          {eyebrow ? (
+            <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-brass">
+              {eyebrow}
+            </p>
+          ) : null}
+          <h2 className="mt-5 font-display text-[clamp(2rem,3.6vw,3.2rem)] font-medium leading-[1.04] tracking-[-0.035em] text-[color:var(--text-on-ink)]">
+            {title}
+          </h2>
+          {body ? (
+            <p className="mt-5 text-[15.5px] leading-[1.75] text-[color:var(--text-on-ink)] opacity-80">
+              {body}
+            </p>
+          ) : null}
+        </Reveal>
+      </Inner>
+    </section>
+  );
+}
+
+/* ------------------------------------------------------------- note cards */
+
+/**
+ * NoteCards — the honest-limits device. Deliberately plain: ink-on-paper cards
+ * with a brass rule, rather than four amber warning boxes in a row, which read
+ * as apology instead of precision.
+ */
+export function NoteCards({
+  items,
+  onInk = false,
+  className,
+}: {
+  items: readonly { title: string; body: string }[];
+  onInk?: boolean;
+  className?: string;
+}) {
+  return (
+    <div className={cn("grid gap-x-10 gap-y-8 sm:grid-cols-2", className)}>
+      {items.map((item, index) => (
+        <Reveal key={item.title} delay={index * 0.06}>
+          <div
+            className={cn(
+              "border-t pt-5",
+              onInk ? "border-white/15" : "border-line-strong",
+            )}
+          >
+            <h3
+              className={cn(
+                "text-[15px] font-semibold tracking-[-0.01em]",
+                onInk ? "text-[color:var(--text-on-ink)]" : "text-ink-900",
+              )}
+            >
+              {item.title}
+            </h3>
+            <p
+              className={cn(
+                "mt-2.5 max-w-[44ch] text-[14px] leading-[1.7]",
+                onInk ? "text-ink-300" : "text-ink-500",
+              )}
+            >
+              {item.body}
+            </p>
+          </div>
+        </Reveal>
+      ))}
+    </div>
+  );
+}
+
+/* ---------------------------------------------------------------- closing */
+
+/**
+ * ClosingCta — the end-of-page call to action. Ink panel, large media on the
+ * right, single primary action.
+ */
+export function ClosingCta({
+  eyebrow,
+  title,
+  body,
+  primaryHref,
+  primaryLabel,
+  secondaryHref,
+  secondaryLabel,
+  imageSrc,
+  imageAlt,
+}: {
+  eyebrow: string;
+  title: string;
+  body: string;
+  primaryHref: string;
+  primaryLabel: string;
+  secondaryHref?: string;
+  secondaryLabel?: string;
+  imageSrc: string;
+  imageAlt: string;
+}) {
+  return (
+    <section className="relative isolate overflow-hidden bg-ink">
+      <div className="absolute inset-y-0 right-0 hidden w-[46%] lg:block">
+        <MonochromeMedia
+          src={imageSrc}
+          alt={imageAlt}
+          radius="none"
+          overlay="none"
+          className="h-full w-full"
+          imageClassName="h-full"
+          overlayClassName="bg-[linear-gradient(90deg,rgba(13,13,11,0.98),rgba(13,13,11,0.6)_44%,rgba(13,13,11,0.15))]"
+        />
+      </div>
+      <Inner className="relative py-20 lg:py-28">
+        <Reveal className="max-w-[38rem]">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-brass">{eyebrow}</p>
+          <h2 className="mt-5 font-display text-[clamp(2.2rem,4vw,3.6rem)] font-medium leading-[1.02] tracking-[-0.04em] text-[color:var(--text-on-ink)]">
+            {title}
+          </h2>
+          <p className="mt-5 max-w-[44ch] text-[15.5px] leading-[1.75] text-[color:var(--text-on-ink)] opacity-80">
+            {body}
+          </p>
+          <div className="mt-9 flex flex-col gap-3 sm:flex-row sm:items-center">
+            <Button asChild variant="brass" size="lg">
+              <a href={primaryHref}>
+                {primaryLabel} <ArrowRight className="h-4 w-4" />
+              </a>
+            </Button>
+            {secondaryHref && secondaryLabel ? (
+              <a
+                href={secondaryHref}
+                className="inline-flex h-[3.25rem] items-center justify-center rounded-sm px-5 text-[15px] font-semibold tracking-[-0.01em] text-[color:var(--text-on-ink)] transition-colors hover:bg-white/5"
+              >
+                {secondaryLabel}
+              </a>
+            ) : null}
+          </div>
+        </Reveal>
+      </Inner>
+    </section>
+  );
+}

--- a/client/src/data/publicSiteCopy.ts
+++ b/client/src/data/publicSiteCopy.ts
@@ -109,30 +109,40 @@ export const homeOutcomes: readonly OutcomeBand[] = [
   },
 ];
 
+// Ordered by relative cost to run, NOT by authority. Real capture is the source
+// of truth; a costlier derived method never outranks it. Each entry carries an
+// explicit `basis` so the public figure cannot be read as a proof hierarchy.
 export const homeEvidenceRungs: readonly EvidenceRung[] = [
   {
     label: "Geometry and reach",
+    basis: "Computed from capture",
     cost: 0.12,
     answers: "Whether the robot physically fits, reaches, and clears the space at all.",
   },
   {
     label: "Recorded real observations",
+    basis: "Real capture",
     cost: 0.3,
-    answers: "What actually happens at this site — traffic, lighting, clutter, timing.",
+    answers:
+      "What actually happens at this site — traffic, lighting, clutter, timing. The reference every derived method is checked against.",
     stopped: true,
   },
   {
     label: "Simulated rollouts",
+    basis: "Derived",
     cost: 0.52,
-    answers: "How a policy behaves across many variations of the task.",
+    answers: "How a policy behaves across many variations of the task, inside a stated envelope.",
   },
   {
     label: "Generated and model-based evidence",
+    basis: "Derived",
     cost: 0.71,
-    answers: "Coverage of conditions the capture did not contain, inside a stated envelope.",
+    answers:
+      "Advisory coverage of conditions the capture did not contain. Support for a claim, never ground truth for it.",
   },
   {
     label: "Evidence from real hardware",
+    basis: "Real world",
     cost: 0.94,
     answers: "The only thing that settles a physical claim. Sometimes there is no substitute.",
   },

--- a/client/src/data/publicSiteCopy.ts
+++ b/client/src/data/publicSiteCopy.ts
@@ -1,0 +1,401 @@
+// Rewritten public-site copy for the single Task Evaluation Run offer.
+//
+// The product boundaries here are identical to the ones in
+// `robotPolicyEvaluationClaims.ts` — this file exists to say them in plain
+// language on the marketing surface. Where that file is the canonical
+// machine-facing phrasing (SEO descriptions, structured data, agent context),
+// this is the buyer-facing voice.
+//
+// Rules that still hold in every line below:
+//   - one customer-facing service, no package tiers or add-ons
+//   - no published fixed price
+//   - the customer never selects a simulator, world model, or provider
+//   - a run may end in a refusal to decide, and that is a valid result
+//   - virtual evidence is never presented as a physical or safety guarantee
+//   - figure values on the public site are schematic, never live run data
+
+import type { EvidenceRung, ClaimInterval, OutcomeBand, DecisionCostRow, StatTile, LifecycleStage } from "@/components/site/figures";
+
+/* -------------------------------------------------------------- home page */
+
+export const homeHero = {
+  eyebrow: "One service · Task Evaluation Runs",
+  title: "Answer it before you send a robot.",
+  body:
+    "Field time is the most expensive possible way to learn that a policy does not work at your site. A Task Evaluation Run turns one real site-task into a testbed we maintain, tests the claims your decision actually rests on, and tells you what the evidence supports — including when it supports nothing yet.",
+  chips: [
+    "One service, one intake",
+    "Answers claim by claim",
+    "We say “not yet” out loud",
+  ],
+} as const;
+
+export const homeStats: readonly StatTile[] = [
+  {
+    label: "Services to choose from",
+    value: "One",
+    detail: "A Task Evaluation Run. No tiers, no packages, no separate add-ons.",
+  },
+  {
+    label: "Ways a run can end",
+    value: "Five",
+    detail: "Yes, no, partly, not yet — and the cheapest test that would settle it.",
+  },
+  {
+    label: "Backends you pick",
+    value: "Zero",
+    detail: "You describe the decision. Choosing the method is our job, not yours.",
+  },
+  {
+    label: "Published fixed prices",
+    value: "None",
+    detail: "Each run is scoped and quoted from the decision and evidence it needs.",
+  },
+];
+
+export const homeLifecycle: readonly LifecycleStage[] = [
+  {
+    label: "Bring one real task",
+    detail:
+      "A specific job at a specific site: the conditions, who can be there, what counts as success, and what must never happen.",
+  },
+  {
+    label: "We build the testbed",
+    detail:
+      "The site-task becomes a captured, versioned testbed we keep — so this answer and the next one are measured against the same thing.",
+  },
+  {
+    label: "You state the decision",
+    detail:
+      "Not “run a benchmark.” The actual call you are about to make, the threshold it turns on, and what a wrong yes would cost.",
+  },
+  {
+    label: "We route each claim",
+    detail:
+      "Every claim goes to the cheapest evidence strong enough to carry it, and climbs only when that is not enough.",
+  },
+  {
+    label: "You get an answer with its limits",
+    detail:
+      "What holds, what does not, what is still open, where the answer stops applying, and what to test next.",
+  },
+];
+
+export const homeOutcomes: readonly OutcomeBand[] = [
+  {
+    label: "Yes, within these conditions",
+    body: "The call is supported — and the report states exactly where that stops being true.",
+    tone: "supported",
+  },
+  {
+    label: "No",
+    body: "The evidence supports ruling the option out. A clear no is often the cheapest result you can buy.",
+    tone: "rejected",
+  },
+  {
+    label: "Partly",
+    body: "Some claims settled, others did not. You see which is which instead of an average that hides both.",
+    tone: "partial",
+  },
+  {
+    label: "Not yet",
+    body: "The evidence is not strong enough to answer. We say so rather than dress a guess up as a finding.",
+    tone: "abstained",
+  },
+  {
+    label: "Test this next",
+    body: "The least expensive experiment that would move the decision — including when that means real hardware.",
+    tone: "next",
+  },
+];
+
+export const homeEvidenceRungs: readonly EvidenceRung[] = [
+  {
+    label: "Geometry and reach",
+    cost: 0.12,
+    answers: "Whether the robot physically fits, reaches, and clears the space at all.",
+  },
+  {
+    label: "Recorded real observations",
+    cost: 0.3,
+    answers: "What actually happens at this site — traffic, lighting, clutter, timing.",
+    stopped: true,
+  },
+  {
+    label: "Simulated rollouts",
+    cost: 0.52,
+    answers: "How a policy behaves across many variations of the task.",
+  },
+  {
+    label: "Generated and model-based evidence",
+    cost: 0.71,
+    answers: "Coverage of conditions the capture did not contain, inside a stated envelope.",
+  },
+  {
+    label: "Evidence from real hardware",
+    cost: 0.94,
+    answers: "The only thing that settles a physical claim. Sometimes there is no substitute.",
+  },
+];
+
+export const homeClaims: readonly ClaimInterval[] = [
+  {
+    claim: "Candidate A can reach the fixture from the approach lane.",
+    estimate: 0.97,
+    low: 0.95,
+    high: 0.99,
+    verdict: "supported",
+  },
+  {
+    claim: "Candidate B clears the dock door at loaded height.",
+    estimate: 0.62,
+    low: 0.54,
+    high: 0.7,
+    verdict: "rejected",
+  },
+  {
+    claim: "Candidate A outperforms candidate B on this site.",
+    estimate: 0.88,
+    low: 0.79,
+    high: 0.96,
+    verdict: "unresolved",
+  },
+];
+
+export const homeClaimThreshold = 0.9;
+export const homeClaimMetricLabel = "success rate";
+
+export const homeDecisionCost: readonly DecisionCostRow[] = [
+  {
+    label: "When you find out a policy will not work here",
+    beforeLabel: "After the robot is already on site",
+    afterLabel: "Before you schedule the visit",
+  },
+  {
+    label: "What a negative answer costs you",
+    beforeLabel: "A trip, a crew, and a slot on the floor",
+    afterLabel: "A run, and the reason it failed",
+  },
+  {
+    label: "What you can put in front of a reviewer",
+    beforeLabel: "A demo reel and a judgement call",
+    afterLabel: "Claims, the evidence behind each, and stated limits",
+  },
+];
+
+export const homeLimits = [
+  {
+    title: "A run is evidence, not permission",
+    body:
+      "Nothing we return is a safety approval, a certification, or a licence to operate. Those stay with you and your regulator.",
+  },
+  {
+    title: "Virtual evidence has an edge",
+    body:
+      "Every estimate comes with the conditions it was measured under. Outside them it is not a weaker claim — it is not a claim.",
+  },
+  {
+    title: "Some claims need hardware",
+    body:
+      "Contact-heavy and safety-critical questions often cannot be settled short of real robots. When that is the case, the run says so.",
+  },
+  {
+    title: "Where we are strongest today",
+    body:
+      "Navigation, mobile-base movement, and rigid pick-and-place in warehouse and logistics spaces. We will tell you when your task is outside that.",
+  },
+] as const;
+
+/* ------------------------------------------------------- robot-team page */
+
+export const robotTeamHero = {
+  eyebrow: "Task Evaluation Runs · for robot teams",
+  title: "Spend field time on the candidate that earned it.",
+  body:
+    "You have more checkpoints than sites, and more sites than weeks. Bring the candidates and the site-task, and find out which questions the current evidence can already close — and which ones only a real robot will settle.",
+  chips: ["Bring policies or checkpoints", "Incompatibility found early", "A no is a useful result"],
+} as const;
+
+export const robotTeamValue = [
+  {
+    title: "Compare your own candidates",
+    body:
+      "Several checkpoints, one task, one threshold, one set of conditions. Same substrate for every candidate, so the comparison means something.",
+  },
+  {
+    title: "Find the disqualifiers first",
+    body:
+      "Reach, footprint, embodiment, observation and action mismatches, environmental limits. Cheap to discover here, expensive to discover on site.",
+  },
+  {
+    title: "Decide what to do next",
+    body:
+      "Test physically, recapture, narrow the task, or stop. The run names the next move and what it would cost you.",
+  },
+] as const;
+
+export const robotTeamFlow: readonly LifecycleStage[] = [
+  {
+    label: "Describe the call",
+    detail:
+      "The decision in front of you, the candidates, the threshold, and what a wrong yes would cost. Budget and deadline included.",
+  },
+  {
+    label: "Pin the substrate",
+    detail: "The run is bound to one exact testbed version and digest, so results stay comparable later.",
+  },
+  {
+    label: "Claims get routed",
+    detail: "Each claim goes to the cheapest evidence strong enough to carry it. You do not choose the method.",
+  },
+  {
+    label: "Read what holds",
+    detail: "Supported, ruled out, still open — per claim, with the conditions attached. Not one number.",
+  },
+  {
+    label: "Commit the field time",
+    detail: "Now the trip is a test of something specific, not a fishing expedition.",
+  },
+];
+
+/* --------------------------------------------------- site-operator page */
+
+export const siteOperatorHero = {
+  eyebrow: "Task Evaluation Runs · for site operators",
+  title: "Find out what a robot could do here, before anyone shows up.",
+  body:
+    "You do not need a policy, a vendor, or an evaluation stack to start. Describe the job you would hand to a robot and the terms you would hand it under. We turn that into a testbed we maintain and a decision you can inspect.",
+  chips: ["No candidate needed to start", "You keep control of access", "Rights and privacy in writing"],
+} as const;
+
+export const siteOperatorNeeds = [
+  {
+    title: "Start with the job, not a robot",
+    body:
+      "The workflow, the shifts, the conditions, the failures you will not accept. That is enough to scope a run.",
+  },
+  {
+    title: "See what is missing",
+    body:
+      "The run separates what your site can already answer from what needs stronger evidence — or real hardware.",
+  },
+  {
+    title: "Judge candidates on your terms",
+    body:
+      "When vendors or policies arrive, they enter the same run, against the same task and the same threshold.",
+  },
+  {
+    title: "Keep the parts that matter to you",
+    body:
+      "Capture windows, restricted areas, privacy, who may use the evidence, and whether anyone tests on your floor.",
+  },
+] as const;
+
+export const siteOperatorControls = [
+  { label: "Capture windows", detail: "You set when, where, and who is on site." },
+  { label: "Restricted areas", detail: "Excluded before capture, not redacted after." },
+  { label: "Evidence use", detail: "What the run may be used for is written down, per artifact." },
+  { label: "Physical access", detail: "Any test on your floor is a separate, explicit yes." },
+] as const;
+
+/* ------------------------------------------------------ how-it-works page */
+
+export const howItWorksSteps = [
+  {
+    title: "Say what you need to decide",
+    body:
+      "The question, the claims under it, the threshold and its units, what a wrong yes would cost, how much risk is acceptable, your budget and deadline, what evidence already exists, and anything we may not do.",
+  },
+  {
+    title: "Bind the run to a testbed",
+    body:
+      "One exact testbed ID, version, and digest. Raw capture stays the source of truth — derived evidence never quietly gets promoted to fact.",
+  },
+  {
+    title: "Route every claim separately",
+    body:
+      "Geometry, real observations, simulation, world models, provider tools, physical tests: each claim gets the cheapest one strong enough. Choosing is our job.",
+  },
+  {
+    title: "Measure and combine honestly",
+    body:
+      "Each method reports what it measured, under what conditions, how sure it is, and where methods disagreed. Disagreement is reported, not averaged away.",
+  },
+  {
+    title: "Return the answer and its edges",
+    body:
+      "Yes, no, partly, or not yet. Unknown states fail closed, and a refusal to decide is never converted into a winner by comparing raw scores.",
+  },
+  {
+    title: "Name the next cheapest test",
+    body:
+      "When the evidence falls short, the run says what would close the gap and whether that means real hardware.",
+  },
+] as const;
+
+export const howItWorksSplit = {
+  blueprint: [
+    "Secure intake and who is allowed to see what",
+    "The maintained testbed, its versions and digests",
+    "Durable records of every request and result",
+    "Provenance, rights, and permitted-use tracking",
+  ],
+  pipeline: [
+    "Whether a method is qualified for a given claim",
+    "Which evidence a claim is routed to, and when to escalate",
+    "What was measured, and how sure the measurement is",
+    "The verdict — including the decision to abstain",
+  ],
+} as const;
+
+/* ------------------------------------------------------------ pricing page */
+
+export const pricingHero = {
+  eyebrow: "One service · scoped per run",
+  title: "You pay for the decision, not a package.",
+  body:
+    "There is one thing to buy and no price list, because two runs that sound alike can need very different evidence. We scope the run with you and quote it before anything is authorised.",
+} as const;
+
+export const pricingDrivers = [
+  { label: "The decision", detail: "How consequential it is, and how strong the evidence has to be to carry it." },
+  { label: "What already exists", detail: "An existing testbed and prior evidence make a run cheaper. A cold start does not." },
+  { label: "Candidates and scenarios", detail: "How many things are being compared, across how many conditions." },
+  { label: "Compute and deadline", detail: "What the evidence plan needs, and how fast you need it." },
+  { label: "Rights and privacy", detail: "Restrictions on capture, storage, providers, and permitted use." },
+  { label: "Physical work", detail: "Whether settling the claims requires anyone on a real floor." },
+] as const;
+
+export const pricingIncluded = [
+  "One decision-shaped request against a real site-task",
+  "A versioned testbed reference the result is bound to",
+  "Claim, threshold, risk, budget, and deadline scoping",
+  "An evidence plan chosen per claim, and the reasoning",
+  "The answer: yes, no, partly, or not yet",
+  "The conditions it holds under, and where it stops",
+  "Uncertainty, and any disagreement between methods",
+  "The next cheapest test, and whether hardware is required",
+  "Exact provenance, and what each artifact may be used for",
+] as const;
+
+export const pricingBoundaries = [
+  {
+    title: "A quote buys the work, not the answer you wanted",
+    body:
+      "Authorising a run does not purchase a winner, a green light, a field recommendation, or a passing result. It purchases an honest one.",
+  },
+  {
+    title: "Price is set on our side",
+    body:
+      "We record your budget and deadline, but the site never treats a client-supplied number as authoritative. Scope and authorisation stay server-owned.",
+  },
+] as const;
+
+/* ----------------------------------------------------------------- shared */
+
+export const closingCta = {
+  eyebrow: "Start with the decision",
+  title: "Tell us what you need to decide.",
+  body:
+    "The site-task, the call you are about to make, the threshold it turns on, and anything we may not do. We will come back with the evidence plan and the quote.",
+} as const;

--- a/client/src/pages/FAQ.tsx
+++ b/client/src/pages/FAQ.tsx
@@ -1,18 +1,138 @@
 import { SEO } from "@/components/SEO";
-import { EditorialFaq, EditorialSectionIntro } from "@/components/site/editorial";
+import { EditorialFaq } from "@/components/site/editorial";
+import { OutcomeSpectrum } from "@/components/site/figures";
+import { Reveal } from "@/components/site/motion";
+import {
+  Band,
+  ClosingCta,
+  Inner,
+  NoteCards,
+  SectionHeader,
+} from "@/components/site/publicSections";
+import { closingCta, homeLimits, homeOutcomes } from "@/data/publicSiteCopy";
 import { faqJsonLd, webPageJsonLd } from "@/lib/seoStructuredData";
 
 export const faqItems = [
-  { question: "What does Blueprint sell?", answer: "One customer-facing service: a Task Evaluation Run. It turns a real site-task into a maintained testbed, routes each decision-relevant claim to qualified evidence, and returns a bounded decision or explicit abstention." },
-  { question: "Do robot teams and site operators use different products?", answer: "No. They are personas using the same request contract, workflow, result model, pricing concept, and call to action. Robot teams often bring policies or checkpoints; site operators may begin with the task and missing evidence." },
-  { question: "Do I choose the simulation or world-model backend?", answer: "No. You describe the decision, site-task, claims, thresholds, false-safe consequence, evidence, budget, deadline, and restrictions. Pipeline owns method qualification and routing." },
-  { question: "Does every run return a ranking or winner?", answer: "No. Valid outcomes include bounded positive or negative decisions, elimination of an incompatible candidate, partial decisions, explicit abstention, and a request for the next evidence needed." },
-  { question: "What appears in a result?", answer: "The requested decision, per-claim outcomes, selected evidence methods and why, what was measured, validation envelope, coverage, uncertainty, disagreements, claim ceiling, next cheapest experiment, physical evidence needs, exact artifact provenance, and permitted evidence uses." },
-  { question: "Can virtual evidence prove physical performance or safety?", answer: "Only within its qualified validation envelope. Estimates are not physical guarantees, safety approval remains external, and claims that cannot be supported virtually still require authoritative physical evidence." },
-  { question: "Is post-training a separate product?", answer: "No. Evidence produced inside a run may be marked eligible for post-training use. An export or eligibility flag does not prove that training happened or that a policy improved." },
-  { question: "How is a run priced?", answer: "Each run is quoted from its decision, evidence, candidates, scenarios, compute, deadline, rights, and physical requirements. Blueprint does not publish an unconfirmed fixed price." },
+  {
+    question: "What does Blueprint sell?",
+    answer:
+      "One service: a Task Evaluation Run. It turns a real job at a real site into a testbed we maintain, tests the claims your decision rests on, and returns an answer with the conditions it holds under — or tells you the evidence will not carry it yet.",
+  },
+  {
+    question: "Do robot teams and site operators use different products?",
+    answer:
+      "No. Two audiences, one service. They get their own explanation pages because they arrive with different things — a robot team usually has candidates, a site operator usually has a job and no candidates — but the intake, workflow, result model, pricing model, and call to action are identical.",
+  },
+  {
+    question: "Do I choose the simulator or world model?",
+    answer:
+      "No, and you should not want to. You describe the decision, the task, the claims, the threshold, what a wrong yes would cost, your budget, your deadline, and any restrictions. Which method is qualified for which claim is the judgement you are paying us for.",
+  },
+  {
+    question: "Does every run produce a ranking?",
+    answer:
+      "No. A run can support a call, rule an option out, settle some claims and not others, or decline to answer. Comparing raw scores to manufacture a winner after the evidence has declined to produce one is exactly the thing this service will not do.",
+  },
+  {
+    question: "What is in a result?",
+    answer:
+      "The decision you asked about, an outcome per claim, which evidence method was used and why, what it measured, the conditions the answer holds under, coverage, uncertainty, any disagreement between methods, the strongest claim the evidence permits, the cheapest next test, whether physical evidence is required, exact artifact provenance, and what each artifact may be used for.",
+  },
+  {
+    question: "Can virtual evidence prove physical performance or safety?",
+    answer:
+      "Only inside the conditions it was qualified for, and never as a guarantee. Safety approval is external and stays with you. Claims that cannot be settled virtually still need evidence from real hardware, and the run will say when that is the case.",
+  },
+  {
+    question: "Is post-training a separate product?",
+    answer:
+      "No. Evidence produced inside a run may be marked eligible for evaluation or post-training use. That flag is permission, not proof — it does not mean training happened or that a policy got better.",
+  },
+  {
+    question: "How is a run priced?",
+    answer:
+      "Per run, quoted from the decision, the evidence already available, the number of candidates and conditions, compute, deadline, rights constraints, and any physical work. There is no published fixed price, and the old fixed campaign prices are gone.",
+  },
+  {
+    question: "What happened to the other products?",
+    answer:
+      "Policy Shortlist, Robot Match, Policy Improvement Runs, and separate post-training packages are no longer offered as current products. Existing records, transactions, URLs, and entitlements stay readable, and legacy requests are translated into the current model rather than dropped.",
+  },
 ];
 
 export default function FAQ() {
-  return <><SEO title="Task Evaluation Run FAQ | Blueprint" description="How Blueprint scopes decisions, routes evidence, reports abstention, and maintains proof boundaries." canonical="/faq" jsonLd={[webPageJsonLd({ path: "/faq", name: "Task Evaluation Run FAQ", description: "Blueprint Task Evaluation Run questions and answers." }), faqJsonLd(faqItems)]} /><section className="bg-canvas"><div className="mx-auto max-w-[72rem] px-5 py-16 sm:px-8 lg:py-24"><EditorialSectionIntro headingLevel="h1" eyebrow="FAQ" title="One product, explicit evidence boundaries." description="Blueprint makes the requested decision, unknowns, evidence strength, and next experiment inspectable." /><EditorialFaq className="mt-12" items={faqItems} /></div></section></>;
+  return (
+    <>
+      <SEO
+        title="Task Evaluation Run FAQ | Blueprint"
+        description="What Blueprint sells, how runs are scoped and priced, what a result contains, and where the evidence stops."
+        canonical="/faq"
+        jsonLd={[
+          webPageJsonLd({
+            path: "/faq",
+            name: "Task Evaluation Run FAQ",
+            description: "Blueprint Task Evaluation Run questions and answers.",
+          }),
+          faqJsonLd(faqItems),
+        ]}
+      />
+
+      <Band tone="canvas">
+        <Inner size="narrow" className="pb-16 pt-20 lg:pb-20 lg:pt-28">
+          <Reveal>
+            <p className="inline-flex items-center gap-[0.6rem] text-[11px] font-semibold uppercase tracking-[0.2em] leading-none text-brass-deep">
+              <span aria-hidden="true" className="h-px w-6 shrink-0 bg-current opacity-50" />
+              FAQ
+            </p>
+            <h1 className="mt-6 max-w-[22ch] font-display text-[clamp(2.6rem,5vw,4.4rem)] font-medium leading-[0.98] tracking-[-0.045em] text-ink-900">
+              One service, and the limits printed on it.
+            </h1>
+            <p className="mt-7 max-w-[46ch] text-[1.05rem] leading-[1.75] text-ink-600">
+              The questions below are the ones worth asking before you spend
+              anything — including the ones whose honest answer is a no.
+            </p>
+          </Reveal>
+          <Reveal delay={0.1} className="mt-14">
+            <EditorialFaq
+              title="Questions"
+              description="If yours is not here, it is a good first line in a run request."
+              items={faqItems}
+            />
+          </Reveal>
+        </Inner>
+      </Band>
+
+      <Band tone="paper" rule>
+        <Inner className="py-20 lg:py-24">
+          <SectionHeader
+            eyebrow="For reference"
+            title="The five ways a run can end."
+            lede="Worth reading once, because four of them are not a winner and all five are valid deliveries."
+          />
+          <div className="mt-14">
+            <OutcomeSpectrum bands={homeOutcomes} />
+          </div>
+        </Inner>
+      </Band>
+
+      <Band tone="ink">
+        <Inner className="py-20 lg:py-24">
+          <SectionHeader eyebrow="Where we stop" title="The limits, stated plainly." onInk />
+          <NoteCards items={homeLimits} onInk className="mt-14" />
+        </Inner>
+      </Band>
+
+      <ClosingCta
+        eyebrow={closingCta.eyebrow}
+        title={closingCta.title}
+        body={closingCta.body}
+        primaryHref="/contact/robot-team?interest=task-evaluation-run&requestedOutputs=Task%20Evaluation%20Run&source=faq-cta"
+        primaryLabel="Request a Task Evaluation Run"
+        secondaryHref="/how-it-works"
+        secondaryLabel="See how it works"
+        imageSrc="/redesign/pov/machine-tending.jpg"
+        imageAlt="A machine-tending station in a working facility"
+      />
+    </>
+  );
 }

--- a/client/src/pages/ForRobotTeams.tsx
+++ b/client/src/pages/ForRobotTeams.tsx
@@ -1,33 +1,198 @@
-import { ArrowRight } from "lucide-react";
-
 import { SEO } from "@/components/SEO";
-import { Button, Eyebrow, ProofBoundary, StatusChip } from "@/components/blueprint";
-import { EditorialCtaBand, EditorialSectionIntro, MonochromeMedia } from "@/components/site/editorial";
-import { TileGrid } from "@/components/site/TileGrid";
-import { robotPolicyComparisonUseCases, robotPolicyEvaluationBoundary } from "@/data/robotPolicyEvaluationClaims";
+import { ProofBoundary } from "@/components/blueprint";
+import {
+  ClaimThresholdChart,
+  EvidenceLadderChart,
+  OutcomeSpectrum,
+  RunLifecycleRail,
+} from "@/components/site/figures";
+import { Reveal } from "@/components/site/motion";
+import {
+  Band,
+  ClosingCta,
+  FullBleedMedia,
+  Inner,
+  NoteCards,
+  PageHero,
+  SectionHeader,
+} from "@/components/site/publicSections";
+import { robotPolicyEvaluationBoundary } from "@/data/robotPolicyEvaluationClaims";
+import {
+  closingCta,
+  homeClaimMetricLabel,
+  homeClaimThreshold,
+  homeClaims,
+  homeEvidenceRungs,
+  homeLimits,
+  homeOutcomes,
+  robotTeamFlow,
+  robotTeamHero,
+  robotTeamValue,
+} from "@/data/publicSiteCopy";
 import { breadcrumbJsonLd, webPageJsonLd } from "@/lib/seoStructuredData";
 
-const flow = [
-  ["Describe the decision", "Bring the prospective site-task, candidates or checkpoints, thresholds, false-safe consequence, budget, deadline, and evidence constraints."],
-  ["Maintain the testbed", "Blueprint links the request to an exact captured Site-Task Testbed version and digest."],
-  ["Route claims", "Pipeline chooses the least expensive currently qualified evidence for each question and escalates only when needed."],
-  ["Read the envelope", "See supported, rejected, unresolved, and abstained claims—not one undifferentiated score."],
-  ["Choose field work", "Use the claim ceiling and next cheapest experiment to decide whether physical robot time is justified."],
-] as const;
+const runHref =
+  "/contact/robot-team?interest=task-evaluation-run&requestedOutputs=Task%20Evaluation%20Run&source=for-robot-teams";
+const runCtaHref =
+  "/contact/robot-team?interest=task-evaluation-run&requestedOutputs=Task%20Evaluation%20Run&source=for-robot-teams-cta";
 
 export default function ForRobotTeams() {
   return (
     <>
-      <SEO title="Task Evaluation Runs for robot teams | Blueprint" description="Compare internal policies or checkpoints, test real-task compatibility, discover failure conditions, and decide whether field time is justified." canonical="/for-robot-teams" jsonLd={[webPageJsonLd({ path: "/for-robot-teams", name: "Task Evaluation Runs for robot teams", description: "One decision-oriented evaluation service for robot teams." }), breadcrumbJsonLd([{ name: "Home", path: "/" }, { name: "For robot teams", path: "/for-robot-teams" }])]} />
-      <section className="bg-canvas">
-        <div className="mx-auto grid max-w-[88rem] gap-10 px-5 py-16 sm:px-8 lg:grid-cols-[1fr_0.9fr] lg:items-center lg:px-10 lg:py-24">
-          <div><Eyebrow tone="brass" rule>Task Evaluation Run · robot-team use case</Eyebrow><h1 className="mt-5 font-display text-[clamp(2.7rem,5vw,4.8rem)] font-medium leading-[1.01] tracking-[-0.05em] text-ink-900">Decide what deserves scarce robot time.</h1><p className="mt-5 max-w-2xl text-[1.05rem] leading-7 text-ink-500">Evaluate internal policies or checkpoints against a prospective real-site task, expose failure conditions, and learn whether the current evidence supports field testing—or requires a stronger experiment.</p><div className="mt-8"><Button asChild variant="brass" size="lg"><a href="/contact/robot-team?interest=task-evaluation-run&requestedOutputs=Task%20Evaluation%20Run&source=for-robot-teams">Request a Task Evaluation Run <ArrowRight className="h-4 w-4" /></a></Button></div></div>
-          <MonochromeMedia src="/redesign/pov/warehouse-tote.jpg" alt="Robot arm working near crates at a real site" loading="eager" radius="lg" overlay="soft" className="aspect-[16/11] border border-line"><span className="absolute left-3 top-3"><StatusChip tone="ink" square dot={false}>Illustrative workflow</StatusChip></span></MonochromeMedia>
-        </div>
-      </section>
-      <section className="border-y border-line bg-paper"><div className="mx-auto max-w-[88rem] px-5 py-16 sm:px-8 lg:px-10 lg:py-24"><EditorialSectionIntro eyebrow="Robot-team wedge" title="Bring candidates when they matter. A ranking is not guaranteed." description="The run is organized around the decision and claims, not a tournament. A candidate can be supported, rejected, eliminated as incompatible, left unresolved, or included in an explicit abstention." /><TileGrid cols={3} className="mt-10">{robotPolicyComparisonUseCases.map((item) => <article key={item.title} className="bg-white p-6"><h2 className="text-title-m font-semibold text-ink-900">{item.title}</h2><p className="mt-3 text-sm leading-7 text-ink-500">{item.body}</p></article>)}</TileGrid></div></section>
-      <section className="bg-canvas"><div className="mx-auto max-w-[88rem] px-5 py-16 sm:px-8 lg:px-10 lg:py-24"><EditorialSectionIntro eyebrow="One lifecycle" title="From site-task to decision or abstention." description="You describe the decision. Blueprint maintains the substrate and Pipeline owns scientific routing and verdicts." /><ol className="mt-10 grid gap-px overflow-hidden border border-line bg-line md:grid-cols-5">{flow.map(([title, body], index) => <li key={title} className="bg-white p-5"><span className="font-mono text-xs text-brass">0{index + 1}</span><h2 className="mt-3 font-semibold text-ink-900">{title}</h2><p className="mt-2 text-sm leading-6 text-ink-500">{body}</p></li>)}</ol><div className="mt-8 grid gap-5 lg:grid-cols-2"><ProofBoundary level="info" title="Router in plain language">Blueprint uses the least expensive evidence that is trustworthy enough for each question, and asks for stronger evidence only when needed.</ProofBoundary><ProofBoundary level="warn" title="Evidence boundary">{robotPolicyEvaluationBoundary}</ProofBoundary></div></div></section>
-      <section className="mx-auto max-w-[88rem] px-5 py-16 sm:px-8 lg:px-10 lg:py-20"><EditorialCtaBand eyebrow="Start with the decision" title="Request a Task Evaluation Run." description="Tell us the site-task, candidates, claims, thresholds, consequences, evidence, budget, deadline, and restrictions. The method plan is Blueprint’s responsibility." imageSrc="/redesign/pov/packing-cell.jpg" imageAlt="Warehouse task environment" primaryHref="/contact/robot-team?interest=task-evaluation-run&requestedOutputs=Task%20Evaluation%20Run&source=for-robot-teams-cta" primaryLabel="Request a Task Evaluation Run" secondaryHref="/pricing" secondaryLabel="See engagement model" /></section>
+      <SEO
+        title="Task Evaluation Runs for robot teams | Blueprint"
+        description="Compare your own checkpoints against a real site-task, find the disqualifiers early, and decide whether field time is justified."
+        canonical="/for-robot-teams"
+        jsonLd={[
+          webPageJsonLd({
+            path: "/for-robot-teams",
+            name: "Task Evaluation Runs for robot teams",
+            description: "One decision-oriented evaluation service, explained for robot teams.",
+          }),
+          breadcrumbJsonLd([
+            { name: "Home", path: "/" },
+            { name: "For robot teams", path: "/for-robot-teams" },
+          ]),
+        ]}
+      />
+
+      <PageHero
+        eyebrow={robotTeamHero.eyebrow}
+        title={robotTeamHero.title}
+        body={robotTeamHero.body}
+        chips={robotTeamHero.chips}
+        ctaHref={runHref}
+        ctaLabel="Request a Task Evaluation Run"
+        secondaryHref="/how-it-works"
+        secondaryLabel="How it works"
+        imageSrc="/redesign/pov/warehouse-tote.jpg"
+        imageAlt="A robot arm working a tote task in a real warehouse aisle"
+        imageCaption="Illustrative task context"
+        routeTrace
+      />
+
+      <Band tone="ink">
+        <Inner className="py-20 lg:py-28">
+          <SectionHeader
+            index="01"
+            eyebrow="The wedge"
+            title="Bring candidates. A ranking is not the promise."
+            lede="A run is organised around your decision, not around a tournament. A candidate can be supported, ruled out, eliminated as flatly incompatible, or left open — and “left open” is reported as itself."
+            onInk
+          />
+          <div className="mt-14 grid gap-x-10 gap-y-10 lg:grid-cols-3">
+            {robotTeamValue.map((item, index) => (
+              <Reveal key={item.title} delay={index * 0.07}>
+                <div className="border-t border-white/15 pt-6">
+                  <span className="font-mono text-[11px] tracking-[0.2em] text-brass">
+                    {String(index + 1).padStart(2, "0")}
+                  </span>
+                  <h3 className="mt-4 font-display text-[1.5rem] font-medium leading-[1.15] tracking-[-0.03em] text-[color:var(--text-on-ink)]">
+                    {item.title}
+                  </h3>
+                  <p className="mt-3.5 max-w-[42ch] text-[14.5px] leading-[1.72] text-ink-300">
+                    {item.body}
+                  </p>
+                </div>
+              </Reveal>
+            ))}
+          </div>
+        </Inner>
+      </Band>
+
+      <Band tone="canvas">
+        <Inner className="py-20 lg:py-28">
+          <SectionHeader
+            index="02"
+            eyebrow="What a result looks like"
+            title="Per claim, with the line it was read against."
+            lede="Your threshold, your units, your definition of a wrong yes. Each claim is answered against that, and the ones that will not resolve are named."
+          />
+          <Reveal className="mt-14">
+            <ClaimThresholdChart
+              claims={homeClaims}
+              threshold={homeClaimThreshold}
+              metricLabel={homeClaimMetricLabel}
+            />
+          </Reveal>
+          <div className="mt-14">
+            <OutcomeSpectrum bands={homeOutcomes} />
+          </div>
+        </Inner>
+      </Band>
+
+      <Band tone="paper" rule>
+        <Inner className="py-20 lg:py-28">
+          <SectionHeader
+            index="03"
+            eyebrow="One lifecycle"
+            title="From site-task to a call you can defend internally."
+            lede="You describe the decision. We maintain the substrate, and the evidence routing happens on our side of the line."
+          />
+          <div className="mt-16">
+            <RunLifecycleRail stages={robotTeamFlow} />
+          </div>
+          <div className="mt-14 grid gap-5 lg:grid-cols-2">
+            <Reveal>
+              <ProofBoundary level="info" title="Why you do not pick the backend">
+                The right method depends on the claim, not on preference. Asking a
+                buyer to choose between simulators moves the hardest judgement in
+                the process onto the person with the least information about it.
+              </ProofBoundary>
+            </Reveal>
+            <Reveal delay={0.08}>
+              <ProofBoundary level="warn" title="Where the evidence stops">
+                {robotPolicyEvaluationBoundary}
+              </ProofBoundary>
+            </Reveal>
+          </div>
+        </Inner>
+      </Band>
+
+      <Band tone="canvas">
+        <Inner className="py-20 lg:py-28">
+          <SectionHeader
+            index="04"
+            eyebrow="How the budget is spent"
+            title="We climb the ladder only as far as the claim requires."
+          />
+          <Reveal className="mt-14">
+            <EvidenceLadderChart rungs={homeEvidenceRungs} />
+          </Reveal>
+        </Inner>
+      </Band>
+
+      <FullBleedMedia
+        src="/redesign/pov/machine-tending.jpg"
+        alt="A machine-tending station in a working facility"
+        eyebrow="Before the trip"
+        title="Find the incompatibility here, not at the door."
+        body="Reach, footprint, clearance, observation and action mismatches, environmental limits. These are the failures that waste an entire site visit, and they are the cheapest ones to catch."
+      />
+
+      <Band tone="ink">
+        <Inner className="py-20 lg:py-28">
+          <SectionHeader
+            index="05"
+            eyebrow="Where we stop"
+            title="The limits, stated plainly."
+            onInk
+          />
+          <NoteCards items={homeLimits} onInk className="mt-14" />
+        </Inner>
+      </Band>
+
+      <ClosingCta
+        eyebrow={closingCta.eyebrow}
+        title="Tell us what you need to decide."
+        body="The site-task, the candidates, the threshold, what a wrong yes would cost, and anything we may not do. The evidence plan is ours to build."
+        primaryHref={runCtaHref}
+        primaryLabel="Request a Task Evaluation Run"
+        secondaryHref="/pricing"
+        secondaryLabel="How pricing works"
+        imageSrc="/redesign/pov/packing-cell.jpg"
+        imageAlt="A packing cell used as a real-site task context"
+      />
     </>
   );
 }

--- a/client/src/pages/ForRobotTeams.tsx
+++ b/client/src/pages/ForRobotTeams.tsx
@@ -154,7 +154,8 @@ export default function ForRobotTeams() {
           <SectionHeader
             index="04"
             eyebrow="How the budget is spent"
-            title="We climb the ladder only as far as the claim requires."
+            title="We pay for the method the claim needs, and no more."
+            lede="Methods are qualified per claim, not ranked against each other. A costlier derived method does not outrank real capture — it covers conditions the capture could not."
           />
           <Reveal className="mt-14">
             <EvidenceLadderChart rungs={homeEvidenceRungs} />

--- a/client/src/pages/ForSiteOperators.tsx
+++ b/client/src/pages/ForSiteOperators.tsx
@@ -1,26 +1,202 @@
-import { ArrowRight } from "lucide-react";
-
 import { SEO } from "@/components/SEO";
-import { Button, Eyebrow, ProofBoundary, StatusChip } from "@/components/blueprint";
-import { EditorialCtaBand, EditorialSectionIntro, MonochromeMedia } from "@/components/site/editorial";
-import { TileGrid } from "@/components/site/TileGrid";
+import { ProofBoundary } from "@/components/blueprint";
+import { OutcomeSpectrum, RunLifecycleRail } from "@/components/site/figures";
+import { Reveal } from "@/components/site/motion";
+import {
+  Band,
+  ClosingCta,
+  FullBleedMedia,
+  Inner,
+  MediaSplit,
+  NoteCards,
+  PageHero,
+  SectionHeader,
+} from "@/components/site/publicSections";
+import {
+  closingCta,
+  homeLifecycle,
+  homeLimits,
+  homeOutcomes,
+  siteOperatorControls,
+  siteOperatorHero,
+  siteOperatorNeeds,
+} from "@/data/publicSiteCopy";
 import { breadcrumbJsonLd, webPageJsonLd } from "@/lib/seoStructuredData";
 
-const operatorNeeds = [
-  ["Turn a task into a testable decision", "Describe the workflow, conditions, thresholds, unacceptable failures, false-safe consequence, timing, and access constraints."],
-  ["See what evidence is missing", "Blueprint separates what the current capture can support from claims that need stronger or physical evidence."],
-  ["Evaluate submitted candidates", "When robot or policy candidates exist, they enter the same request and per-claim evidence model."],
-  ["Receive a bounded answer", "The result can be positive, negative, partial, or an explicit abstention with the next cheapest experiment."],
-] as const;
+const runHref =
+  "/contact/site-operator?interest=task-evaluation-run&requestedOutputs=Task%20Evaluation%20Run&source=for-site-operators";
+const runCtaHref =
+  "/contact/site-operator?interest=task-evaluation-run&requestedOutputs=Task%20Evaluation%20Run&source=for-site-operators-cta";
 
 export default function ForSiteOperators() {
   return (
     <>
-      <SEO title="Task Evaluation Runs for site operators | Blueprint" description="Turn a real site-task into a maintained testbed and a bounded decision, with missing evidence and physical requirements made explicit." canonical="/for-site-operators" jsonLd={[webPageJsonLd({ path: "/for-site-operators", name: "Task Evaluation Runs for site operators", description: "The same Task Evaluation Run used by robot teams, explained for site operators." }), breadcrumbJsonLd([{ name: "Home", path: "/" }, { name: "For site operators", path: "/for-site-operators" }])]} />
-      <section className="bg-canvas"><div className="mx-auto grid max-w-[88rem] gap-10 px-5 py-16 sm:px-8 lg:grid-cols-[1fr_0.9fr] lg:items-center lg:px-10 lg:py-24"><div><Eyebrow tone="brass" rule>Task Evaluation Run · site-operator use case</Eyebrow><h1 className="mt-5 font-display text-[clamp(2.7rem,5vw,4.8rem)] font-medium leading-[1.01] tracking-[-0.05em] text-ink-900">Turn one real task into a decision you can inspect.</h1><p className="mt-5 max-w-2xl text-[1.05rem] leading-7 text-ink-500">Blueprint captures and maintains the site-task substrate, identifies the evidence each claim needs, evaluates submitted candidates when available, and returns a bounded decision or an explicit abstention.</p><div className="mt-8"><Button asChild variant="brass" size="lg"><a href="/contact/site-operator?interest=task-evaluation-run&requestedOutputs=Task%20Evaluation%20Run&source=for-site-operators">Request a Task Evaluation Run <ArrowRight className="h-4 w-4" /></a></Button></div></div><MonochromeMedia src="/redesign/pov/loading-dock.jpg" alt="Real loading dock used to define a site-task" loading="eager" radius="lg" overlay="soft" className="aspect-[16/11] border border-line"><span className="absolute left-3 top-3"><StatusChip tone="ink" square dot={false}>Illustrative workflow</StatusChip></span></MonochromeMedia></div></section>
-      <section className="border-y border-line bg-paper"><div className="mx-auto max-w-[88rem] px-5 py-16 sm:px-8 lg:px-10 lg:py-24"><EditorialSectionIntro eyebrow="Same service · same result model" title="Site operators do not need to design an evaluation stack." description="The intake asks for the task, decision, thresholds, consequences, evidence, budget, deadline, rights, and whether physical testing is possible." /><TileGrid cols={4} className="mt-10">{operatorNeeds.map(([title, body]) => <article key={title} className="bg-white p-6"><h2 className="text-title-m font-semibold text-ink-900">{title}</h2><p className="mt-3 text-sm leading-7 text-ink-500">{body}</p></article>)}</TileGrid></div></section>
-      <section className="bg-canvas"><div className="mx-auto max-w-[88rem] px-5 py-16 sm:px-8 lg:px-10 lg:py-24"><EditorialSectionIntro eyebrow="Maintained learning loop" title="Real site-task → testbed → run → decision or abstention." description="Targeted physical evidence joins the exact decision and testbed identifiers. A user-entered note alone cannot recalibrate an evidence method." /><div className="mt-10 grid gap-5 lg:grid-cols-2"><ProofBoundary level="info" title="Router in plain language">Blueprint uses the least expensive evidence that is trustworthy enough for each question, and asks for stronger evidence only when needed.</ProofBoundary><ProofBoundary level="warn" title="Operator and safety control">Capture windows, privacy, restricted areas, evidence use, physical access, and safety approval remain explicitly controlled. Virtual evidence is never presented as a physical guarantee.</ProofBoundary></div></div></section>
-      <section className="mx-auto max-w-[88rem] px-5 py-16 sm:px-8 lg:px-10 lg:py-20"><EditorialCtaBand eyebrow="Start with the task" title="Request the same Task Evaluation Run." description="Describe the real workflow and the decision it should inform. Candidates are optional at intake and can be linked when available." imageSrc="/redesign/pov/cold-storage.jpg" imageAlt="Cold-storage site task environment" primaryHref="/contact/site-operator?interest=task-evaluation-run&requestedOutputs=Task%20Evaluation%20Run&source=for-site-operators-cta" primaryLabel="Request a Task Evaluation Run" secondaryHref="/governance" secondaryLabel="Review rights and privacy" dark={false} /></section>
+      <SEO
+        title="Task Evaluation Runs for site operators | Blueprint"
+        description="Turn one real job at your site into a maintained testbed and an inspectable decision, with the missing evidence and physical requirements named."
+        canonical="/for-site-operators"
+        jsonLd={[
+          webPageJsonLd({
+            path: "/for-site-operators",
+            name: "Task Evaluation Runs for site operators",
+            description:
+              "The same Task Evaluation Run robot teams use, explained for the people who own the site.",
+          }),
+          breadcrumbJsonLd([
+            { name: "Home", path: "/" },
+            { name: "For site operators", path: "/for-site-operators" },
+          ]),
+        ]}
+      />
+
+      <PageHero
+        eyebrow={siteOperatorHero.eyebrow}
+        title={siteOperatorHero.title}
+        body={siteOperatorHero.body}
+        chips={siteOperatorHero.chips}
+        ctaHref={runHref}
+        ctaLabel="Request a Task Evaluation Run"
+        secondaryHref="/governance"
+        secondaryLabel="Rights and privacy"
+        imageSrc="/redesign/pov/loading-dock.jpg"
+        imageAlt="A real loading dock of the kind a site-task is defined from"
+        imageCaption="Illustrative task context"
+        routeTrace
+      />
+
+      <Band tone="ink">
+        <Inner className="py-20 lg:py-28">
+          <SectionHeader
+            index="01"
+            eyebrow="Same service, different entry"
+            title="You should not have to become an evaluation expert to get an answer."
+            lede="Robot teams arrive with candidates and a threshold. You can arrive with a job and a set of conditions. Both end up in the same run."
+            onInk
+          />
+          <div className="mt-14 grid gap-x-10 gap-y-10 sm:grid-cols-2">
+            {siteOperatorNeeds.map((item, index) => (
+              <Reveal key={item.title} delay={index * 0.06}>
+                <div className="border-t border-white/15 pt-6">
+                  <span className="font-mono text-[11px] tracking-[0.2em] text-brass">
+                    {String(index + 1).padStart(2, "0")}
+                  </span>
+                  <h3 className="mt-4 font-display text-[1.5rem] font-medium leading-[1.15] tracking-[-0.03em] text-[color:var(--text-on-ink)]">
+                    {item.title}
+                  </h3>
+                  <p className="mt-3.5 max-w-[44ch] text-[14.5px] leading-[1.72] text-ink-300">
+                    {item.body}
+                  </p>
+                </div>
+              </Reveal>
+            ))}
+          </div>
+        </Inner>
+      </Band>
+
+      <Band tone="canvas">
+        <Inner className="py-20 lg:py-28">
+          <MediaSplit
+            imageSrc="/redesign/pov/cold-storage.jpg"
+            imageAlt="A cold-storage aisle where conditions define what a robot can do"
+            imageCaption="Conditions are part of the task"
+          >
+            <div>
+              <p className="inline-flex items-center gap-[0.6rem] text-[11px] font-semibold uppercase tracking-[0.2em] leading-none text-brass-deep">
+                <span aria-hidden="true" className="h-px w-6 shrink-0 bg-current opacity-50" />
+                02 · What you keep
+              </p>
+              <h2 className="mt-6 max-w-[24ch] font-display text-[clamp(2rem,3.6vw,3.1rem)] font-medium leading-[1.03] tracking-[-0.035em] text-ink-900">
+                Your floor, your rules — written down before anything is captured.
+              </h2>
+              <p className="mt-6 max-w-[46ch] text-[15.5px] leading-[1.75] text-ink-600">
+                Restricted areas are excluded before capture rather than redacted
+                afterwards, and what a run's evidence may be used for is recorded
+                per artifact. Nobody tests on your floor without a separate,
+                explicit yes.
+              </p>
+              <dl className="mt-9 divide-y divide-line">
+                {siteOperatorControls.map((control) => (
+                  <div key={control.label} className="grid gap-1 py-3.5 sm:grid-cols-[minmax(0,0.42fr)_minmax(0,0.58fr)] sm:gap-6">
+                    <dt className="text-[13px] font-semibold text-ink-900">{control.label}</dt>
+                    <dd className="text-[13.5px] leading-[1.65] text-ink-500">{control.detail}</dd>
+                  </div>
+                ))}
+              </dl>
+            </div>
+          </MediaSplit>
+        </Inner>
+      </Band>
+
+      <Band tone="paper" rule>
+        <Inner className="py-20 lg:py-28">
+          <SectionHeader
+            index="03"
+            eyebrow="How a run moves"
+            title="One real task in. One inspectable answer out."
+            lede="Candidates are optional at the start. The task and the terms are what make a run scopeable."
+          />
+          <div className="mt-16">
+            <RunLifecycleRail stages={homeLifecycle} />
+          </div>
+        </Inner>
+      </Band>
+
+      <Band tone="canvas">
+        <Inner className="py-20 lg:py-28">
+          <SectionHeader
+            index="04"
+            eyebrow="What comes back"
+            title="Including the answer nobody likes to sell."
+            lede="If the evidence will not carry the decision, the run says so and names what would. That is the version of this service worth buying twice."
+          />
+          <div className="mt-14">
+            <OutcomeSpectrum bands={homeOutcomes} />
+          </div>
+          <div className="mt-14 grid gap-5 lg:grid-cols-2">
+            <Reveal>
+              <ProofBoundary level="info" title="The learning loop is joined, not typed">
+                When physical evidence is needed, it is tied back to the exact
+                decision and testbed version it belongs to. A note typed into a
+                form is not evidence and cannot recalibrate a method.
+              </ProofBoundary>
+            </Reveal>
+            <Reveal delay={0.08}>
+              <ProofBoundary level="warn" title="Safety stays yours">
+                Nothing a run returns is a safety approval or a certification for
+                operating a robot at your site. Virtual evidence is never
+                presented as a physical guarantee.
+              </ProofBoundary>
+            </Reveal>
+          </div>
+        </Inner>
+      </Band>
+
+      <FullBleedMedia
+        src="/redesign/pov/retail-backroom.jpg"
+        alt="A retail backroom being assessed as a robot work area"
+        eyebrow="Before a vendor arrives"
+        title="Know what the honest answer is before someone pitches you one."
+        body="A maintained testbed of your own task means every candidate that shows up later is measured against the same job, the same conditions, and the same threshold — yours."
+      />
+
+      <Band tone="ink">
+        <Inner className="py-20 lg:py-28">
+          <SectionHeader index="05" eyebrow="Where we stop" title="The limits, stated plainly." onInk />
+          <NoteCards items={homeLimits} onInk className="mt-14" />
+        </Inner>
+      </Band>
+
+      <ClosingCta
+        eyebrow="Start with the job"
+        title={closingCta.title}
+        body="Describe the real workflow, the conditions, the failures you will not accept, and the terms of access. Candidates can be linked whenever they exist."
+        primaryHref={runCtaHref}
+        primaryLabel="Request a Task Evaluation Run"
+        secondaryHref="/governance"
+        secondaryLabel="Review rights and privacy"
+        imageSrc="/redesign/pov/inspection-bench.jpg"
+        imageAlt="An inspection bench in a working facility"
+      />
     </>
   );
 }

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1,28 +1,323 @@
-import { ArrowRight } from "lucide-react";
-
 import { SEO } from "@/components/SEO";
-import { Button, Eyebrow, ProofBoundary, StatusChip } from "@/components/blueprint";
-import { EditorialCtaBand, EditorialSectionIntro, MonochromeMedia, ProofChip } from "@/components/site/editorial";
-import { TileGrid } from "@/components/site/TileGrid";
-import { blueprintPositioning, rankingOutcomeCategories } from "@/data/robotPolicyEvaluationClaims";
+import { ProofBoundary } from "@/components/blueprint";
+import {
+  ClaimThresholdChart,
+  EvidenceLadderChart,
+  DecisionShiftCompare,
+  OutcomeSpectrum,
+  RunLifecycleRail,
+  StatRow,
+} from "@/components/site/figures";
+import { Reveal } from "@/components/site/motion";
+import {
+  Band,
+  ClosingCta,
+  FullBleedMedia,
+  Inner,
+  MediaSplit,
+  NoteCards,
+  PageHero,
+  SectionHeader,
+} from "@/components/site/publicSections";
+import { blueprintPositioning } from "@/data/robotPolicyEvaluationClaims";
+import {
+  closingCta,
+  homeClaimMetricLabel,
+  homeClaimThreshold,
+  homeClaims,
+  homeDecisionCost,
+  homeEvidenceRungs,
+  homeHero,
+  homeLifecycle,
+  homeLimits,
+  homeOutcomes,
+  homeStats,
+} from "@/data/publicSiteCopy";
 import { webPageJsonLd } from "@/lib/seoStructuredData";
 
-const lifecycle = [
-  ["Real site-task", "Capture the task, conditions, rights, thresholds, and provenance that define the decision."],
-  ["Maintained testbed", "Keep an exact versioned substrate behind this run and future decisions."],
-  ["Task Evaluation Run", "Submit the decision, claims, consequences, candidates when applicable, evidence, budget, and deadline."],
-  ["Cheapest qualified evidence", "Pipeline selects trustworthy-enough methods claim by claim and escalates only when needed."],
-  ["Decision or abstention", "Receive the supported answer, unknowns, claim ceiling, and next cheapest experiment."],
-  ["Physical learning loop", "Join authoritative physical outcomes to exact identifiers when virtual evidence cannot support the claim."],
-] as const;
+const runHref =
+  "/contact/robot-team?interest=task-evaluation-run&requestedOutputs=Task%20Evaluation%20Run&source=home";
+const runCtaHref =
+  "/contact/robot-team?interest=task-evaluation-run&requestedOutputs=Task%20Evaluation%20Run&source=home-cta";
 
 export default function Home() {
-  return <>
-    <SEO title="Blueprint | Task Evaluation Runs for real site-tasks" description="Blueprint turns a real site-task into a maintained testbed and returns a bounded decision or explicit abstention using the least expensive qualified evidence." canonical="/" jsonLd={[webPageJsonLd({ path: "/", name: "Blueprint Task Evaluation Runs", description: blueprintPositioning })]} />
-    <section className="bg-canvas"><div className="mx-auto grid max-w-[88rem] gap-10 px-5 py-16 sm:px-8 lg:grid-cols-[1fr_0.9fr] lg:items-center lg:px-10 lg:py-24"><div><Eyebrow tone="brass" rule>Real-site Task Evaluation Runs</Eyebrow><h1 className="mt-5 font-display text-[clamp(2.9rem,5.7vw,5.4rem)] font-medium leading-[0.98] tracking-[-0.055em] text-ink-900">Turn a real site-task into a decision you can defend.</h1><p className="mt-5 max-w-2xl text-[1.08rem] leading-8 text-ink-500">{blueprintPositioning}</p><div className="mt-8"><Button asChild variant="brass" size="lg"><a href="/contact/robot-team?interest=task-evaluation-run&requestedOutputs=Task%20Evaluation%20Run&source=home">Request a Task Evaluation Run <ArrowRight className="h-4 w-4" /></a></Button></div><div className="mt-6 flex flex-wrap gap-2"><ProofChip>Decision, not backend selection</ProofChip><ProofChip>Explicit abstention supported</ProofChip><ProofChip>Physical evidence when required</ProofChip></div></div><MonochromeMedia src="/redesign/pov/packing-cell.jpg" alt="Real packing-cell task environment" loading="eager" radius="lg" overlay="soft" className="aspect-[16/11] border border-line"><span className="absolute left-3 top-3"><StatusChip tone="ink" square dot={false}>Real-site substrate</StatusChip></span></MonochromeMedia></div></section>
-    <section className="border-y border-line bg-paper"><div className="mx-auto max-w-[88rem] px-5 py-16 sm:px-8 lg:px-10 lg:py-24"><EditorialSectionIntro eyebrow="One product" title="One lifecycle from task to maintained evidence." description="Robot teams and site operators enter through different explanations, then use the same service, intake, workflow, result contract, and call to action." /><ol className="mt-10 grid gap-px overflow-hidden border border-line bg-line md:grid-cols-3 lg:grid-cols-6">{lifecycle.map(([title, body], index) => <li key={title} className="bg-white p-5"><span className="font-mono text-xs text-brass">0{index + 1}</span><h2 className="mt-3 font-semibold text-ink-900">{title}</h2><p className="mt-2 text-sm leading-6 text-ink-500">{body}</p></li>)}</ol></div></section>
-    <section className="bg-canvas"><div className="mx-auto max-w-[88rem] px-5 py-16 sm:px-8 lg:px-10 lg:py-24"><EditorialSectionIntro eyebrow="Truthful outcomes" title="A useful run does not have to name a winner." description="The result is a set of per-claim conclusions and limits, never one undifferentiated score." /><TileGrid cols={5} className="mt-10">{rankingOutcomeCategories.map((item) => <article key={item.label} className="bg-white p-5"><h2 className="font-semibold text-ink-900">{item.label}</h2><p className="mt-3 text-sm leading-6 text-ink-500">{item.body}</p></article>)}</TileGrid><div className="mt-8"><ProofBoundary level="info" title="Illustrative abstention—not a ranking claim">Candidate reachability may be supported while onsite outperformance remains unresolved. In that case Blueprint shows a partial decision or abstention, the validation envelope, and the next evidence needed. It does not infer a winner from raw scores.</ProofBoundary></div></div></section>
-    <section className="border-y border-line bg-paper"><div className="mx-auto grid max-w-[88rem] gap-10 px-5 py-16 sm:px-8 lg:grid-cols-2 lg:px-10 lg:py-24"><div><Eyebrow tone="brass" rule>For robot teams</Eyebrow><h2 className="mt-4 text-title-l font-semibold text-ink-900">Compare internal candidates and decide whether field time is justified.</h2><p className="mt-3 text-sm leading-7 text-ink-500">Bring policies or checkpoints when applicable. Discover compatibility failures, unresolved claims, and the evidence that would change the decision.</p><Button asChild variant="secondary" className="mt-6"><a href="/for-robot-teams">Robot-team use case <ArrowRight className="h-4 w-4" /></a></Button></div><div><Eyebrow tone="brass" rule>For site operators</Eyebrow><h2 className="mt-4 text-title-l font-semibold text-ink-900">Turn the task into a testable decision before candidates are even available.</h2><p className="mt-3 text-sm leading-7 text-ink-500">See what evidence is missing, evaluate submissions when available, and retain control over rights, privacy, access, and physical testing.</p><Button asChild variant="secondary" className="mt-6"><a href="/for-site-operators">Site-operator use case <ArrowRight className="h-4 w-4" /></a></Button></div></div></section>
-    <section className="mx-auto max-w-[88rem] px-5 py-16 sm:px-8 lg:px-10 lg:py-20"><EditorialCtaBand eyebrow="Start with the decision" title="Request a Task Evaluation Run." description="Describe the site-task, decision, thresholds, consequences, evidence, budget, deadline, and restrictions. Blueprint owns the evidence-routing complexity." imageSrc="/redesign/pov/route-scan.jpg" imageAlt="Captured real-site route" primaryHref="/contact/robot-team?interest=task-evaluation-run&requestedOutputs=Task%20Evaluation%20Run&source=home-cta" primaryLabel="Request a Task Evaluation Run" secondaryHref="/how-it-works" secondaryLabel="How it works" /></section>
-  </>;
+  return (
+    <>
+      <SEO
+        title="Blueprint | Task Evaluation Runs for real site-tasks"
+        description="Blueprint turns a real site-task into a maintained testbed and answers the decision claim by claim — including when the evidence cannot answer it yet."
+        canonical="/"
+        jsonLd={[
+          webPageJsonLd({
+            path: "/",
+            name: "Blueprint Task Evaluation Runs",
+            description: blueprintPositioning,
+          }),
+        ]}
+      />
+
+      <PageHero
+        eyebrow={homeHero.eyebrow}
+        title={homeHero.title}
+        body={homeHero.body}
+        chips={homeHero.chips}
+        ctaHref={runHref}
+        ctaLabel="Request a Task Evaluation Run"
+        secondaryHref="/how-it-works"
+        secondaryLabel="How it works"
+        imageSrc="/redesign/pov/packing-cell.jpg"
+        imageAlt="A real packing cell, the kind of site-task a run is built around"
+        imageCaption="Real site · captured substrate"
+        routeTrace
+      />
+
+      {/* 01 — what you are actually buying */}
+      <Band tone="ink">
+        <Inner className="py-16 lg:py-20">
+          <SectionHeader
+            index="01"
+            eyebrow="What you are buying"
+            title="One service. Priced per decision."
+            lede="Blueprint used to sell several loosely related things. It now sells one: a Task Evaluation Run. Robot teams and site operators get their own explanation of it, then use the same intake, the same workflow, and the same result."
+            onInk
+          />
+          <div className="mt-12 overflow-hidden rounded-lg border border-white/10 bg-[#ded7c8]">
+            <StatRow tiles={homeStats} onInk />
+          </div>
+        </Inner>
+      </Band>
+
+      {/* 02 — the problem, with the before/after figure */}
+      <Band tone="canvas">
+        <Inner className="py-20 lg:py-28">
+          <MediaSplit
+            imageSrc="/redesign/pov/loading-dock.jpg"
+            imageAlt="A loading dock where a robot task would have to work in real conditions"
+            imageCaption="Where the answer has to hold"
+            flip
+          >
+            <div>
+              <p className="inline-flex items-center gap-[0.6rem] text-[11px] font-semibold uppercase tracking-[0.2em] leading-none text-brass-deep">
+                <span aria-hidden="true" className="h-px w-6 shrink-0 bg-current opacity-50" />
+                02 · The problem
+              </p>
+              <h2 className="mt-6 max-w-[22ch] font-display text-[clamp(2rem,3.6vw,3.2rem)] font-medium leading-[1.03] tracking-[-0.035em] text-ink-900">
+                A robot on site is a very expensive way to ask a question.
+              </h2>
+              <p className="mt-6 max-w-[46ch] text-[15.5px] leading-[1.75] text-ink-600">
+                By the time a policy is failing on a real floor, you have already
+                spent the trip, the crew, the slot, and the goodwill of whoever
+                let you in. The information you needed was cheap. Getting it that
+                way was not.
+              </p>
+              <p className="mt-4 max-w-[46ch] text-[15.5px] leading-[1.75] text-ink-600">
+                A run does not replace the visit. It makes the visit a test of
+                something you have already narrowed down.
+              </p>
+            </div>
+          </MediaSplit>
+
+          <Reveal className="mt-16">
+            <DecisionShiftCompare rows={homeDecisionCost} />
+          </Reveal>
+        </Inner>
+      </Band>
+
+      {/* 03 — lifecycle */}
+      <Band tone="paper" rule>
+        <Inner className="py-20 lg:py-28">
+          <SectionHeader
+            index="03"
+            eyebrow="How a run moves"
+            title="Five moves from a real task to an answer."
+            lede="Nothing here asks you to design an evaluation. You bring the job and the decision; the substrate and the method are ours to get right."
+          />
+          <div className="mt-16">
+            <RunLifecycleRail stages={homeLifecycle} />
+          </div>
+        </Inner>
+      </Band>
+
+      {/* 04 — the abstention chart: the centrepiece */}
+      <Band tone="canvas">
+        <Inner className="py-20 lg:py-28">
+          <SectionHeader
+            index="04"
+            eyebrow="The honest part"
+            title="A run is allowed to tell you it cannot tell you."
+            lede="Most evaluation products always produce a ranking, because a ranking is what looks like a deliverable. If the evidence under a claim will not carry it, we report that instead of rounding a guess into a verdict."
+          />
+          <Reveal className="mt-14">
+            <ClaimThresholdChart
+              claims={homeClaims}
+              threshold={homeClaimThreshold}
+              metricLabel={homeClaimMetricLabel}
+            />
+          </Reveal>
+          <div className="mt-8 grid gap-5 lg:grid-cols-2">
+            <Reveal>
+              <ProofBoundary level="info" title="Read the figure this way">
+                Reachability clears the line with room to spare, so it is
+                supported. Dock clearance falls short, so it is ruled out. Onsite
+                outperformance has a point estimate above the line and an
+                interval that crosses it — which is not a win, and is not
+                reported as one.
+              </ProofBoundary>
+            </Reveal>
+            <Reveal delay={0.08}>
+              <ProofBoundary level="warn" title="What that means commercially">
+                You can buy a run and be told no. You can buy a run and be told
+                not yet. Both are cheaper than the version of that answer you get
+                from a robot standing in a warehouse.
+              </ProofBoundary>
+            </Reveal>
+          </div>
+        </Inner>
+      </Band>
+
+      {/* 05 — outcome spectrum */}
+      <Band tone="paper" rule>
+        <Inner className="py-20 lg:py-28">
+          <SectionHeader
+            index="05"
+            eyebrow="What comes back"
+            title="Five ways a run can end. Four of them are not a winner."
+            lede="The result is a set of per-claim findings with their conditions attached — never one score standing in for the whole decision."
+          />
+          <div className="mt-14">
+            <OutcomeSpectrum bands={homeOutcomes} />
+          </div>
+        </Inner>
+      </Band>
+
+      {/* 06 — evidence ladder */}
+      <Band tone="canvas">
+        <Inner className="py-20 lg:py-28">
+          <SectionHeader
+            index="06"
+            eyebrow="How we spend your budget"
+            title="The cheapest evidence that is actually good enough."
+            lede="You will not be asked to choose a simulator, a world model, or a provider. That choice depends on what each claim needs, which is exactly the part you are paying us to know."
+          />
+          <Reveal className="mt-14">
+            <EvidenceLadderChart rungs={homeEvidenceRungs} />
+          </Reveal>
+        </Inner>
+      </Band>
+
+      <FullBleedMedia
+        src="/redesign/pov/route-scan.jpg"
+        alt="A captured route through a real working site"
+        eyebrow="The substrate"
+        title="One captured site-task, kept and versioned."
+        body="A testbed is not a one-off scene. It is maintained, digest-pinned, and reused, so an answer you get next quarter is comparable to the one you got today — and so raw capture stays the source of truth rather than whatever was derived from it."
+      />
+
+      {/* 07 — personas */}
+      <Band tone="canvas">
+        <Inner className="py-20 lg:py-28">
+          <SectionHeader
+            index="07"
+            eyebrow="Two ways in"
+            title="Same run. Different starting point."
+          />
+          <div className="mt-14 grid gap-12 lg:grid-cols-2 lg:gap-16">
+            <Reveal>
+              <MediaSplitCard
+                href="/for-robot-teams"
+                imageSrc="/redesign/pov/warehouse-tote.jpg"
+                imageAlt="A robot arm working a tote task at a real site"
+                eyebrow="For robot teams"
+                title="Spend field time on the candidate that earned it."
+                body="Bring checkpoints or policies. Find the disqualifiers early, see which claims the current evidence can already close, and decide whether the trip is justified."
+                linkLabel="Robot-team use case"
+              />
+            </Reveal>
+            <Reveal delay={0.08}>
+              <MediaSplitCard
+                href="/for-site-operators"
+                imageSrc="/redesign/pov/retail-backroom.jpg"
+                imageAlt="A retail backroom being considered for robot work"
+                eyebrow="For site operators"
+                title="Find out what a robot could do here first."
+                body="You do not need a vendor or a policy to start. Describe the job and the terms, and keep control of access, privacy, and whether anyone tests on your floor."
+                linkLabel="Site-operator use case"
+              />
+            </Reveal>
+          </div>
+        </Inner>
+      </Band>
+
+      {/* 08 — limits */}
+      <Band tone="ink">
+        <Inner className="py-20 lg:py-28">
+          <SectionHeader
+            index="08"
+            eyebrow="Where we stop"
+            title="The limits, in the same size type as the promises."
+            lede="If these are going to be a problem for your decision, it is cheaper for both of us to know now."
+            onInk
+          />
+          <NoteCards items={homeLimits} onInk className="mt-14" />
+        </Inner>
+      </Band>
+
+      <ClosingCta
+        eyebrow={closingCta.eyebrow}
+        title={closingCta.title}
+        body={closingCta.body}
+        primaryHref={runCtaHref}
+        primaryLabel="Request a Task Evaluation Run"
+        secondaryHref="/pricing"
+        secondaryLabel="How pricing works"
+        imageSrc="/redesign/pov/factory-conveyor.jpg"
+        imageAlt="An industrial line of the kind a site-task is captured from"
+      />
+    </>
+  );
+}
+
+/**
+ * Persona card — large media over a short pitch. Local to Home because it is the
+ * only place two personas are presented side by side at this size.
+ */
+function MediaSplitCard({
+  href,
+  imageSrc,
+  imageAlt,
+  eyebrow,
+  title,
+  body,
+  linkLabel,
+}: {
+  href: string;
+  imageSrc: string;
+  imageAlt: string;
+  eyebrow: string;
+  title: string;
+  body: string;
+  linkLabel: string;
+}) {
+  return (
+    <a href={href} className="group block">
+      <div className="overflow-hidden rounded-lg border border-line">
+        <img
+          src={imageSrc}
+          alt={imageAlt}
+          loading="lazy"
+          className="aspect-[16/10] w-full object-cover grayscale contrast-[1.03] brightness-[0.82] transition-transform duration-700 ease-out-bp group-hover:scale-[1.03]"
+        />
+      </div>
+      <p className="mt-7 text-[11px] font-semibold uppercase tracking-[0.2em] text-brass-deep">
+        {eyebrow}
+      </p>
+      <h3 className="mt-4 max-w-[24ch] font-display text-[clamp(1.5rem,2.2vw,2.05rem)] font-medium leading-[1.1] tracking-[-0.03em] text-ink-900">
+        {title}
+      </h3>
+      <p className="mt-4 max-w-[44ch] text-[14.5px] leading-[1.72] text-ink-500">{body}</p>
+      <span className="mt-5 inline-flex items-center gap-2 text-[13px] font-semibold text-ink-900 underline decoration-brass decoration-2 underline-offset-[6px] transition-colors group-hover:text-brass-deep">
+        {linkLabel}
+      </span>
+    </a>
+  );
 }

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -197,7 +197,7 @@ export default function Home() {
             index="06"
             eyebrow="How we spend your budget"
             title="The cheapest evidence that is actually good enough."
-            lede="You will not be asked to choose a simulator, a world model, or a provider. That choice depends on what each claim needs, which is exactly the part you are paying us to know."
+            lede="You will not be asked to choose a simulator, a world model, or a provider. That choice depends on what each claim needs, which is exactly the part you are paying us to know. Cheaper is about cost, not about proving less — real capture stays the reference, and derived methods stay support."
           />
           <Reveal className="mt-14">
             <EvidenceLadderChart rungs={homeEvidenceRungs} />

--- a/client/src/pages/HowItWorks.tsx
+++ b/client/src/pages/HowItWorks.tsx
@@ -1,18 +1,233 @@
 import { SEO } from "@/components/SEO";
-import { Eyebrow, ProofBoundary } from "@/components/blueprint";
-import { EditorialCtaBand, EditorialSectionIntro } from "@/components/site/editorial";
-import { TileGrid } from "@/components/site/TileGrid";
+import { ProofBoundary } from "@/components/blueprint";
+import { ClaimThresholdChart, EvidenceLadderChart } from "@/components/site/figures";
+import { Reveal, ScrollProgressRail } from "@/components/site/motion";
+import {
+  Band,
+  ClosingCta,
+  FullBleedMedia,
+  Inner,
+  NoteCards,
+  PageHero,
+  SectionHeader,
+} from "@/components/site/publicSections";
+import {
+  closingCta,
+  homeClaimMetricLabel,
+  homeClaimThreshold,
+  homeClaims,
+  homeEvidenceRungs,
+  homeLimits,
+  howItWorksSplit,
+  howItWorksSteps,
+} from "@/data/publicSiteCopy";
 import { breadcrumbJsonLd, webPageJsonLd } from "@/lib/seoStructuredData";
 
-const steps = [
-  ["1", "Describe the site-task and decision", "State the question, claims, thresholds and units, false-safe consequence, acceptable risk, budget, deadline, available evidence, rights, and physical-testing constraints."],
-  ["2", "Link the maintained testbed", "The request names an exact Site-Task Testbed ID, version, and digest. Raw capture provenance remains authoritative; derived evidence does not silently upgrade the claim."],
-  ["3", "Plan the cheapest qualified evidence", "Pipeline qualifies and selects geometry, real observations, traditional simulation, world models, provider tools, or physical evidence claim by claim. WebApp does not select the backend."],
-  ["4", "Measure and aggregate", "Each method reports what it measured, its qualification profile, validation envelope, uncertainty, disagreement, coverage, and exact artifacts."],
-  ["5", "Return a decision or abstention", "The result may be positive, negative, partial, blocked, or abstained. Unknown states fail closed and an abstention can never be converted into a winner from raw scores."],
-  ["6", "Run the next cheapest experiment", "When evidence is insufficient, Blueprint identifies the least expensive stronger test and whether authoritative physical evidence is necessary."],
-] as const;
+const runHref =
+  "/contact/robot-team?interest=task-evaluation-run&requestedOutputs=Task%20Evaluation%20Run&source=how-it-works";
 
 export default function HowItWorks() {
-  return <><SEO title="How a Task Evaluation Run works | Blueprint" description="From real site-task to maintained testbed, qualified evidence plan, bounded decision or abstention, and physical learning loop." canonical="/how-it-works" jsonLd={[webPageJsonLd({ path: "/how-it-works", name: "How a Task Evaluation Run works", description: "The Blueprint Task Evaluation Run lifecycle." }), breadcrumbJsonLd([{ name: "Home", path: "/" }, { name: "How it works", path: "/how-it-works" }])]} /><section className="bg-canvas"><div className="mx-auto max-w-[88rem] px-5 py-16 sm:px-8 lg:px-10 lg:py-24"><Eyebrow tone="brass" rule>How it works</Eyebrow><h1 className="mt-5 max-w-4xl font-display text-[clamp(2.7rem,5vw,4.8rem)] font-medium leading-[1.01] tracking-[-0.05em] text-ink-900">How a Task Evaluation Run works.</h1><p className="mt-5 max-w-3xl text-[1.05rem] leading-8 text-ink-500">One real site-task becomes a maintained testbed. One decision request becomes a qualified evidence plan. The result is a bounded answer or an explicit abstention—not a backend choice or guaranteed ranking.</p></div></section><section className="border-y border-line bg-paper"><div className="mx-auto max-w-[88rem] px-5 py-16 sm:px-8 lg:px-10 lg:py-24"><EditorialSectionIntro eyebrow="Six stages" title="From real task to inspectable decision." description="Pipeline owns method qualification, routing, normalized evidence, and scientific verdicts. WebApp owns secure intake, authorization, durable state, projection, and access." /><TileGrid cols={3} className="mt-10">{steps.map(([number, title, body]) => <article key={number} className="bg-white p-6"><span className="font-mono text-sm text-brass">{number}</span><h2 className="mt-3 text-title-m font-semibold text-ink-900">{title}</h2><p className="mt-3 text-sm leading-7 text-ink-500">{body}</p></article>)}</TileGrid><div className="mt-8 grid gap-5 lg:grid-cols-2"><ProofBoundary level="info" title="Router in plain language">Blueprint uses the least expensive evidence that is trustworthy enough for each question, and asks for stronger evidence only when needed.</ProofBoundary><ProofBoundary level="warn" title="Claim ceiling">Simulation, generated evidence, provider availability, and export eligibility are not physical guarantees. Safety approval remains external.</ProofBoundary></div></div></section><section className="mx-auto max-w-[88rem] px-5 py-16 sm:px-8 lg:px-10 lg:py-20"><EditorialCtaBand eyebrow="One intake" title="Request a Task Evaluation Run." description="Robot teams and site operators use the same decision contract and result model." imageSrc="/redesign/pov/inspection-bench.jpg" imageAlt="Real-site inspection task" primaryHref="/contact/robot-team?interest=task-evaluation-run&requestedOutputs=Task%20Evaluation%20Run&source=how-it-works" primaryLabel="Request a Task Evaluation Run" secondaryHref="/pricing" secondaryLabel="See pricing" /></section></>;
+  return (
+    <>
+      <SEO
+        title="How a Task Evaluation Run works | Blueprint"
+        description="From one real site-task to a maintained testbed, an evidence plan chosen per claim, an answer with its limits, and the next cheapest test."
+        canonical="/how-it-works"
+        jsonLd={[
+          webPageJsonLd({
+            path: "/how-it-works",
+            name: "How a Task Evaluation Run works",
+            description: "The Blueprint Task Evaluation Run lifecycle, step by step.",
+          }),
+          breadcrumbJsonLd([
+            { name: "Home", path: "/" },
+            { name: "How it works", path: "/how-it-works" },
+          ]),
+        ]}
+      />
+
+      <PageHero
+        eyebrow="How it works"
+        title="Six steps, and one of them is allowed to say no."
+        body="One real site-task becomes a testbed we keep. One decision becomes an evidence plan built claim by claim. What comes back is an answer with its edges drawn — not a backend you chose and not a ranking we owed you."
+        ctaHref={runHref}
+        ctaLabel="Request a Task Evaluation Run"
+        secondaryHref="/pricing"
+        secondaryLabel="How pricing works"
+        imageSrc="/redesign/pov/inspection-bench.jpg"
+        imageAlt="An inspection bench task at a real working site"
+        imageCaption="Real site · captured substrate"
+        routeTrace
+      />
+
+      {/* Stepped walkthrough, bound together by a scroll-tracked rail. */}
+      <Band tone="canvas">
+        <Inner className="py-20 lg:py-28">
+          <SectionHeader
+            index="01"
+            eyebrow="The walkthrough"
+            title="What actually happens, in order."
+            lede="Two of these steps are yours. The rest are ours, and the split is deliberate: the hardest judgement in evaluation is method selection, and that is the last thing a buyer should be holding."
+          />
+
+          <ScrollProgressRail className="mt-16 pl-8 sm:pl-12" railClassName="left-0">
+            <ol className="flex flex-col gap-14">
+              {howItWorksSteps.map((step, index) => (
+                <Reveal as="li" key={step.title} from="up" distance={20}>
+                  <div className="relative">
+                    <span
+                      className="absolute -left-8 top-1 flex h-3 w-3 items-center justify-center sm:-left-12"
+                      aria-hidden="true"
+                    >
+                      <span className="h-2.5 w-2.5 rounded-full bg-brass-deep ring-4 ring-canvas" />
+                    </span>
+                    {/* Heading and body sit side by side from lg up so the
+                        stepped list uses the full measure instead of leaving
+                        half the page empty. */}
+                    <div className="grid gap-x-12 gap-y-4 lg:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)]">
+                      <div>
+                        <span className="font-mono text-[11px] tracking-[0.2em] text-brass-deep">
+                          Step {String(index + 1).padStart(2, "0")}
+                        </span>
+                        <h3 className="mt-3 max-w-[22ch] font-display text-[clamp(1.6rem,2.6vw,2.35rem)] font-medium leading-[1.1] tracking-[-0.03em] text-ink-900">
+                          {step.title}
+                        </h3>
+                      </div>
+                      <p className="max-w-[54ch] text-[15.5px] leading-[1.75] text-ink-600 lg:self-center">
+                        {step.body}
+                      </p>
+                    </div>
+                  </div>
+                </Reveal>
+              ))}
+            </ol>
+          </ScrollProgressRail>
+        </Inner>
+      </Band>
+
+      {/* Who owns what */}
+      <Band tone="ink">
+        <Inner className="py-20 lg:py-28">
+          <SectionHeader
+            index="02"
+            eyebrow="Who owns what"
+            title="A clean line between the record and the science."
+            lede="Worth knowing, because it explains why the site will never turn a refusal to decide into a winner: the site does not get a vote on the verdict."
+            onInk
+          />
+          <div className="mt-14 grid gap-10 lg:grid-cols-2 lg:gap-16">
+            <Reveal>
+              <div className="border-t border-white/15 pt-6">
+                <h3 className="font-display text-[1.6rem] font-medium leading-[1.15] tracking-[-0.03em] text-[color:var(--text-on-ink)]">
+                  The website owns the record
+                </h3>
+                <ul className="mt-6 space-y-3.5">
+                  {howItWorksSplit.blueprint.map((item) => (
+                    <li key={item} className="flex gap-3 text-[14.5px] leading-[1.65] text-ink-300">
+                      <span
+                        aria-hidden="true"
+                        className="mt-[0.5rem] h-1 w-4 shrink-0 bg-brass opacity-70"
+                      />
+                      {item}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </Reveal>
+            <Reveal delay={0.08}>
+              <div className="border-t border-white/15 pt-6">
+                <h3 className="font-display text-[1.6rem] font-medium leading-[1.15] tracking-[-0.03em] text-[color:var(--text-on-ink)]">
+                  The pipeline owns the verdict
+                </h3>
+                <ul className="mt-6 space-y-3.5">
+                  {howItWorksSplit.pipeline.map((item) => (
+                    <li key={item} className="flex gap-3 text-[14.5px] leading-[1.65] text-ink-300">
+                      <span
+                        aria-hidden="true"
+                        className="mt-[0.5rem] h-1 w-4 shrink-0 bg-brass opacity-70"
+                      />
+                      {item}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </Reveal>
+          </div>
+        </Inner>
+      </Band>
+
+      <Band tone="canvas">
+        <Inner className="py-20 lg:py-28">
+          <SectionHeader
+            index="03"
+            eyebrow="Step 03, in a picture"
+            title="Routing, and where it stops."
+          />
+          <Reveal className="mt-14">
+            <EvidenceLadderChart rungs={homeEvidenceRungs} />
+          </Reveal>
+        </Inner>
+      </Band>
+
+      <Band tone="paper" rule>
+        <Inner className="py-20 lg:py-28">
+          <SectionHeader
+            index="04"
+            eyebrow="Step 05, in a picture"
+            title="How the answer gets its edges."
+          />
+          <Reveal className="mt-14">
+            <ClaimThresholdChart
+              claims={homeClaims}
+              threshold={homeClaimThreshold}
+              metricLabel={homeClaimMetricLabel}
+            />
+          </Reveal>
+          <div className="mt-8 grid gap-5 lg:grid-cols-2">
+            <Reveal>
+              <ProofBoundary level="info" title="Unknown states fail closed">
+                If a state cannot be established, it is not treated as a pass. The
+                run reports the gap rather than defaulting to the answer that
+                would be more convenient.
+              </ProofBoundary>
+            </Reveal>
+            <Reveal delay={0.08}>
+              <ProofBoundary level="warn" title="Derived evidence stays derived">
+                Simulated, generated, and provider-produced evidence is never
+                silently promoted to the status of raw capture, and none of it is a
+                physical guarantee. Safety approval stays external.
+              </ProofBoundary>
+            </Reveal>
+          </div>
+        </Inner>
+      </Band>
+
+      <FullBleedMedia
+        src="/redesign/pov/factory-conveyor.jpg"
+        alt="A conveyor line in a working plant"
+        eyebrow="Step 06"
+        title="Then we tell you the cheapest thing left to try."
+        body="When the evidence falls short, the useful output is not an apology — it is the next experiment, its cost, and whether it can be done short of putting a robot on the floor."
+      />
+
+      <Band tone="ink">
+        <Inner className="py-20 lg:py-28">
+          <SectionHeader index="05" eyebrow="Where we stop" title="The limits, stated plainly." onInk />
+          <NoteCards items={homeLimits} onInk className="mt-14" />
+        </Inner>
+      </Band>
+
+      <ClosingCta
+        eyebrow={closingCta.eyebrow}
+        title={closingCta.title}
+        body={closingCta.body}
+        primaryHref="/contact/robot-team?interest=task-evaluation-run&requestedOutputs=Task%20Evaluation%20Run&source=how-it-works-cta"
+        primaryLabel="Request a Task Evaluation Run"
+        secondaryHref="/pricing"
+        secondaryLabel="How pricing works"
+        imageSrc="/redesign/pov/dishwasher.jpg"
+        imageAlt="A commercial kitchen task environment"
+      />
+    </>
+  );
 }

--- a/client/src/pages/Pricing.tsx
+++ b/client/src/pages/Pricing.tsx
@@ -1,39 +1,56 @@
-import { ArrowRight, Check } from "lucide-react";
+import { Check } from "lucide-react";
 
 import { SEO } from "@/components/SEO";
-import { Button, Eyebrow, ProofBoundary } from "@/components/blueprint";
-import { EditorialCtaBand, EditorialFaq, EditorialSectionIntro, ProofChip } from "@/components/site/editorial";
-import { TileGrid } from "@/components/site/TileGrid";
-import { blueprintPositioning } from "@/data/robotPolicyEvaluationClaims";
+import { Button, ProofBoundary } from "@/components/blueprint";
+import { EditorialFaq } from "@/components/site/editorial";
+import { OutcomeSpectrum } from "@/components/site/figures";
+import { Reveal } from "@/components/site/motion";
+import {
+  Band,
+  ClosingCta,
+  Inner,
+  NoteCards,
+  PageHero,
+  SectionHeader,
+} from "@/components/site/publicSections";
+import {
+  closingCta,
+  homeOutcomes,
+  pricingBoundaries,
+  pricingDrivers,
+  pricingHero,
+  pricingIncluded,
+} from "@/data/publicSiteCopy";
 import { breadcrumbJsonLd, faqJsonLd, webPageJsonLd } from "@/lib/seoStructuredData";
 
-const included = [
-  "One decision-oriented request for a real site-task",
-  "A versioned Site-Task Testbed reference",
-  "Claim, threshold, false-safe, budget, and deadline scoping",
-  "Pipeline-qualified evidence plan and per-claim outcomes",
-  "Decision, partial decision, or explicit abstention",
-  "Validation envelope, uncertainty, disagreements, and claim ceiling",
-  "Next cheapest experiment and physical-evidence requirements",
-  "Exact evidence provenance and permitted-use eligibility",
-];
+const runHref =
+  "/contact/robot-team?interest=task-evaluation-run&requestedOutputs=Task%20Evaluation%20Run&source=pricing";
 
 const faqItems = [
   {
-    question: "How is a Task Evaluation Run priced?",
-    answer: "Each run is quoted from the decision, evidence already available, number of candidates and scenarios, compute, deadline, rights constraints, and any physical work required. Blueprint does not publish an invented fixed price.",
+    question: "Why is there no price on this page?",
+    answer:
+      "Because two runs that sound identical can need very different evidence. A decision resting on an existing testbed with prior evidence costs a fraction of a cold start on a contact-heavy task with a hard deadline. Publishing one number would mean overcharging the first or underdelivering the second.",
   },
   {
-    question: "Do robot teams and site operators buy different products?",
-    answer: "No. They are two personas using the same Task Evaluation Run, request contract, workflow, result model, and intake. A robot team may bring policies; a site operator may begin with the task and missing evidence.",
+    question: "Do robot teams and site operators buy different things?",
+    answer:
+      "No. Same service, same intake, same workflow, same result model. A robot team usually arrives with candidates; a site operator usually arrives with a job and no candidates yet. Neither is a different product.",
   },
   {
-    question: "Does every run return a ranking or winner?",
-    answer: "No. Valid outcomes include bounded positive or negative decisions, elimination of an incompatible candidate, partial decisions, explicit abstention, or a request for the next evidence needed.",
+    question: "What if the run cannot answer my question?",
+    answer:
+      "Then it says so, tells you which claims stayed open and why, and names the cheapest test that would settle them. That is a valid delivered result — a quote pays for the work and an honest answer, not for a particular verdict.",
   },
   {
-    question: "Is post-training a separate add-on?",
-    answer: "No. A qualifying evidence artifact may be marked eligible for evaluation or post-training use inside a run. Eligibility does not prove that training occurred or that a policy improved.",
+    question: "Is post-training something I buy separately?",
+    answer:
+      "No. Evidence produced inside a run can be marked eligible for evaluation or post-training use. That flag records permission, not an outcome — it does not mean training happened or that a policy improved.",
+  },
+  {
+    question: "Can I set the price by naming my budget?",
+    answer:
+      "Your budget and deadline are real inputs to scoping and we want them early. But the site does not treat a client-supplied number as authoritative — scope, price, and authorisation stay on our side of the boundary.",
   },
 ];
 
@@ -42,48 +59,160 @@ export default function Pricing() {
     <>
       <SEO
         title="Task Evaluation Run pricing | Blueprint"
-        description="One scoped Task Evaluation Run, quoted according to the decision, evidence, candidates, scenarios, compute, timing, rights, and physical requirements."
+        description="One scoped Task Evaluation Run, quoted from the decision, the evidence it needs, the candidates and conditions, the deadline, rights, and any physical work."
         canonical="/pricing"
         jsonLd={[
-          webPageJsonLd({ path: "/pricing", name: "Task Evaluation Run pricing", description: "One scoped Task Evaluation Run with request-for-quote pricing." }),
-          breadcrumbJsonLd([{ name: "Home", path: "/" }, { name: "Pricing", path: "/pricing" }]),
+          webPageJsonLd({
+            path: "/pricing",
+            name: "Task Evaluation Run pricing",
+            description: "One scoped Task Evaluation Run, quoted per decision.",
+          }),
+          breadcrumbJsonLd([
+            { name: "Home", path: "/" },
+            { name: "Pricing", path: "/pricing" },
+          ]),
           faqJsonLd(faqItems),
         ]}
       />
 
-      <section className="bg-canvas">
-        <div className="mx-auto max-w-[88rem] px-5 py-16 sm:px-8 lg:px-10 lg:py-24">
-          <Eyebrow tone="brass" rule>One product · scoped engagement</Eyebrow>
-          <h1 className="mt-5 max-w-4xl font-display text-[clamp(2.6rem,5vw,4.4rem)] font-medium leading-[1.02] tracking-[-0.045em] text-ink-900">Price the decision and evidence it actually requires.</h1>
-          <p className="mt-5 max-w-3xl text-[1.05rem] leading-[1.7] text-ink-500">{blueprintPositioning}</p>
-          <div className="mt-7 flex flex-wrap gap-2"><ProofChip>One Task Evaluation Run</ProofChip><ProofChip>Quote before authorization</ProofChip><ProofChip>Decision or abstention</ProofChip></div>
-        </div>
-      </section>
+      <PageHero
+        eyebrow={pricingHero.eyebrow}
+        title={pricingHero.title}
+        body={pricingHero.body}
+        chips={["One thing to buy", "Quoted before you authorise", "No tiers, no add-ons"]}
+        ctaHref={runHref}
+        ctaLabel="Request a Task Evaluation Run"
+        secondaryHref="/how-it-works"
+        secondaryLabel="How it works"
+        imageSrc="/redesign/pov/factory-conveyor.jpg"
+        imageAlt="An industrial line of the kind a site-task is captured from"
+        imageCaption="Scoped per decision"
+      />
 
-      <section className="border-y border-line bg-paper">
-        <div className="mx-auto max-w-[88rem] px-5 py-16 sm:px-8 lg:px-10 lg:py-24">
-          <EditorialSectionIntro eyebrow="Engagement model" title="One scoped run. No separate package, submission fee, or subscription." description="The quote reflects only what is needed to answer the requested decision at the required evidence strength." />
-          <TileGrid cols={2} className="mt-12 rounded-lg">
-            <article className="bg-ink p-7 text-paper lg:p-9">
-              <Eyebrow tone="onInk">Task Evaluation Run</Eyebrow>
-              <h2 className="mt-5 text-title-l font-semibold">Scoped quote</h2>
-              <p className="mt-4 text-sm leading-7 text-paper/75">Decision, claims, candidates, evidence gaps, compute, deadline, access, privacy, and physical requirements determine scope.</p>
-              <Button asChild variant="brass" size="lg" className="mt-8"><a href="/contact/robot-team?interest=task-evaluation-run&requestedOutputs=Task%20Evaluation%20Run&source=pricing">Request a Task Evaluation Run <ArrowRight className="h-4 w-4" /></a></Button>
-            </article>
-            <article className="bg-white p-7 lg:p-9">
-              <h2 className="text-title-l font-semibold text-ink-900">What the scope covers</h2>
-              <ul className="mt-5 space-y-3">{included.map((item) => <li key={item} className="flex gap-3 text-sm leading-6 text-ink-700"><Check className="mt-1 h-4 w-4 shrink-0 text-brass" />{item}</li>)}</ul>
-            </article>
-          </TileGrid>
-          <div className="mt-8 grid gap-5 lg:grid-cols-2">
-            <ProofBoundary level="info" title="Server-authoritative commercial scope">The website records budget and timing constraints, but it does not accept a client-supplied price as authoritative. Authorization and any transaction remain tied to server-owned records.</ProofBoundary>
-            <ProofBoundary level="warn" title="No guaranteed outcome">A quote authorizes the work, not a ranking, winner, field recommendation, deployment, safety approval, or successful physical result.</ProofBoundary>
+      {/* What moves the number */}
+      <Band tone="ink">
+        <Inner className="py-20 lg:py-28">
+          <SectionHeader
+            index="01"
+            eyebrow="What moves the number"
+            title="Six things, and none of them is a tier."
+            lede="Fixed campaign prices are gone. They implied every decision needs the same evidence, which was never true — and it made the cheap runs expensive."
+            onInk
+          />
+          <div className="mt-14 grid gap-x-10 gap-y-9 sm:grid-cols-2 lg:grid-cols-3">
+            {pricingDrivers.map((driver, index) => (
+              <Reveal key={driver.label} delay={index * 0.05}>
+                <div className="border-t border-white/15 pt-5">
+                  <span className="font-mono text-[11px] tracking-[0.2em] text-brass">
+                    {String(index + 1).padStart(2, "0")}
+                  </span>
+                  <h3 className="mt-3.5 text-[15px] font-semibold tracking-[-0.01em] text-[color:var(--text-on-ink)]">
+                    {driver.label}
+                  </h3>
+                  <p className="mt-2.5 max-w-[40ch] text-[14px] leading-[1.7] text-ink-300">
+                    {driver.detail}
+                  </p>
+                </div>
+              </Reveal>
+            ))}
           </div>
-        </div>
-      </section>
+        </Inner>
+      </Band>
 
-      <section className="bg-canvas"><div className="mx-auto max-w-[70rem] px-5 py-16 sm:px-8 lg:py-24"><EditorialFaq items={faqItems} /></div></section>
-      <section className="mx-auto max-w-[88rem] px-5 py-16 sm:px-8 lg:px-10 lg:py-20"><EditorialCtaBand eyebrow="Start with the decision" title="Request a Task Evaluation Run." description="Describe the site-task, the decision you need, thresholds, consequences, evidence, budget, timing, and restrictions. Blueprint scopes the evidence plan with you." imageSrc="/redesign/pov/factory-conveyor.jpg" imageAlt="Real industrial site used to define a task evaluation" primaryHref="/contact/robot-team?interest=task-evaluation-run&requestedOutputs=Task%20Evaluation%20Run&source=pricing-cta" primaryLabel="Request a Task Evaluation Run" secondaryHref="/how-it-works" secondaryLabel="See how it works" /></section>
+      {/* What the scope covers */}
+      <Band tone="canvas">
+        <Inner className="py-20 lg:py-28">
+          <SectionHeader
+            index="02"
+            eyebrow="What a quote covers"
+            title="One scoped run, and everything needed to read it."
+          />
+          <div className="mt-14 grid gap-10 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)] lg:gap-16">
+            <Reveal>
+              <div className="rounded-lg border border-line bg-ink p-7 lg:p-9">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-brass">
+                  Task Evaluation Run
+                </p>
+                <h3 className="mt-6 font-display text-[clamp(2.2rem,3.4vw,2.9rem)] font-medium leading-[1.02] tracking-[-0.04em] text-[color:var(--text-on-ink)]">
+                  Scoped quote
+                </h3>
+                <p className="mt-5 text-[14.5px] leading-[1.72] text-ink-300">
+                  We scope the decision with you, price the evidence it needs, and
+                  send the quote before anything is authorised. You will know what
+                  the run can and cannot settle before you commit to it.
+                </p>
+                <Button asChild variant="brass" size="lg" className="mt-9">
+                  <a href={runHref}>Request a Task Evaluation Run</a>
+                </Button>
+              </div>
+            </Reveal>
+            <Reveal delay={0.08}>
+              <ul className="grid gap-y-3.5 sm:grid-cols-2 sm:gap-x-8">
+                {pricingIncluded.map((item) => (
+                  <li key={item} className="flex gap-3 text-[14px] leading-[1.65] text-ink-700">
+                    <Check className="mt-[0.2rem] h-4 w-4 shrink-0 text-brass-deep" aria-hidden="true" />
+                    {item}
+                  </li>
+                ))}
+              </ul>
+            </Reveal>
+          </div>
+        </Inner>
+      </Band>
+
+      {/* What you are and are not paying for */}
+      <Band tone="paper" rule>
+        <Inner className="py-20 lg:py-28">
+          <SectionHeader
+            index="03"
+            eyebrow="What the money buys"
+            title="An answer. Not necessarily the answer you were hoping for."
+            lede="Five outcomes are in scope for every run, and a quote does not privilege the flattering ones."
+          />
+          <div className="mt-14">
+            <OutcomeSpectrum bands={homeOutcomes} />
+          </div>
+          <NoteCards items={pricingBoundaries} className="mt-16" />
+          <div className="mt-10 grid gap-5 lg:grid-cols-2">
+            <Reveal>
+              <ProofBoundary level="info" title="Pricing is server-owned">
+                Budget and timing are recorded as constraints. Authorisation and any
+                transaction stay tied to server-owned records, not to values posted
+                from a browser.
+              </ProofBoundary>
+            </Reveal>
+            <Reveal delay={0.08}>
+              <ProofBoundary level="warn" title="No guaranteed outcome">
+                A quote authorises work. It does not purchase a ranking, a winner, a
+                field recommendation, a deployment, a safety approval, or a
+                successful physical result.
+              </ProofBoundary>
+            </Reveal>
+          </div>
+        </Inner>
+      </Band>
+
+      <Band tone="canvas">
+        <Inner size="narrow" className="py-20 lg:py-28">
+          <EditorialFaq
+            title="Pricing questions"
+            description="The ones that come up before a first run is scoped."
+            items={faqItems}
+          />
+        </Inner>
+      </Band>
+
+      <ClosingCta
+        eyebrow={closingCta.eyebrow}
+        title={closingCta.title}
+        body={closingCta.body}
+        primaryHref="/contact/robot-team?interest=task-evaluation-run&requestedOutputs=Task%20Evaluation%20Run&source=pricing-cta"
+        primaryLabel="Request a Task Evaluation Run"
+        secondaryHref="/how-it-works"
+        secondaryLabel="See how it works"
+        imageSrc="/redesign/pov/laundry-folding.jpg"
+        imageAlt="A commercial laundry line used as a real-site task context"
+      />
     </>
   );
 }

--- a/client/src/pages/Proof.tsx
+++ b/client/src/pages/Proof.tsx
@@ -1,33 +1,75 @@
+import { ArrowUpRight } from "lucide-react";
+
 import { SEO } from "@/components/SEO";
+import { ProofBoundary } from "@/components/blueprint";
+import { ClaimThresholdChart, EvidenceLadderChart } from "@/components/site/figures";
+import { Reveal } from "@/components/site/motion";
+import {
+  Band,
+  ClosingCta,
+  FullBleedMedia,
+  Inner,
+  NoteCards,
+  PageHero,
+  SectionHeader,
+} from "@/components/site/publicSections";
 import {
   robotPolicyEvaluationBeachhead,
   robotPolicyEvaluationBoundary,
   robotPolicyResearchSignals,
-  robotPolicyScreeningValue,
+  robotPolicyResearchSignalsNote,
 } from "@/data/robotPolicyEvaluationClaims";
-import { wamPolicyEvalAssets } from "@/lib/editorialGeneratedAssets";
 import {
-  breadcrumbJsonLd,
-  faqJsonLd,
-  webPageJsonLd,
-} from "@/lib/seoStructuredData";
-import { ArrowRight, CheckCircle2, ShieldCheck } from "lucide-react";
+  closingCta,
+  homeClaimMetricLabel,
+  homeClaimThreshold,
+  homeClaims,
+  homeEvidenceRungs,
+  homeLimits,
+} from "@/data/publicSiteCopy";
+import { wamPolicyEvalAssets } from "@/lib/editorialGeneratedAssets";
+import { breadcrumbJsonLd, faqJsonLd, webPageJsonLd } from "@/lib/seoStructuredData";
 
-const requestHref =
+const runHref =
   "/contact/robot-team?persona=robot-team&buyerType=robot_team&interest=task-evaluation-run&path=task-evaluation-run&requestedOutputs=Task%20Evaluation%20Run&source=proof";
 
-const proofLayers = [
-  ["Request packet", "Scopes one site, task, robot, policy set, and threshold."],
-  ["Owner proof", "Adds simulator traces, action logs, or real rollouts when needed."],
-  ["Research signal", "A secondary, follow-on support layer: generated-observation review can back policy comparisons."],
+const sourceLayers = [
+  {
+    label: "Raw capture",
+    body:
+      "Timestamps, poses, rights and privacy records. This is the source of truth, and nothing derived from it is allowed to outrank it.",
+  },
+  {
+    label: "Derived evidence",
+    body:
+      "Simulation, generated observations, provider tools. Useful, bounded, and always labelled as derived — never quietly promoted to fact.",
+  },
+  {
+    label: "Physical outcomes",
+    body:
+      "Results from real hardware. The only thing that settles a physical claim, joined back to the exact decision and testbed version it belongs to.",
+  },
+];
+
+const faqEntries = [
+  {
+    question: "Does the 0.929 figure mean Blueprint claims 93% accuracy?",
+    answer:
+      "No. SC3-Eval reports a 0.929 closed-loop Pearson correlation across seven VLA policies. That is published third-party research about a category of method. It is not a Blueprint result, not an accuracy guarantee, and not a claim about your site.",
+  },
+  {
+    question: "What does a Task Evaluation Run actually return?",
+    answer:
+      "An outcome per claim, the evidence method behind each and why it was chosen, what it measured, the conditions the answer holds under, uncertainty, any disagreement between methods, the strongest claim the evidence permits, the cheapest next test, whether physical evidence is required, and exact artifact provenance. A ranking appears only when the evidence supports one.",
+  },
 ];
 
 export default function Proof() {
   return (
     <>
       <SEO
-        title="Proof | Blueprint"
-        description="Blueprint keeps policy evaluation claims scoped to the site, task, robot, and evidence behind each run."
+        title="Proof boundaries | Blueprint"
+        description="What Blueprint treats as evidence, what it treats as support, and the claims it will not make on either."
         canonical="/proof"
         image={`https://tryblueprint.io${wamPolicyEvalAssets.rolloutStrip}`}
         jsonLd={[
@@ -35,114 +77,150 @@ export default function Proof() {
             path: "/proof",
             name: "Blueprint proof boundaries",
             description:
-              "Explains public samples, request packets, and real robot validation boundaries.",
+              "How Blueprint separates raw capture from derived evidence and physical outcomes, and which claims it declines to make.",
           }),
           breadcrumbJsonLd([
             { name: "Home", path: "/" },
             { name: "Proof", path: "/proof" },
           ]),
-          faqJsonLd([
-            {
-              question: "Does the 0.929 result mean Blueprint claims 93% external accuracy?",
-              answer:
-                "No. SC3-Eval reports a 0.929 closed-loop Pearson correlation across seven VLA policies. Blueprint cites it as research evidence for ranking workflows, not as an external accuracy guarantee.",
-            },
-            {
-              question: "What does a Task Evaluation Run return?",
-              answer:
-                "It returns per-claim outcomes, selected evidence methods, a validation envelope, uncertainty, disagreements, a claim ceiling, the next experiment, physical-evidence needs, and exact artifacts. A ranking appears only when supported; abstention never implies a winner.",
-            },
-          ]),
+          faqJsonLd(faqEntries),
         ]}
       />
 
-      <div className="bg-white text-slate-950">
-        <section className="border-b border-slate-200">
-          <div className="mx-auto grid max-w-[88rem] gap-10 px-5 py-12 md:grid-cols-[0.78fr_1.22fr] md:items-center md:px-8 md:py-16">
-            <div>
-              <p className="text-xs font-semibold uppercase tracking-[0.14em] text-blue-700">
-                {robotPolicyEvaluationBeachhead}
-              </p>
-              <h1 className="mt-4 max-w-[16ch] text-5xl font-semibold leading-[0.95] tracking-normal sm:text-6xl">
-                Proof stays scoped.
-              </h1>
-              <p className="mt-5 max-w-md text-lg leading-8 text-slate-600">
-                {robotPolicyScreeningValue}
-              </p>
-              <p className="mt-4 max-w-md text-sm leading-7 text-slate-500">
-                SC3-Eval's published 0.929 correlation is third-party research
-                context, not a Blueprint result, accuracy claim, or deployment claim.
-              </p>
-              <a
-                href={requestHref}
-                className="mt-8 inline-flex min-h-12 items-center justify-center gap-2 rounded-lg bg-blue-600 px-5 text-sm font-semibold text-white hover:bg-blue-700"
-              >
-                Request a Task Evaluation Run
-                <ArrowRight className="h-4 w-4" aria-hidden="true" />
-              </a>
-            </div>
-            <img
-              src={wamPolicyEvalAssets.rolloutStrip}
-              alt="Generated preview / review support: rollout frames of a mobile robot navigating a warehouse aisle and making a rigid tote pick"
-              className="aspect-[16/6] w-full rounded-lg border border-slate-200 object-cover"
+      <PageHero
+        eyebrow="Proof boundaries"
+        title="Proof stays scoped."
+        body="Every number a run returns carries the conditions it was measured under. Outside them it is not a weaker claim — it is not a claim. This page is the short version of what we will and will not say, and why."
+        chips={["Raw capture outranks derived", "Research is context, not result", "Safety approval stays external"]}
+        ctaHref={runHref}
+        ctaLabel="Request a Task Evaluation Run"
+        secondaryHref="/how-it-works"
+        secondaryLabel="How it works"
+        imageSrc="/redesign/pov/inspection-bench.jpg"
+        imageAlt="An inspection bench task at a real working site"
+        imageCaption="Real capture · source of truth"
+      />
+
+      <Band tone="ink">
+        <Inner className="py-20 lg:py-28">
+          <SectionHeader
+            index="01"
+            eyebrow="Three kinds of evidence"
+            title="They are not interchangeable, and we do not let them blur."
+            lede={robotPolicyEvaluationBeachhead}
+            onInk
+          />
+          <div className="mt-14 grid gap-x-10 gap-y-10 lg:grid-cols-3">
+            {sourceLayers.map((layer, index) => (
+              <Reveal key={layer.label} delay={index * 0.07}>
+                <div className="border-t border-white/15 pt-6">
+                  <span className="font-mono text-[11px] tracking-[0.2em] text-brass">
+                    {String(index + 1).padStart(2, "0")}
+                  </span>
+                  <h3 className="mt-4 font-display text-[1.5rem] font-medium leading-[1.15] tracking-[-0.03em] text-[color:var(--text-on-ink)]">
+                    {layer.label}
+                  </h3>
+                  <p className="mt-3.5 max-w-[42ch] text-[14.5px] leading-[1.72] text-ink-300">
+                    {layer.body}
+                  </p>
+                </div>
+              </Reveal>
+            ))}
+          </div>
+        </Inner>
+      </Band>
+
+      <Band tone="canvas">
+        <Inner className="py-20 lg:py-28">
+          <SectionHeader
+            index="02"
+            eyebrow="The boundary in practice"
+            title="Where an answer stops being an answer."
+            lede="The threshold, the interval, and the claim that will not resolve — this is the mechanism behind every honest no on this site."
+          />
+          <Reveal className="mt-14">
+            <ClaimThresholdChart
+              claims={homeClaims}
+              threshold={homeClaimThreshold}
+              metricLabel={homeClaimMetricLabel}
             />
-          </div>
-        </section>
+          </Reveal>
+          <Reveal className="mt-14">
+            <EvidenceLadderChart rungs={homeEvidenceRungs} />
+          </Reveal>
+        </Inner>
+      </Band>
 
-        <section className="mx-auto grid max-w-[88rem] gap-4 px-5 py-10 md:grid-cols-3 md:px-8">
-          {proofLayers.map(([title, body]) => (
-            <article key={title} className="rounded-lg border border-slate-200 bg-white p-6">
-              <CheckCircle2 className="h-5 w-5 text-blue-600" aria-hidden="true" />
-              <h2 className="mt-5 text-3xl font-semibold">{title}</h2>
-              <p className="mt-3 text-base leading-7 text-slate-600">{body}</p>
-            </article>
-          ))}
-        </section>
-
-        <section className="border-y border-slate-200 bg-slate-50">
-          <div className="mx-auto grid max-w-[88rem] gap-4 px-5 py-10 md:grid-cols-[0.34fr_0.66fr] md:px-8">
-            <div>
-              <h2 className="text-3xl font-semibold">What we cite.</h2>
-              <p className="mt-3 text-sm leading-7 text-slate-600">
-                These papers support the category: generated or virtual policy
-                rollouts can be useful for comparing policies and diagnosing
-                failures. Blueprint still requires request-scoped evidence for
-                stronger operational claims.
-              </p>
-            </div>
-            <div className="grid gap-3 md:grid-cols-2">
-              {robotPolicyResearchSignals.map((signal) => (
+      <Band tone="paper" rule>
+        <Inner className="py-20 lg:py-28">
+          <SectionHeader
+            index="03"
+            eyebrow="What we cite"
+            title="Research can motivate a method. It cannot stand in for a result."
+            lede={robotPolicyResearchSignalsNote}
+          />
+          <div className="mt-14 grid gap-5 lg:grid-cols-2">
+            {robotPolicyResearchSignals.map((signal, index) => (
+              <Reveal key={signal.label} delay={index * 0.07}>
                 <a
-                  key={signal.label}
                   href={signal.href}
-                  className="rounded-lg border border-slate-200 bg-white p-5 hover:bg-slate-50"
+                  className="group flex h-full flex-col rounded-lg border border-line bg-white p-6 transition-colors hover:bg-inset"
                 >
-                  <h3 className="text-xl font-semibold">{signal.label}</h3>
-                  <p className="mt-3 text-sm font-semibold text-blue-700">{signal.stat}</p>
-                  <p className="mt-2 text-sm leading-6 text-slate-600">{signal.body}</p>
+                  <div className="flex items-start justify-between gap-4">
+                    <h3 className="font-display text-[1.5rem] font-medium leading-[1.15] tracking-[-0.03em] text-ink-900">
+                      {signal.label}
+                    </h3>
+                    <ArrowUpRight
+                      className="mt-1 h-4 w-4 shrink-0 text-ink-400 transition-colors group-hover:text-brass-deep"
+                      aria-hidden="true"
+                    />
+                  </div>
+                  <p className="mt-4 text-[11px] font-semibold uppercase tracking-[0.16em] text-brass-deep">
+                    {signal.stat}
+                  </p>
+                  <p className="mt-3 text-[14px] leading-[1.7] text-ink-500">{signal.body}</p>
                 </a>
-              ))}
-            </div>
+              </Reveal>
+            ))}
           </div>
-        </section>
+          <div className="mt-10">
+            <Reveal>
+              <ProofBoundary level="warn" title="On the 0.929 figure specifically">
+                SC3-Eval's published 0.929 closed-loop correlation is third-party
+                research context. It is not a Blueprint result, not an accuracy
+                claim, and not a statement about any site or policy of yours.
+              </ProofBoundary>
+            </Reveal>
+          </div>
+        </Inner>
+      </Band>
 
-        <section className="border-y border-slate-200 bg-slate-950 text-white">
-          <div className="mx-auto grid max-w-[88rem] gap-6 px-5 py-10 md:grid-cols-[auto_1fr] md:items-start md:px-8">
-            <ShieldCheck className="h-10 w-10 text-blue-300" aria-hidden="true" />
-            <div>
-              <h2 className="text-3xl font-semibold">What we do not claim.</h2>
-              <p className="mt-4 max-w-4xl text-sm leading-7 text-slate-300">
-                {robotPolicyEvaluationBoundary} Provenance-linked run evidence reports
-                metrics only inside the matched robot, task, and site envelope.
-              </p>
-              <p className="mt-4 max-w-4xl text-sm font-semibold leading-7 text-slate-200">
-                A Task Evaluation Run returns only the bounded decision, partial decision,
-                or abstention supported by its evidence envelope — never a safety certification.
-              </p>
-            </div>
-          </div>
-        </section>
-      </div>
+      <FullBleedMedia
+        src="/redesign/pov/route-scan.jpg"
+        alt="A captured route through a real working site"
+        eyebrow="What we do not claim"
+        title="A run is evidence. It is not permission."
+        body={`${robotPolicyEvaluationBoundary} A result reports metrics only inside the matched robot, task, and site envelope — and never as a safety certification.`}
+      />
+
+      <Band tone="ink">
+        <Inner className="py-20 lg:py-28">
+          <SectionHeader index="04" eyebrow="Where we stop" title="The limits, stated plainly." onInk />
+          <NoteCards items={homeLimits} onInk className="mt-14" />
+        </Inner>
+      </Band>
+
+      <ClosingCta
+        eyebrow={closingCta.eyebrow}
+        title={closingCta.title}
+        body={closingCta.body}
+        primaryHref="/contact/robot-team?interest=task-evaluation-run&requestedOutputs=Task%20Evaluation%20Run&source=proof-cta"
+        primaryLabel="Request a Task Evaluation Run"
+        secondaryHref="/faq"
+        secondaryLabel="Read the FAQ"
+        imageSrc="/redesign/pov/cold-storage.jpg"
+        imageAlt="A cold-storage aisle used as a real-site task context"
+      />
     </>
   );
 }

--- a/client/tests/build-output.test.ts
+++ b/client/tests/build-output.test.ts
@@ -203,13 +203,15 @@ describe("build output", () => {
     const pricingHtml = fs.readFileSync(distPath("pricing/index.html"), "utf8");
     const proofHtml = fs.readFileSync(distPath("proof/index.html"), "utf8");
 
-    expect(homeHtml).toContain("Turn a real site-task into a decision you can defend.");
-    expect(homeHtml).toContain("Decision or abstention");
-    expect(homeHtml).toContain("Cheapest qualified evidence");
+    expect(homeHtml).toContain("Answer it before you send a robot.");
+    expect(homeHtml).toContain("A run is allowed to tell you it cannot tell you.");
+    expect(homeHtml).toContain("cheapest evidence that is actually good enough");
+    // Schematic figure values must be marked as such in the prerendered HTML too.
+    expect(homeHtml).toContain("Illustrative");
     expect(homeHtml).toContain('rel="canonical" href="https://tryblueprint.io/"');
     expect(homeHtml).toContain('type="application/ld+json"');
     // /pricing prerenders the single scoped engagement without inventing a price.
-    expect(pricingHtml).toContain("One scoped run. No separate package, submission fee, or subscription.");
+    expect(pricingHtml).toContain("You pay for the decision, not a package.");
     expect(pricingHtml).toContain("Scoped quote");
     expect(pricingHtml).toContain("Request a Task Evaluation Run");
     expect(pricingHtml).not.toContain("Policy Shortlist");
@@ -219,8 +221,8 @@ describe("build output", () => {
     expect(pricingHtml).not.toContain("Quick-look eval");
     expect(pricingHtml).not.toContain("Robot-team subscription");
     expect(proofHtml).toContain("Proof stays scoped");
-    expect(proofHtml).toContain("bounded decision, partial decision");
-    expect(proofHtml).toContain("never a safety certification");
+    expect(proofHtml).toContain("A run is evidence. It is not permission.");
+    expect(proofHtml).toContain("never as a safety certification");
     expect(proofHtml).not.toContain("images.unsplash.com");
   });
 
@@ -245,6 +247,6 @@ describe("build output", () => {
     expect(browserJavaScript).not.toMatch(/pplx-[A-Za-z0-9_-]{12,}/);
     expect(browserJavaScript).not.toMatch(/fc-[A-Za-z0-9_-]{12,}/);
     expect(browserJavaScript).toContain("Task Evaluation Run");
-    expect(browserJavaScript).toContain("Decision or abstention");
+    expect(browserJavaScript).toContain("You get an answer with its limits");
   });
 });

--- a/client/tests/components/site/PublicCopy.test.tsx
+++ b/client/tests/components/site/PublicCopy.test.tsx
@@ -35,20 +35,26 @@ describe("public real-site evaluation copy", () => {
     expect(
       screen.getByRole("heading", {
         level: 1,
-        name: /Turn a real site-task into a decision you can defend/i,
+        name: /Answer it before you send a robot/i,
       }),
     ).toBeInTheDocument();
     expect(screen.getAllByRole("link", { name: /Request a Task Evaluation Run/i }).length).toBeGreaterThan(0);
-    expect(container).toHaveTextContent(/Maintained testbed/i);
-    expect(container).toHaveTextContent(/Cheapest qualified evidence/i);
-    expect(container).toHaveTextContent(/Decision or abstention/i);
-    expect(container).toHaveTextContent(/Physical learning loop/i);
-    expect(container).toHaveTextContent(/does not infer a winner from raw scores/i);
+
+    // One service, and the lifecycle that backs it.
+    expect(container).toHaveTextContent(/One service\. Priced per decision\./i);
+    expect(container).toHaveTextContent(/We build the testbed/i);
+    expect(container).toHaveTextContent(/cheapest evidence that is actually good enough/i);
+
+    // Refusing to decide is still stated on the page, not buried.
+    expect(container).toHaveTextContent(/A run is allowed to tell you it cannot tell you/i);
+    expect(container).toHaveTextContent(/is not reported as one/i);
+
+    // Withdrawn products, fixed prices, and outcome guarantees stay absent.
     expect(container).not.toHaveTextContent(/Policy Shortlist/i);
     expect(container).not.toHaveTextContent(/Robot Match/i);
     expect(container).not.toHaveTextContent(/\$3,000/i);
     expect(container).not.toHaveTextContent(/\$5,000/i);
-    expect(screen.queryByRole("link", { name: /^Environments$/i })).not.toBeInTheDocument();
     expect(container).not.toHaveTextContent(/guaranteed winner/i);
+    expect(screen.queryByRole("link", { name: /^Environments$/i })).not.toBeInTheDocument();
   });
 });

--- a/client/tests/pages/FAQ.test.tsx
+++ b/client/tests/pages/FAQ.test.tsx
@@ -8,16 +8,26 @@ describe("FAQ", () => {
 
     expect(
       screen.getByRole("heading", {
-        name: /One product, explicit evidence boundaries\./i,
+        level: 1,
+        name: /One service, and the limits printed on it\./i,
       }),
     ).toBeInTheDocument();
+
     expect(screen.getByText(/What does Blueprint sell\?/i)).toBeInTheDocument();
-    expect(screen.getByText(/Do robot teams and site operators use different products\?/i)).toBeInTheDocument();
-    expect(screen.getByText(/Does every run return a ranking or winner\?/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Do robot teams and site operators use different products\?/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Does every run produce a ranking\?/i)).toBeInTheDocument();
     expect(screen.getByText(/Is post-training a separate product\?/i)).toBeInTheDocument();
-    expect(screen.getByText(/One customer-facing service: a Task Evaluation Run/i)).toBeInTheDocument();
-    expect(screen.getByText(/Valid outcomes include bounded positive or negative decisions/i)).toBeInTheDocument();
-    expect(screen.queryByText(/Policy Shortlist/i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/Robot Match/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/What happened to the other products\?/i)).toBeInTheDocument();
+
+    expect(screen.getByText(/One service: a Task Evaluation Run/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/manufacture a winner after the evidence has declined to produce one/i),
+    ).toBeInTheDocument();
+    // Withdrawn names may be described as withdrawn, but never offered.
+    expect(
+      screen.getByText(/no longer offered as current products/i),
+    ).toBeInTheDocument();
   });
 });

--- a/client/tests/pages/ForRobotTeams.test.tsx
+++ b/client/tests/pages/ForRobotTeams.test.tsx
@@ -5,10 +5,24 @@ import ForRobotTeams from "@/pages/ForRobotTeams";
 describe("ForRobotTeams", () => {
   it("explains the robot-team use case for the single Task Evaluation Run", () => {
     render(<ForRobotTeams />);
-    expect(screen.getByRole("heading", { name: /Decide what deserves scarce robot time/i })).toBeInTheDocument();
-    expect(screen.getAllByRole("link", { name: /Request a Task Evaluation Run/i }).length).toBeGreaterThan(0);
-    expect(screen.getByText(/A ranking is not guaranteed/i)).toBeInTheDocument();
-    expect(screen.getByText(/Pipeline chooses the least expensive currently qualified evidence/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        level: 1,
+        name: /Spend field time on the candidate that earned it/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getAllByRole("link", { name: /Request a Task Evaluation Run/i }).length,
+    ).toBeGreaterThan(0);
+
+    // A ranking is explicitly not the promise.
+    expect(screen.getByText(/A ranking is not the promise/i)).toBeInTheDocument();
+    // The buyer does not select the evidence backend.
+    expect(screen.getByText(/Why you do not pick the backend/i)).toBeInTheDocument();
+    // Abstention survives as a named outcome on the persona page too.
+    expect(screen.getByText(/^Not yet$/i)).toBeInTheDocument();
+
     expect(screen.queryByText(/Policy Shortlist/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/\$3,000/)).not.toBeInTheDocument();
   });
 });

--- a/client/tests/pages/ForSiteOperators.test.tsx
+++ b/client/tests/pages/ForSiteOperators.test.tsx
@@ -5,10 +5,29 @@ import ForSiteOperators from "@/pages/ForSiteOperators";
 describe("ForSiteOperators", () => {
   it("uses the same service, result model, and CTA for the site-operator persona", () => {
     render(<ForSiteOperators />);
-    expect(screen.getByRole("heading", { name: /Turn one real task into a decision you can inspect/i })).toBeInTheDocument();
-    expect(screen.getAllByRole("link", { name: /Request a Task Evaluation Run/i }).length).toBeGreaterThan(0);
-    expect(screen.getByText(/Same service · same result model/i)).toBeInTheDocument();
-    expect(screen.getByText(/Candidates are optional at intake/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        level: 1,
+        name: /Find out what a robot could do here, before anyone shows up/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getAllByRole("link", { name: /Request a Task Evaluation Run/i }).length,
+    ).toBeGreaterThan(0);
+
+    // Same service as the robot-team persona, entered from the other side.
+    expect(
+      screen.getByText(/You should not have to become an evaluation expert to get an answer/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Both end up in the same run/i)).toBeInTheDocument();
+    // Candidates are optional at intake.
+    expect(screen.getByText(/Candidates can be linked whenever they exist/i)).toBeInTheDocument();
+    // Operator control and the safety boundary stay explicit.
+    expect(screen.getByText(/^Restricted areas$/i)).toBeInTheDocument();
+    expect(screen.getByText(/Safety stays yours/i)).toBeInTheDocument();
+    // Abstention is still one of the named outcomes.
+    expect(screen.getByText(/^Not yet$/i)).toBeInTheDocument();
+
     expect(screen.queryByText(/Robot Match/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/\$5,000/)).not.toBeInTheDocument();
   });

--- a/client/tests/pages/Home.test.tsx
+++ b/client/tests/pages/Home.test.tsx
@@ -5,14 +5,44 @@ import Home from "@/pages/Home";
 describe("Home", () => {
   it("renders one Task Evaluation Run lifecycle with abstention and one primary CTA", () => {
     render(<Home />);
-    expect(screen.getByRole("heading", { level: 1, name: /Turn a real site-task into a decision you can defend/i })).toBeInTheDocument();
-    expect(screen.getAllByRole("link", { name: /Request a Task Evaluation Run/i }).length).toBeGreaterThan(0);
-    expect(screen.getByText(/^Maintained testbed$/i)).toBeInTheDocument();
-    expect(screen.getByText(/^Cheapest qualified evidence$/i)).toBeInTheDocument();
-    expect(screen.getAllByText(/Decision or abstention/i).length).toBeGreaterThan(0);
-    expect(screen.getByText(/^Explicit abstention$/i)).toBeInTheDocument();
-    expect(screen.getByText(/does not infer a winner from raw scores/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { level: 1, name: /Answer it before you send a robot/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getAllByRole("link", { name: /Request a Task Evaluation Run/i }).length,
+    ).toBeGreaterThan(0);
+
+    // The lifecycle still reads task -> maintained testbed -> routed evidence -> answer.
+    expect(screen.getByText(/^Bring one real task$/i)).toBeInTheDocument();
+    expect(screen.getByText(/^We build the testbed$/i)).toBeInTheDocument();
+    expect(screen.getByText(/^We route each claim$/i)).toBeInTheDocument();
+    expect(screen.getByText(/^You get an answer with its limits$/i)).toBeInTheDocument();
+
+    // Abstention is still a first-class, named outcome.
+    expect(screen.getByText(/^Not yet$/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/^Unresolved$/i).length).toBeGreaterThan(0);
+    expect(
+      screen.getByText(/A run is allowed to tell you it cannot tell you/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/is not reported as one/i),
+    ).toBeInTheDocument();
+
+    // Withdrawn product names and fixed campaign prices stay gone.
     expect(screen.queryByText(/Policy Shortlist/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/Robot Match/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/\$3,000/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/\$5,000/)).not.toBeInTheDocument();
+  });
+
+  it("marks every figure that shows numbers as illustrative", () => {
+    const { container } = render(<Home />);
+    const figures = container.querySelectorAll("figure");
+    expect(figures.length).toBeGreaterThanOrEqual(3);
+
+    // The two figures that plot schematic values must both carry the marker, so
+    // neither can be read as live run data. The qualitative before/after
+    // comparison plots nothing and needs none.
+    expect(screen.getAllByText(/^Illustrative$/i).length).toBe(2);
   });
 });

--- a/client/tests/pages/HowItWorks.test.tsx
+++ b/client/tests/pages/HowItWorks.test.tsx
@@ -3,15 +3,28 @@ import { describe, expect, it } from "vitest";
 import HowItWorks from "@/pages/HowItWorks";
 
 describe("HowItWorks", () => {
-  it("shows decision-oriented intake, Pipeline routing, abstention, and the next experiment", () => {
+  it("shows decision-oriented intake, routing owned by the pipeline, abstention, and the next experiment", () => {
     render(<HowItWorks />);
-    expect(screen.getByRole("heading", { name: /How a Task Evaluation Run works/i })).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: /Describe the site-task and decision/i })).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: /Plan the cheapest qualified evidence/i })).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: /Return a decision or abstention/i })).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: /Run the next cheapest experiment/i })).toBeInTheDocument();
-    expect(screen.getByText(/WebApp does not select the backend/i)).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /Request a Task Evaluation Run/i })).toHaveAttribute("href", expect.stringContaining("/contact/robot-team"));
+    expect(
+      screen.getByRole("heading", { level: 1, name: /Six steps, and one of them is allowed to say no/i }),
+    ).toBeInTheDocument();
+
+    expect(screen.getByRole("heading", { name: /Say what you need to decide/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /Route every claim separately/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /Return the answer and its edges/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /Name the next cheapest test/i })).toBeInTheDocument();
+
+    // The customer does not choose the evidence backend, and the split says so.
+    expect(screen.getByText(/Choosing is our job/i)).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /The pipeline owns the verdict/i })).toBeInTheDocument();
+    expect(screen.getByText(/including the decision to abstain/i)).toBeInTheDocument();
+
+    // Unknown states fail closed rather than defaulting to a pass.
+    expect(screen.getAllByText(/Unknown states fail closed/i).length).toBeGreaterThan(0);
+
+    expect(
+      screen.getAllByRole("link", { name: /Request a Task Evaluation Run/i })[0],
+    ).toHaveAttribute("href", expect.stringContaining("/contact/robot-team"));
     expect(screen.queryByText(/Policy Improvement Run/i)).not.toBeInTheDocument();
   });
 });

--- a/client/tests/pages/Pricing.test.tsx
+++ b/client/tests/pages/Pricing.test.tsx
@@ -5,12 +5,27 @@ import Pricing from "@/pages/Pricing";
 describe("Pricing", () => {
   it("renders one scoped quote without fixed campaign prices or guaranteed outcomes", () => {
     render(<Pricing />);
-    expect(screen.getByRole("heading", { name: /Price the decision and evidence it actually requires/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        level: 1,
+        name: /You pay for the decision, not a package/i,
+      }),
+    ).toBeInTheDocument();
     expect(screen.getByText(/^Task Evaluation Run$/i)).toBeInTheDocument();
     expect(screen.getByText(/^Scoped quote$/i)).toBeInTheDocument();
-    expect(screen.getAllByRole("link", { name: /Request a Task Evaluation Run/i }).length).toBeGreaterThan(0);
-    expect(screen.getByText(/does not accept a client-supplied price as authoritative/i)).toBeInTheDocument();
+    expect(
+      screen.getAllByRole("link", { name: /Request a Task Evaluation Run/i }).length,
+    ).toBeGreaterThan(0);
+
+    // Price is set server-side; a client-supplied number is not authoritative.
+    expect(screen.getByText(/Pricing is server-owned/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/does not treat a client-supplied number as authoritative/i),
+    ).toBeInTheDocument();
+    // A quote buys work, not a favourable verdict.
     expect(screen.getByText(/No guaranteed outcome/i)).toBeInTheDocument();
+    expect(screen.getByText(/none of them is a tier/i)).toBeInTheDocument();
+
     expect(screen.queryByText(/\$3,000/)).not.toBeInTheDocument();
     expect(screen.queryByText(/\$5,000/)).not.toBeInTheDocument();
     expect(screen.queryByText(/Policy Shortlist/i)).not.toBeInTheDocument();

--- a/client/tests/pages/Proof.test.tsx
+++ b/client/tests/pages/Proof.test.tsx
@@ -7,22 +7,28 @@ describe("Proof page", () => {
     render(<Proof />);
 
     expect(
-      screen.getByRole("heading", { name: /Proof stays scoped\./i }),
+      screen.getByRole("heading", { level: 1, name: /Proof stays scoped\./i }),
     ).toBeInTheDocument();
+
+    // The three evidence layers stay distinct and ranked.
+    expect(screen.getByRole("heading", { name: /^Raw capture$/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /^Derived evidence$/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /^Physical outcomes$/i })).toBeInTheDocument();
     expect(
-      screen.getByText(/third-party research context, not a Blueprint result, accuracy claim, or deployment claim/i),
+      screen.getByText(/never quietly promoted to fact/i),
     ).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: /^Research signal$/i })).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: /^Request packet$/i })).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: /^Owner proof$/i })).toBeInTheDocument();
-    expect(screen.getByText(/Scopes one site, task, robot, policy set, and threshold/i)).toBeInTheDocument();
+
+    // External research is cited as category context only.
+    expect(
+      screen.getByText(/It is not a Blueprint result, not an accuracy/i),
+    ).toBeInTheDocument();
   });
 
   it("keeps the claim boundary and request CTA visible", () => {
     render(<Proof />);
 
     expect(
-      screen.getByRole("heading", { name: /What we do not claim\./i }),
+      screen.getByRole("heading", { name: /A run is evidence\. It is not permission\./i }),
     ).toBeInTheDocument();
     expect(
       screen.getByText(/Estimates are not physical guarantees, safety approval remains external/i),

--- a/e2e/docs-blog.spec.ts
+++ b/e2e/docs-blog.spec.ts
@@ -17,7 +17,7 @@ test("blog alias redirects to home", async ({ page }) => {
   await expect(page).toHaveURL(/\/$/);
   await expect(
     page.getByRole("heading", {
-      name: /Turn a real site-task into a decision you can defend\./i,
+      name: /Answer it before you send a robot\./i,
     }),
   ).toBeVisible();
 });

--- a/e2e/exact-site-hosted-review.spec.ts
+++ b/e2e/exact-site-hosted-review.spec.ts
@@ -8,7 +8,7 @@ test("exact-site hosted review route redirects to home", async ({ page }) => {
   await expect(page).toHaveURL(/\/$/);
   await expect(
     page.getByRole("heading", {
-      name: /Turn a real site-task into a decision you can defend\./i,
+      name: /Answer it before you send a robot\./i,
     }),
   ).toBeVisible();
 });

--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -5,7 +5,7 @@ test('homepage leads with the single Task Evaluation Run story', async ({ page }
 
   await expect(
     page.getByRole('heading', {
-      name: /Turn a real site-task into a decision you can defend\./i,
+      name: /Answer it before you send a robot\./i,
     }),
   ).toBeVisible();
   const nav = page.getByRole('banner').getByRole('navigation');
@@ -18,12 +18,20 @@ test('homepage leads with the single Task Evaluation Run story', async ({ page }
     page.getByRole('contentinfo').getByRole('link', { name: /^For Site Operators$/i }),
   ).toBeVisible();
   await expect(page.getByRole('link', { name: /^Request a Task Evaluation Run$/i }).first()).toBeVisible();
+
+  // One service, and the lifecycle behind it.
   await expect(
-    page.locator('main').getByText(/One lifecycle from task to maintained evidence/i),
+    page.locator('main').getByText(/One service\. Priced per decision\./i),
   ).toBeVisible();
-  await expect(page.getByText(/^Real site-task$/i)).toBeVisible();
-  await expect(page.getByText(/^Maintained testbed$/i)).toBeVisible();
-  await expect(page.getByText(/^Decision or abstention$/i)).toBeVisible();
-  await expect(page.getByText(/A useful run does not have to name a winner/i)).toBeVisible();
-  await expect(page.getByText(/does not infer a winner from raw scores/i)).toBeVisible();
+  await expect(page.getByText(/^Bring one real task$/i)).toBeVisible();
+  await expect(page.getByText(/^We build the testbed$/i)).toBeVisible();
+  await expect(page.getByText(/^You get an answer with its limits$/i)).toBeVisible();
+
+  // Declining to decide is stated on the page, not implied.
+  await expect(page.getByText(/A run is allowed to tell you it cannot tell you/i)).toBeVisible();
+  await expect(page.getByText(/^Not yet$/i).first()).toBeVisible();
+  await expect(page.getByText(/is not reported as one/i)).toBeVisible();
+
+  // Figures carrying schematic values are marked as illustrative.
+  await expect(page.getByText(/^Illustrative$/i).first()).toBeVisible();
 });

--- a/e2e/pricing.spec.ts
+++ b/e2e/pricing.spec.ts
@@ -7,14 +7,14 @@ test("pricing page presents one scoped Task Evaluation Run", async ({
 
   await expect(
     page.getByRole("heading", {
-      name: "Price the decision and evidence it actually requires.",
+      name: "You pay for the decision, not a package.",
     }),
   ).toBeVisible();
   await expect(
     page.getByRole("heading", { name: "Scoped quote", exact: true }),
   ).toBeVisible();
   await expect(
-    page.getByRole("heading", { name: "What the scope covers", exact: true }),
+    page.getByRole("heading", { name: "One scoped run, and everything needed to read it.", exact: true }),
   ).toBeVisible();
   await expect(page.getByText(/\$3,000/)).toHaveCount(0);
   await expect(page.getByText(/\$5,000/)).toHaveCount(0);

--- a/e2e/redirects.spec.ts
+++ b/e2e/redirects.spec.ts
@@ -61,7 +61,7 @@ test('FAQ remains a real public destination', async ({ page }) => {
 
   await expect(page).toHaveURL(/\/faq$/);
   await expect(
-    page.getByRole('heading', { name: /One product, explicit evidence boundaries\./i }),
+    page.getByRole('heading', { name: /One service, and the limits printed on it\./i }),
   ).toBeVisible();
 });
 

--- a/e2e/robot-team-eval.spec.ts
+++ b/e2e/robot-team-eval.spec.ts
@@ -4,7 +4,7 @@ test("legacy robot-team evaluation URL reaches the current product", async ({ pa
   await page.goto("/robot-team/eval");
   await expect(page).toHaveURL(/\/for-robot-teams/);
   await expect(
-    page.getByRole("heading", { name: "Decide what deserves scarce robot time." }),
+    page.getByRole("heading", { name: "Spend field time on the candidate that earned it." }),
   ).toBeVisible();
   await expect(
     page.getByRole("link", { name: /Request a Task Evaluation Run/i }).first(),
@@ -13,12 +13,16 @@ test("legacy robot-team evaluation URL reaches the current product", async ({ pa
 
 test("robot-team and site-operator pages describe one service and intake", async ({ page }) => {
   await page.goto("/for-robot-teams");
-  await expect(page.getByText(/explicit abstention/i).first()).toBeVisible();
+  // Declining to decide is still presented as an outcome, not omitted.
+  await expect(page.getByText(/A ranking is not the promise/i).first()).toBeVisible();
+  await expect(page.getByText(/^Not yet$/i).first()).toBeVisible();
   await expect(page.getByText(/Policy Shortlist/i)).toHaveCount(0);
 
   await page.goto("/for-site-operators");
   await expect(
-    page.getByRole("heading", { name: "Turn one real task into a decision you can inspect." }),
+    page.getByRole("heading", {
+      name: "Find out what a robot could do here, before anyone shows up.",
+    }),
   ).toBeVisible();
   await expect(
     page.locator("main").getByRole("link", { name: /Request a Task Evaluation Run/i }).first(),

--- a/scripts/graphify/run-webapp-architecture-pilot.sh
+++ b/scripts/graphify/run-webapp-architecture-pilot.sh
@@ -207,7 +207,16 @@ fi
 
 echo "[graphify pilot] running staged AST pilot"
 SCAN_DIR="$(mktemp -d "${TMPDIR:-/tmp}/blueprint-webapp-graphify-corpus.XXXXXX")"
-rsync -a --delete "$CORPUS_DIR/" "$SCAN_DIR/"
+# The scan dir is a fresh mktemp -d, so a plain recursive copy is equivalent to
+# `rsync -a --delete` here. rsync stays the fast path where it exists; some
+# minimal container images (including CI/agent sandboxes) do not ship it.
+if command -v rsync >/dev/null 2>&1; then
+  rsync -a --delete "$CORPUS_DIR/" "$SCAN_DIR/"
+else
+  rm -rf "$SCAN_DIR"
+  mkdir -p "$SCAN_DIR"
+  cp -a "$CORPUS_DIR/." "$SCAN_DIR/"
+fi
 
 # graphify walks up to the nearest VCS root and honors ancestor .graphifyignore
 # files. The canonical staged corpus lives under derived/graphify/, which the

--- a/scripts/prerender.tsx
+++ b/scripts/prerender.tsx
@@ -26,6 +26,7 @@ import Governance from "../client/src/pages/Governance";
 import FAQ from "../client/src/pages/FAQ";
 import ForSiteOperators from "../client/src/pages/ForSiteOperators";
 import ForRobotTeams from "../client/src/pages/ForRobotTeams";
+import Proof from "../client/src/pages/Proof";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -219,18 +220,6 @@ const PrerenderForgotPassword = () => (
   />
 );
 
-const PrerenderProofSummary = () => (
-  <MinimalStaticPage
-    title="Proof | Blueprint"
-    description="Blueprint keeps Task Evaluation Run claims scoped to the site, task, robot, and evidence behind each run."
-    heading="Proof stays scoped"
-    body="A Task Evaluation Run may return a bounded decision, partial decision, or abstention inside its evidence envelope, never a safety certification. Physical claims still require authoritative physical evidence."
-    primaryHref="/contact/robot-team?persona=robot-team&buyerType=robot_team&interest=task-evaluation-run&path=task-evaluation-run&requestedOutputs=Task%20Evaluation%20Run"
-    primaryLabel="Request a Task Evaluation Run"
-    canonical="/proof"
-  />
-);
-
 const PrerenderCaptureLaunchAccessSummary = () => (
   <MinimalStaticPage
     title="Capture Launch Access | Blueprint"
@@ -265,7 +254,10 @@ const staticRoutes: StaticRoute[] = [
   // them (WSPEC context: the summary shell made /pricing look price-free).
   { path: "/pricing", component: Pricing },
   { path: "/sites", component: Sites },
-  { path: "/proof", component: PrerenderProofSummary, shell: "bare" },
+  // /proof states the claim boundaries the rest of the site depends on, so
+  // crawlers and no-JS agents must see the real page rather than a summary that
+  // paraphrases them.
+  { path: "/proof", component: Proof },
   { path: "/faq", component: FAQ },
   // /for-robot-teams is the canonical citation target advertised in the
   // sitemap and llms.txt, so crawlers must see the real page, not a summary

--- a/scripts/qa/brand-polish.test.ts
+++ b/scripts/qa/brand-polish.test.ts
@@ -55,7 +55,7 @@ describe("brand polish QA harness contract", () => {
     const faqRoute = harness.publicQaRoutes.find((route: { path: string }) => route.path === "/faq");
     expect(faqRoute).toMatchObject({
       canonicalPath: "/faq",
-      expectedHeading: "One product, explicit evidence boundaries.",
+      expectedHeading: "One service, and the limits printed on it.",
     });
 
     const notionChecklist = harness.buildNotionLayoutChecklistMarkdown({

--- a/scripts/qa/brand-polish.ts
+++ b/scripts/qa/brand-polish.ts
@@ -152,7 +152,7 @@ export const publicQaRoutes: PublicQaRoute[] = [
     label: "Home",
     path: "/",
     canonicalPath: "/",
-    expectedHeading: "Turn a real site-task into a decision you can defend.",
+    expectedHeading: "Answer it before you send a robot.",
     requiredCtas: [
       { label: "Request a Task Evaluation Run", hrefStartsWith: "/contact" },
       { label: "How it works", hrefStartsWith: "/how-it-works" },
@@ -162,7 +162,7 @@ export const publicQaRoutes: PublicQaRoute[] = [
     label: "Product (legacy, redirects to Home)",
     path: "/product",
     canonicalPath: "/",
-    expectedHeading: "Turn a real site-task into a decision you can defend.",
+    expectedHeading: "Answer it before you send a robot.",
     requiredCtas: [
       { label: "Request a Task Evaluation Run", hrefStartsWith: "/contact" },
       { label: "How it works", hrefStartsWith: "/how-it-works" },
@@ -192,7 +192,7 @@ export const publicQaRoutes: PublicQaRoute[] = [
     label: "Pricing",
     path: "/pricing",
     canonicalPath: "/pricing",
-    expectedHeading: "Price the decision and evidence it actually requires.",
+    expectedHeading: "You pay for the decision, not a package.",
     requiredCtas: [
       { label: "Request a Task Evaluation Run", hrefStartsWith: "/contact" },
     ],
@@ -240,7 +240,7 @@ export const publicQaRoutes: PublicQaRoute[] = [
     label: "FAQ",
     path: "/faq",
     canonicalPath: "/faq",
-    expectedHeading: "One product, explicit evidence boundaries.",
+    expectedHeading: "One service, and the limits printed on it.",
     requiredCtas: [],
   },
   {
@@ -257,7 +257,7 @@ export const publicQaRoutes: PublicQaRoute[] = [
     label: "Updates (legacy, redirects to Home)",
     path: "/updates",
     canonicalPath: "/",
-    expectedHeading: "Turn a real site-task into a decision you can defend.",
+    expectedHeading: "Answer it before you send a robot.",
     requiredCtas: [
       { label: "Request a Task Evaluation Run", hrefStartsWith: "/contact" },
       { label: "How it works", hrefStartsWith: "/how-it-works" },


### PR DESCRIPTION
Keeps the single-service story from #426 and replaces **how it is told**: new buyer-facing copy, a new page structure, motion, and figures that explain the mechanism rather than describing it in prose. Large imagery is kept and made larger.

Pages redesigned: `/`, `/for-robot-teams`, `/for-site-operators`, `/how-it-works`, `/pricing`, `/faq`, `/proof`.

## Copy

The pages led with internal vocabulary — "bounded decision", "explicit abstention", "validation envelope", "claim ceiling", "false-safe consequence", "least expensive currently qualified evidence". Same product boundaries, said in plain language.

| Before | After |
| --- | --- |
| Turn a real site-task into a decision you can defend. | Answer it before you send a robot. |
| Price the decision and evidence it actually requires. | You pay for the decision, not a package. |
| One product, explicit evidence boundaries. | One service, and the limits printed on it. |

Every constraint from the pivot still holds, and the guard assertions covering them are kept and extended: withdrawn product names stay absent, no fixed prices, the customer never chooses a backend, and abstention remains a first-class named outcome ("Not yet").

New copy lives in `client/src/data/publicSiteCopy.ts`. `robotPolicyEvaluationClaims.ts` is untouched, so it stays the canonical machine-facing phrasing for SEO, structured data, and agent context — the pages that consume it (About, Vision, Governance, Sites, Capture, Contact) are unaffected.

## Design

The site was built from essentially one device — a hairline grid of equal white tiles — which gave every section the same rhythm. Added:

- alternating ink/paper/canvas bands with numbered section headers at display size
- asymmetric editorial splits instead of uniform column grids
- full-bleed image bands between sections
- **bigger** media: the hero image runs to the viewport edge at up to 80vh
- `/proof` moved off default slate/blue Tailwind colours onto the brand palette

New layout primitives in `client/src/components/site/publicSections.tsx`.

## Motion

`client/src/components/site/motion.tsx` — scroll reveals, staggered grids, parallax on large media, a scroll-tracked rail on the stepped walkthrough, and SVG path drawing.

Two invariants, because these pages are prerendered to static HTML:

1. **Reduced motion wins outright** — every helper stays in its static branch.
2. **No helper ever ships hidden content.** Each renders plainly and fully visible on the server and on the first client paint, then arms its animation after mount *only* for elements still outside the viewport. Above-the-fold content is never animated from `opacity: 0`, so there is no hydration flash.

Verified: no prerendered page contains an opacity-0 text node.

## Figures

`client/src/components/site/figures.tsx` — a lifecycle rail, an evidence-cost ladder, a per-claim threshold chart, the outcome spectrum, and a before/after comparison.

Colour follows the data's job:

- **Magnitude** uses the emphasis form — action blue `#2563a6` against a de-emphasis warm gray `#817e72`. Validated for CVD separation (worst adjacent ΔE 12.9 tritan) and ≥3:1 contrast on both surfaces.
- **Claim outcomes** use the reserved status scale, with an icon *and* a text label on every mark, because the status hues are not separable under protanopia (green↔amber ΔE 8.3).
- Brass is brand chrome and is deliberately **not** used as a data colour — against the warm neutral ramp it lands at ΔE 8.1 normal-vision.

Charts carry an axis with ticks, a legend, a toggleable values table, per-row screen-reader text, and selective rather than per-point labels.

### Honesty of the figures

No figure reads live run data. Every figure that renders a value prints a visible **"Illustrative"** marker, asserted in unit tests and in the prerendered HTML, so the public site cannot imply an operational state it cannot prove.

The evidence ladder orders methods by **cost only, never authority**. Each row carries a required `basis` tag (Real capture / Real world / Computed from capture / Derived), and the figure states outright that real capture is the source of truth and a costlier derived method never outranks it — simulated, generated, and model-based evidence is support that must be qualified per claim, and is not ground truth at any price. An earlier draft ordered by cost while claiming later rungs "can support more," which turned the cost axis into a proof hierarchy and contradicted capture-first doctrine; that framing was removed.

The one figure whose underlying data is qualitative (when information arrives, with/without a run) is rendered as a two-column comparison rather than a chart. An earlier draft plotted it as a dumbbell; that invented numeric positions for statements that have no measured quantity and detached each label from the mark it described, so the axis was removed rather than kept for looks.

## Also

- `/proof` now prerenders the real page instead of a hand-written summary that paraphrased the claim boundaries — matching the rationale already applied to `/pricing` and `/for-robot-teams`.
- `llms.txt` public-page descriptions re-synced to what the pages now say. Doctrine sections unchanged.
- Fixed a real bug in `DrawIn`: arming swapped the plain `<path>` for a `motion.path` without the ref, so React cleared the ref the external `useInView` watched and the path stayed at `opacity: 0` — every lifecycle rail below the fold silently lost its accent line. Viewport detection is now framer's own via `whileInView`.
- `scripts/graphify/run-webapp-architecture-pilot.sh` falls back to `cp` when `rsync` is absent (minimal container images do not ship it).

## Verification

- `npm run check` — clean
- `npm run build` — clean, all routes prerender
- `npx vitest run` — **340 files, 1726 tests, all passing**
- **Playwright e2e — 28/28 passing**, run locally against a real server (including the brand-polish route sweep). This caught two stale copy assertions in `robot-team-eval.spec.ts` that CI also flagged, now fixed.
- `scripts/claims/cross-source-claims-guard.ts` — no operational proof drift findings
- Rendered every page at 1440×1000 and 390×844, scrolled to fire all reveals, and inspected the screenshots: **no horizontal overflow at either width**, no label collisions
- Copy assertions updated in unit tests, e2e specs, and the brand-polish QA route table

All five CI checks (check, test, e2e, build, rules-emulator) are green on `ffb0a87`.