### PR TITLE
Gate shared doctrine blocks on a committed cross-repo lock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,9 @@ jobs:
       - name: Claims guard (public-claims truthfulness gate)
         run: npm run claims:guard
 
+      - name: Verify shared doctrine blocks match the cross-repo lock
+        run: npm run doctrine:verify
+
       - name: Upload claims-guard report
         if: ${{ always() && hashFiles('output/claims-guard/**') != '' }}
         uses: actions/upload-artifact@v4

--- a/PLATFORM_CONTEXT.md
+++ b/PLATFORM_CONTEXT.md
@@ -5,26 +5,109 @@
 <!-- SHARED_PLATFORM_CONTEXT_START -->
 ## Shared Platform Doctrine
 
-### System framing
+### System Framing
 
-- `BlueprintCapture` collects immutable, provenance-linked real-site evidence.
-- `BlueprintCapturePipeline` owns the versioned Site-Task Testbed manifest, Decision/Evidence Request, Evidence Plan, Evidence Method Profile, normalized Evidence Result, Decision Envelope, and Physical Outcome Join. It owns method qualification, routing, aggregation, and scientific verdicts.
-- `Blueprint-WebApp` owns authenticated intake, request validation, idempotency, entitlement and authorization, durable queue/outbox state, status projection, artifact access, redacted presentation, and operator workflows.
-- `BlueprintValidation` remains optional downstream infrastructure.
+- `BlueprintCapture` is the capture client and supply-side evidence collection
+  tool. It collects immutable, provenance-linked real-site evidence.
+- `BlueprintCapturePipeline` composes capture bundles, cards, evaluators, and
+  reset artifacts into maintained Site-Task Testbeds, then produces claim-level
+  Task Evaluation Run plans, evidence, decisions, or explicit abstentions. It
+  owns the versioned Site-Task Testbed manifest, Decision/Evidence Request,
+  Evidence Plan, Evidence Method Profile, normalized Evidence Result, Decision
+  Envelope, and Physical Outcome Join, plus method qualification, routing,
+  aggregation, and scientific verdicts.
+- `Blueprint-WebApp` is the buyer, licensing, ops, and hosted-access surface for
+  Task Evaluation Runs. It owns authenticated intake, request validation,
+  idempotency, entitlement and authorization, durable queue/outbox state, status
+  projection, artifact access, redacted presentation, and operator workflows. It
+  collects constraints and displays Pipeline-owned results; it does not select
+  providers or recompute scientific verdicts.
+- `BlueprintValidation` remains optional downstream infrastructure for
+  benchmarking, runtime checks, robot evaluation support, and specialized
+  validation after the primary package or run is scoped.
 
-Blueprint is capture-first and real-site-task first. Raw capture, timestamps, poses, device metadata, rights/privacy records, and provenance remain authoritative. Derived geometry, simulation, generated media, provider output, and runtime artifacts do not silently upgrade the claim.
+This platform is capture-first and real-site decision-evaluation first. Raw
+capture, timestamps, poses, device metadata, rights/privacy records, and
+provenance remain authoritative. World models, site-world routes, simulation
+outputs, generated media, editing assets, legacy data-package exports, and
+model-derived artifacts are evidence or support artifacts inside a run. They are
+not additional public offers, and they do not silently upgrade the claim.
 
-### One customer-facing product
+### One Customer-Facing Product
 
 Blueprint sells one product: **Task Evaluation Run**.
 
-The maintained Site-Task Testbed is the reusable substrate behind runs. Robot teams and site operators are personas using the same service, decision request, workflow, result model, pricing concept, and call to action. Post-training is only a permitted use of qualifying evidence inside a run; it is not a SKU, add-on, navigation item, checkout flow, or delivery promise.
+The maintained Site-Task Testbed is the reusable substrate behind runs. Robot
+teams and site operators are personas using the same service, decision request,
+workflow, result model, pricing concept, and call to action. Post-training is
+only a permitted use of qualifying evidence inside a run; it is not a SKU,
+add-on, navigation item, checkout flow, or delivery promise.
 
-The normal customer describes the site-task, decision, candidates when applicable, claims, thresholds, false-safe consequence, acceptable risk, budget, deadline, available evidence, rights/privacy restrictions, and physical-testing constraints. The WebApp does not ask ordinary users to choose a simulator, world model, or provider.
+The normal customer describes the site-task, decision, candidates when
+applicable, claims, thresholds, false-safe consequence, acceptable risk, budget,
+deadline, available evidence, rights/privacy restrictions, and physical-testing
+constraints. The WebApp does not ask ordinary users to choose a simulator, world
+model, or provider.
 
-### Decision and evidence router
+### Product Center of Gravity
 
-Pipeline routes every decision-relevant claim to the least expensive currently qualified combination of fixture data, geometry, real observations, traditional simulation, world models, provider tools, and physical evidence. It escalates only when stronger evidence is required.
+The center of gravity is:
+
+- broad real-world capture coverage
+- strong capture quality and provenance
+- Task Evaluation Runs for robot teams
+- maintained, immutable-version Site-Task Testbeds reused across successive runs
+- claim-level routing to the cheapest currently qualified evidence method or
+  combination, with explicit escalation and abstention
+- rights-cleared evidence-use determinations inside a run; post-training use is
+  allowed only after rights, provenance, action-alignment, quality, and leakage
+  gates
+- hosted access for request-scoped review
+- rights, privacy, and commercialization controls
+- buyer-facing product surfaces that make real sites easy to browse, buy, run,
+  and manage
+
+The center of gravity is not:
+
+- generic marketplace browsing as the main story
+- qualification/readiness as the main thing Blueprint sells
+- world models are not the primary public product, and Blueprint is not a generic
+  world-model marketplace
+- one-off model demos disconnected from real capture
+- a single permanent world-model backend
+
+### Market Structure
+
+The core business engine is two-sided:
+
+- **Capturers** supply real-site evidence packages.
+- **Robot teams** buy Task Evaluation Runs.
+
+`Site operators` remain important, but they are an optional third lane at
+capture time, covering:
+
+- access control
+- rights / consent / privacy boundaries
+- commercialization and revenue sharing
+
+The platform must support lawful capture and packaging even when a site has not
+already gone through a pre-negotiated intake flow. Site-operator involvement is
+a supported workflow branch, not a universal prerequisite for all capture.
+
+Optional at capture time is not the same as unimportant at adoption time. The
+long-horizon direction (see `VISION.md`, rung 2) is that site operators become
+the demand-side channel that routes deployment decisions through Blueprint
+evaluation — requiring a Task Evaluation Run before a robot reaches their floor.
+That is a strategic adoption bet about where the standard gets enforced, not a
+current capture prerequisite; the two statements describe different lifecycle
+stages and do not conflict.
+
+### Decision And Evidence Router
+
+Pipeline routes every decision-relevant claim to the least expensive currently
+qualified combination of fixture data, geometry, real observations, traditional
+simulation, world models, provider tools, and physical evidence. It escalates
+only when stronger evidence is required.
 
 A valid run outcome may be:
 
@@ -36,32 +119,106 @@ A valid run outcome may be:
 - blocked or failed;
 - a request for the next evidence needed.
 
-A run does not guarantee ranking, shortlist, winner, deployment, pilot readiness, physical success, or safety approval. Unknown future states fail closed. An abstained result never implies a winner from raw scores.
+A run does not guarantee ranking, shortlist, winner, deployment, pilot
+readiness, physical success, or safety approval. Unknown future states fail
+closed. An abstained result never implies a winner from raw scores.
 
-### Result contract
+### Truth Hierarchy
 
-Buyer-facing results expose the requested decision, per-claim outcomes, selected methods and selection reasons, measurements, validation envelope, unsupported conditions, coverage, uncertainty, disagreements and correlated-evidence warnings, claim ceiling, next cheapest experiment, physical-evidence requirements, cost/time when available, exact artifact versions and digests, and permitted evidence uses.
+- raw capture, timestamps, poses, device metadata, and provenance are
+  authoritative
+- rights / privacy / consent metadata are authoritative
+- Site Cards, Task Cards, Scenario Cards, Eval Cards, package manifests,
+  generated/model-derived support assets, and hosted-session artifacts are
+  downstream artifacts with explicit proof boundaries
+- Task Evaluation Run is the one primary sellable downstream product
+- maintained Site-Task Testbeds are reusable substrates, not a second product
+- post-training is a permitted use of qualifying run evidence, never proof that
+  training occurred or a policy improved
+- qualification / readiness / review outputs are optional trust layers that can
+  guide buying, commercialization, and deployment decisions
+- downstream outputs must not rewrite capture truth or provenance truth
 
-An evidence export does not prove training happened or a policy improved. Physical outcome ingestion requires authoritative evidence and exact join identifiers; a user note alone cannot recalibrate a method.
+### Result Contract
 
-### Product stack
+Buyer-facing results expose the requested decision, per-claim outcomes, selected
+methods and selection reasons, measurements, validation envelope, unsupported
+conditions, coverage, uncertainty, disagreements and correlated-evidence
+warnings, claim ceiling, next cheapest experiment, physical-evidence
+requirements, cost/time when available, exact artifact versions and digests, and
+permitted evidence uses.
 
-1. supply and truth layer: real-site capture, rights, privacy, and provenance;
-2. reusable substrate: maintained Site-Task Testbeds;
-3. single buyer product: Task Evaluation Runs;
-4. evidence support: geometry, real observations, simulation, world models, provider tools, and physical outcomes;
-5. access support: hosted review, licensing, entitlements, and operator workflows.
+An evidence export does not prove training happened or a policy improved.
+Physical outcome ingestion requires authoritative evidence and exact join
+identifiers; a user note alone cannot recalibrate a method.
 
-### Commercial and compatibility rules
+### Product Stack
 
-- One run is scoped and quoted according to decision, evidence, candidates, scenarios, compute, deadline, rights, and physical requirements.
+1. supply and truth layer: real-site capture, rights, privacy, and provenance
+2. reusable substrate: maintained Site-Task Testbeds
+3. single buyer product: Task Evaluation Runs
+4. evidence methods: geometry, captured observations, traditional simulation,
+   learned/world-model evaluation, provider tools, physical evidence, and
+   bounded owner inputs
+5. access and support layer: hosted review, licensing, entitlements, operator
+   workflows, evidence export/use, legacy compatibility, generated/model-derived
+   data, editing, and augmentation
+
+### Commercial Wedge Overlay
+
+The current PMF wedge is the Task Evaluation Run: a decision request bound to an
+exact maintained testbed. The router decomposes the decision into claims,
+selects only qualified methods, and returns a partial or complete decision or an
+explicit abstention with the next cheapest experiment. A run may emit
+rights-cleared evidence for later evaluation or post-training use, but the
+evidence export is not another product and does not imply training or
+improvement.
+
+Wedge claims stay inside the proof boundary. The current comparative
+policy-ranking scientific verdict is `thesis_not_supported`; physical success,
+deployment readiness, and safety claims require separately accepted physical
+evidence. Generated frames are support, never real-world proof.
+
+### Commercial And Compatibility Rules
+
+- One run is scoped and quoted according to decision, evidence, candidates,
+  scenarios, compute, deadline, rights, and physical requirements.
 - The server owns authoritative pricing. The client cannot supply it.
-- No new subscription, standalone evidence package, improvement add-on, or vendor submission fee.
-- Historical data, URLs, transactions, and entitlements remain readable through explicit compatibility paths.
+- No new subscription, standalone evidence package, improvement add-on, or
+  vendor submission fee.
+- Historical data, URLs, transactions, and entitlements remain readable through
+  explicit compatibility paths.
 - Legacy paid or customer-visible intent is never silently reinterpreted.
-- Live provider, physical robot, deployment, payment, rights, calibration, and customer claims require proof from the system that owns them.
+- Live provider, physical robot, deployment, payment, rights, calibration, and
+  customer claims require proof from the system that owns them.
 
-### Practical rule for agents
+### Default Lifecycle
 
-Optimize for stronger capture truth, stable versioned testbeds, secure decision intake, Pipeline-authoritative evidence routing, honest decisions or abstentions, explicit claim ceilings, and maintained learning from authoritative physical outcomes. Do not move scientific routing or scoring into WebApp.
+1. A capture is sourced proactively or through a buyer / site / ops request.
+2. `BlueprintCapture` records and uploads a truthful evidence bundle.
+3. `BlueprintCapturePipeline` composes a versioned Site-Task Testbed and routes a
+   Task Evaluation Run at claim level through qualified evidence adapters.
+4. `Blueprint-WebApp` exposes the request, plan status, decision envelope,
+   abstentions, and proof-bound supporting artifacts.
+5. Optional world-model, simulation, deeper evaluation, validation, or managed
+   support follows only when commercially useful and proof-bounded.
+
+### Practical Rule For Agents
+
+When changing any Blueprint repo, optimize for:
+
+1. stronger real-site capture supply and capture truth
+2. better Task Evaluation Runs, maintained testbeds, routing, abstention, and
+   learning from authoritative physical outcomes
+3. stable rights / privacy / provenance contracts and stable versioned testbeds
+4. secure decision intake, durable state, and buyer and ops surfaces that make
+   those outputs easy to sell and use
+5. optional trust, readiness, world-model, simulation, generated-data, and
+   validation layers that support the product without becoming the product story
+
+Do not assume that every capture must begin with formal site qualification.
+Do not treat qualification/readiness as the universal center of the company.
+Do not overstate world-model quality beyond what capture, privacy, and runtime
+artifacts support.
+Do not move scientific routing or scoring into WebApp.
 <!-- SHARED_PLATFORM_CONTEXT_END -->

--- a/VISION.md
+++ b/VISION.md
@@ -14,7 +14,6 @@ bets**, not current capability. Every forward claim carries an explicit proof bo
 > Current-product correction (2026-07-29): the sole customer-facing product is one scoped Task Evaluation Run. It may return a bounded positive or negative decision, candidate elimination, a partial decision, explicit abstention, or the next evidence needed. Ranking is conditional, not guaranteed. Post-training is only a permitted use of qualifying evidence inside a run, never a separate SKU or proof that training occurred. Any older rung language below that calls ranking or policy-improvement/data packages "shipping today" is retained long-horizon strategy text and is superseded for current product and commercial behavior by `PLATFORM_CONTEXT.md`.
 
 <!-- SHARED_VISION_START -->
-
 ## The one-sentence version
 
 Blueprint starts as the neutral way to know **which robot policy will actually work at a specific
@@ -61,23 +60,27 @@ Three curves make this the right decade to build a measurement-and-data layer un
 
 ## The ladder
 
-Each rung is a product we can sell, a moat we deepen, and a launchpad for the next. We do not skip
-rungs; we earn each one with the data the previous rung produces.
+Each rung is a capability and moat built through the Task Evaluation Run product,
+plus a launchpad for the next. We do not create a new SKU for each rung, and we
+earn each claim with evidence from the previous rung.
 
 ---
 
 ### Rung 1 — The wedge: claim-bounded Task Evaluation Runs
 
-**What it is (shipping today).** Blueprint's **Task Evaluation Run** turns a real site-task into a
-maintained testbed and routes each decision-relevant claim to the least expensive currently
-qualified evidence. It returns a bounded positive or negative decision, candidate elimination,
-partial decision, explicit abstention, or the next evidence needed. Candidate ordering appears only
-when the evidence supports it; it is not guaranteed. This is the current PMF wedge (see the
+**What it is (shipping today).** Blueprint's one product is the **Task Evaluation
+Run**: bind a decision to an exact maintained Site-Task Testbed, decompose it into
+claims, route each claim to qualified evidence, and return a decision, a partial
+decision, or an explicit abstention with the next cheapest experiment. It returns
+a bounded positive or negative decision, candidate elimination, partial decision,
+explicit abstention, or the next evidence needed. Comparative policy ranking is
+one possible claim, not the product definition, and candidate ordering appears
+only when the evidence supports it. This is the current PMF wedge (see the
 [Commercial Wedge Overlay](PLATFORM_CONTEXT.md)).
 
-**Why it is credible enough to qualify methods, not to assume verdicts — two research signals.**
-Evaluating a policy inside a *generated world* may support some comparison claims. As of June 2026,
-two external results motivate method qualification without becoming Blueprint run evidence:
+**Research direction, not Blueprint proof.** Published generated-world results
+motivate a learned-evaluator evidence method, but do not qualify it for a Blueprint
+claim or domain. As of June 2026 two results make that research direction concrete:
 
 - **SC3-Eval** (NVIDIA · Physical Intelligence · Toronto/Vector · Stanford · UC Berkeley,
   arXiv:2606.18610) adapts a pre-trained video foundation model into a *closed-loop* policy evaluator
@@ -86,24 +89,39 @@ two external results motivate method qualification without becoming Blueprint ru
   **seven VLA policies** (381 hours of real table-bussing data), a **0.929 headline correlation**,
   and — honestly — a drop to **r = 0.870 out-of-distribution.** This is the same self-consistency
   family Blueprint's own WAM evaluator prepares (forward/inverse episode-consistency scoring, behind
-  a replaceable external-scorer boundary — see [`AGENTS.md`](AGENTS.md)).
+  a replaceable external-scorer boundary — see [`AGENTS.md`](AGENTS.md)). The `0.929` value is
+  SC3-Eval's published overall Pearson result across those seven policies, not a Blueprint
+  measurement; Blueprint has not measured an equivalent correlation.
 - **OSCAR** (Peking University · NVIDIA/Michigan, arXiv:2606.04463) — an **omni-embodiment,
   action-conditioned world model** (a fine-tune of Cosmos-Predict2.5-2B on a single GH200, using 2D
   kinematic-skeleton conditioning for cross-embodiment) — reports **Pearson r = 0.852 /
   Spearman ρ = 0.750** against the real **RoboArena** ranking across 7 generalist policies (65
   sessions, 1,365 pairwise comparisons), and argues explicitly for "a future where robot policies can
-  be **purely evaluated in virtual generated worlds**." OSCAR sits behind Blueprint's swappable
+  be **purely evaluated in virtual generated worlds**." Two honesty caveats travel with that quote:
+  OSCAR's published validation is **open-loop only** — no chained closed-loop durability result was
+  published — and exposure-bias collapse in long chained generation is a named open problem in the
+  2026 literature, so the "purely virtual evaluation" future is the paper's argued direction, not its
+  demonstrated result. OSCAR sits behind Blueprint's swappable
   world-model adapter (see [`WORLD_MODEL_STRATEGY_CONTEXT.md`](WORLD_MODEL_STRATEGY_CONTEXT.md)).
 
 Earlier work corroborates the direction (SIMPLER r ≈ 0.924; AutoEval r ≈ 0.942 while cutting human
-supervision >99%). **The 0.929 figure is SC3-Eval's external headline correlation, not a Blueprint
-result.** The in-distribution 0.98 becomes ~0.85–0.87 cross-embodiment / OOD, which is precisely why
+supervision >99%). **SC3-Eval reports an overall closed-loop Pearson correlation of `0.929` across
+seven policies under its published protocol. This is not a Blueprint measurement; Blueprint has
+not measured equivalent rank fidelity.** Ranking is the honest, defensible unit; the honest caveat
+is that SC3-Eval's in-distribution 0.98 becomes ~0.85–0.87 cross-embodiment / OOD — and on the OOD
+online split its Pearson edge over its own Cosmos-Predict2.5 baseline is a statistical wash
+(0.870 vs 0.871; it keeps only an MMRV edge, 0.171 vs 0.195). The consistency recipe's advantage is
+largely an in-distribution result today — precisely the gap rung 3b has to close, and precisely why
 Pipeline must qualify each method for the requested claim and may abstain.
 
-**Proof boundary (non-negotiable).** We sell an inspectable decision or abstention with per-claim
-outcomes, validation envelope, uncertainty, disagreement, claim ceiling, next experiment, and exact
-provenance. We do **not** sell a guaranteed ranking or field outcome, an off-scope validation, or a
-claim that we ran the buyer's real robot unless request-scoped owner-system proof exists. Generated
+**Proof boundary (non-negotiable).** Blueprint's current preregistered
+policy-ranking verdict is `thesis_not_supported`. A Task Evaluation Run may still
+resolve geometry, perception, collision, or other qualified claims and abstain on
+ranking. We sell an inspectable decision or abstention with per-claim outcomes,
+validation envelope, uncertainty, disagreement, claim ceiling, next experiment,
+and exact provenance. We do **not** sell a guaranteed ranking or field outcome, an
+off-scope validation, deployment readiness, safety certification, or a claim that
+we ran the buyer's robot without separately accepted physical proof. Generated
 frames are review support, never real-world proof.
 
 ---
@@ -145,10 +163,12 @@ conflict-of-interest firewall** — the same discipline that keeps a ratings age
 
 Two capabilities grow out of the data rungs 1–2 produce. They are **partly shipping, partly bets.**
 
-**3a — Post-training data generation and policy improvement (permitted evidence use today; future
-capability beyond that).** Post-training is not a separate current product. A run may mark exact
-qualifying evidence eligible for post-training use, which does not prove that training occurred or
-that a policy improved. Robotics is data-starved in a way language never was: usable
+**3a — Evidence reuse and optional policy experiments (inside Task Evaluation
+Runs).** Post-training is not a separate current product. Rights-cleared run
+evidence may become eligible for evaluation or
+post-training use after provenance, robot-action alignment, quality, and leakage
+gates; eligibility does not prove that training occurred or that a policy
+improved. Policy improvement may be an internal candidate-generation experiment. Robotics is data-starved in a way language never was: usable
 open-source real-world interaction data is **<5,000 hours** vs. trillions of text tokens; Bessemer
 calls robot data **"~a billion times smaller than internet text"** and projects **>$3B** of industry
 data spend in two years. High-quality teleoperation still costs **~$118–340/hour**. Two things follow:
@@ -157,7 +177,7 @@ and generated **780k trajectories (~6,500 human-hours-equivalent) in 11 hours** 
 physics sim, it doesn't yet replace real data; and (ii) — the load-bearing fact for us — **policy
 generalization scales with the *diversity of real environments*, not raw demo count** ("Data Scaling
 Laws in Imitation Learning," 2024). **That is exactly what proprietary multi-site capture is.** Every
-site we capture makes our data packages more valuable; Scale AI's own framing is that strict data
+site we capture makes qualifying evidence more valuable; Scale AI's own framing is that strict data
 lineage is **"a moat that grows with every deployment."**
 
 **3b — Calibrated real-world prediction ("95% on our eval ≈ 95% in real life").** This is the
@@ -256,15 +276,16 @@ These are inherited from platform doctrine and do not bend as we climb:
 > → more proprietary real-world outcome data → better prediction *and* better data generation → better
 > per-site policies → more deployments we can credibly serve → funds and justifies more capture.
 
-Rungs 1–2 are the **buyer-facing evidence foundation.** Every deployment decision we support can
-produce a labeled outcome that strengthens later evaluation and policy-improvement work, without
-turning an unverified prediction into ground truth.
+Rungs 1–2 are a **data-acquisition strategy disguised as a product**, and the buyer-facing evidence
+foundation everything above rests on. Every deployment decision we support can produce a labeled
+outcome that strengthens later evaluation and policy-improvement work — an outcome no competitor
+without our capture footprint can buy — without turning an unverified prediction into ground truth.
 
 ## The bets we are explicitly making (and what would have to become true)
 
 | Bet | Current evidence | What must become true |
 |-----|------------------|------------------------|
-| World models get good enough to predict physical outcomes | **SC3-Eval r=0.984 in-dist / OSCAR r=0.852 RoboArena** (generated-world eval); Cosmos/Genie/Marble usable for augmentation *today* | Close the OOD/cross-embodiment gap (0.85–0.87 → ~0.95); action-conditioned, long-horizon, physically-accurate prediction — years out |
+| World models get good enough to predict physical outcomes | **SC3-Eval r=0.984 in-dist (OOD ≈ its Predict2.5 baseline) / OSCAR r=0.852 RoboArena, open-loop-validated only**; Cosmos/Genie/Marble usable for augmentation *today* | Close the OOD/cross-embodiment gap (0.85–0.87 → ~0.95); action-conditioned, long-horizon, physically-accurate prediction with published chained closed-loop durability — years out |
 | Synthetic + site data gets good enough for post-training | GR00T-Dreams, 780k-traj/11h, DreamGen ~10× | Sim-to-real transfer strong enough to sell improvement, not just data |
 | Real-site diversity is the durable data moat | Data-scaling-law: generalization ∝ environment diversity | We out-capture competitors on breadth *and* provenance quality |
 | A neutral eval standard can become a required gate | Ratings/UL/MLPerf precedents | We get embedded in procurement/insurance/pilot decisions before a rival |
@@ -281,7 +302,6 @@ ranking is valuable even if world models plateau.
   Decide only with rung-1 evidence and a neutrality plan.
 - **Neutrality governance:** when do we formalize the eval firewall? (Answer: before rung 4, not
   after.)
-
 <!-- SHARED_VISION_END -->
 
 ## Evidence base (selected, verified 2026-07-03)
@@ -332,5 +352,10 @@ figures beyond the ~40% one-year drop are lower-confidence.*
 
 ---
 
-*Maintained as a shared cross-repo doctrine. Edit the shared block in one place and mirror to all
-three repos. Last updated 2026-07-03.*
+*Shared cross-repo doctrine, generated from a single source. Edit
+`BlueprintCapturePipeline doctrine/`, then run
+`python3 scripts/sync_shared_doctrine.py --write` to splice it into every repo and
+re-lock. Do not hand-edit the block above: CI verifies it against
+`contracts/shared-doctrine.lock.json` and will reject a drifted copy. Last synced
+2026-07-31 (union merge of the previously diverged Pipeline and WebApp copies;
+`BlueprintCapture` was not checked out and remains unsynced).*

--- a/WORLD_MODEL_STRATEGY_CONTEXT.md
+++ b/WORLD_MODEL_STRATEGY_CONTEXT.md
@@ -3,74 +3,282 @@
 > Repo-authoritative mirror of Blueprint world-model strategy. Reconcile material changes with Blueprint Knowledge.
 
 <!-- SHARED_WORLD_MODEL_STRATEGY_START -->
-## Strategic doctrine
+## Strategic Doctrine
 
-Blueprint assumes world models, simulators, providers, checkpoints, and inference methods will change rapidly. The company must not depend on owning or permanently selecting one backend.
+Blueprint should assume world models, simulators, providers, checkpoints, and
+inference methods will improve rapidly, and that multiple viable options will
+exist over time.
 
-Blueprint's durable moat is:
+Blueprint should not build the company around owning or permanently selecting
+one backend.
 
-1. real-site capture supply and coverage;
-2. immutable, rights-safe, privacy-safe, provenance-linked raw evidence;
-3. maintained Site-Task Testbeds;
-4. Task Evaluation Runs with qualified claim-by-claim evidence routing;
-5. buyer and operator workflows around inspectable decisions, abstentions, and physical learning.
+Blueprint's durable moat should be:
 
-### World models are evidence methods, not the offer
+1. real-site capture supply and coverage
+2. immutable, rights-safe, privacy-safe, provenance-linked raw evidence
+3. maintained Site-Task Testbeds
+4. claim-level Task Evaluation Runs with qualified claim-by-claim evidence routing
+5. buyer, licensing, and ops product surfaces around inspectable decisions,
+   abstentions, and physical learning
+6. a compounding capture -> package -> buyer usage -> more capture flywheel
 
-Task Evaluation Run is the sole customer-facing product. A world model may be selected by Pipeline when its Evidence Method Profile qualifies it for a claim and validation envelope. It is never automatically ground truth, the default first method, a customer-selected backend, or proof of physical success.
+The model backend matters, but it should remain a replaceable engine behind
+stable capture, packaging, and product contracts.
+
+## Core Belief
+
+Blueprint is not qualification-first and not model-first.
+
+Blueprint is capture-first and real-site decision-evaluation first.
+
+That means:
+
+- real capture supply is the entry point
+- Task Evaluation Run is the one primary sellable output; a maintained Site-Task
+  Testbed is its reusable substrate
+- world models and simulators are replaceable evidence methods behind stable
+  adapters, alongside geometry, captured observations, provider tools, and
+  physical evidence; their artifacts never gain authority from realism or
+  provider identity
+- qualification / readiness can exist as optional trust layers, especially for
+  high-stakes buyers, commercialization decisions, or deployment review
+- those trust layers should support the product, not define the company
+
+## World Models Are Evidence Methods, Not The Offer
+
+Task Evaluation Run is the sole customer-facing product. A world model may be
+selected by Pipeline when its Evidence Method Profile qualifies it for a claim
+and validation envelope. It is never automatically ground truth, the default
+first method, a customer-selected backend, or proof of physical success.
 
 Pipeline may combine:
 
-- fixture and contract evidence;
-- captured geometry;
-- real observations;
-- traditional simulation;
-- world models;
-- provider tools;
-- authoritative physical evidence.
+- fixture and contract evidence
+- captured geometry
+- real observations
+- traditional simulation
+- world models
+- provider tools
+- authoritative physical evidence
 
-The routing objective is the least expensive currently qualified evidence for each decision-relevant claim, with stronger evidence requested only when needed.
+The routing objective is the least expensive currently qualified evidence for
+each decision-relevant claim, with stronger evidence requested only when needed.
 
-### Stable contracts across backend swaps
+## Practical Strategic Conclusion
 
-Keep stable:
+Do not overfit the platform to any one of:
 
-- raw capture bundle structure and native timelines;
-- timestamps, poses, intrinsics, depth, and device metadata;
-- consent, rights, privacy, and provenance;
-- Site-Task Testbed identity, version, and digest;
-- Decision/Evidence Request;
-- Evidence Plan and Method Profile;
-- normalized Evidence Result and Decision Envelope;
-- Physical Outcome Join;
-- hosted access, entitlements, redaction, and audit contracts.
+- a single model paper
+- a single checkpoint family
+- a single provider
+- a single inference trick
+- a single hardware profile
 
-Keep replaceable:
+Instead, build the stack so that better model backends can be dropped in later
+with minimal changes above the model-adapter layer.
 
-- model checkpoints and providers;
-- simulators and inference services;
-- retrieval and conditioning strategies;
-- generation, editing, and augmentation methods;
-- training and export adapters.
+## Current Product Truth
 
-### Post-training boundary
+Today, the strongest near-term value comes from:
 
-Post-training is a permitted evidence use inside a Task Evaluation Run, never a separate product. Eligibility requires the Pipeline artifact to say so. An eligible export does not prove training occurred, a customer consumed it, or a policy improved.
+1. capturing real indoor spaces at scale
+2. turning those captures into site/task/scenario/eval artifacts for robot
+   evaluation
+3. preserving strong rights, privacy, and provenance metadata around those assets
+4. giving robot teams clear buyer surfaces for Task Evaluation Runs before
+   expensive pilots
+5. routing each claim to the cheapest qualified combination of analytic,
+   observed, simulated, learned/provider, or physical evidence
+6. allowing evaluation or post-training use of run evidence only after the
+   corresponding proof, rights, provenance, alignment, quality, and leakage gates
+7. using qualification/readiness summaries as supporting views, not products
 
-### Proof and calibration boundary
+Native SWM-like interaction remains an important direction, but it is not the
+only thing customers need in order for the product to be valuable now.
 
-Simulation, world-model, provider, and generated evidence stays inside the stated validation envelope. External research may motivate method qualification but is not a Blueprint run result. Physical performance, deployment, safety, calibration, and onsite ordering claims require their own evidence. A physical outcome updates the learning loop only through an authoritative exact-ID join; WebApp does not recalibrate methods.
+## How To Think About The Runtime
 
-### Build priorities
+The runtime should be treated as a bridge architecture:
 
-1. capture quality, synchronization, provenance, rights, and privacy;
-2. maintained versioned testbeds;
-3. decision-oriented intake and secure durable state;
-4. Pipeline qualification, routing, normalized evidence, and abstention;
-5. clear result projection and physical learning joins;
-6. swappable evidence backends that improve cost or claim coverage without becoming the product story.
+- immediate interaction should come from truthful, site-grounded rendering and
+  hosted-session paths
+- more generative continuation can sit behind that as optional refinement
+- the browser/runtime contract should not assume one model family
 
-### Decision rule
+This keeps the product useful now while preserving room for stronger native
+world-model behavior later.
 
-Default toward reusable capture, contract, testbed, evidence, and product infrastructure. Adopt model-specific work only when it materially improves a qualified claim path without increasing long-term coupling or overstating evidence.
+## What Must Stay Stable Across Model Swaps
+
+These should be treated as long-lived platform contracts:
+
+- raw capture bundle structure and native timelines
+- timestamps, poses, intrinsics, depth, and device metadata
+- consent, rights, privacy, and provenance metadata
+- site-specific package manifests
+- Site-Task Testbed identity, version, and digest
+- Decision/Evidence Request
+- Evidence Plan and Evidence Method Profile
+- normalized Evidence Result and Decision Envelope
+- Physical Outcome Join
+- hosted-session and runtime session contracts
+- hosted access, entitlements, redaction, and audit contracts
+- buyer attachment, licensing, and sync contracts
+- truth labeling in UI and APIs
+- legacy Policy Improvement Run and Post-Training Data Package readers and
+  translators until consumers migrate
+
+Qualification / readiness outputs should stay compatible where they exist, but
+they should be treated as optional support contracts rather than the only source
+of product value.
+
+## What Must Remain Swappable
+
+These should be deliberately replaceable:
+
+- world-model checkpoints
+- world-model providers
+- simulators and inference services
+- retrieval-conditioned generation and conditioning strategies
+- generation, editing, augmentation, and refinement methods
+- training/export adapters
+
+No repo should assume one specific model or provider is permanent.
+
+For current WAM evaluator work, Cosmos 3 can be treated as the preferred
+configured candidate when a real adapter, checkpoint/provider runtime, explicit
+run gates, consistency scorer, and calibration anchors exist. That preference
+must remain behind the same replaceable adapter boundary as OSCAR,
+Cosmos-Predict2.5, or any future model family. It is not universal grading
+proof, deployment approval, safety validation, physical-robot readiness, or a
+reason to weaken capture/provenance truth.
+
+## Post-Training Boundary
+
+Post-training is a permitted evidence use inside a Task Evaluation Run, never a
+separate product. Eligibility requires the Pipeline artifact to say so. An
+eligible export does not prove training occurred, a customer consumed it, or a
+policy improved.
+
+## Proof And Calibration Boundary
+
+Simulation, world-model, provider, and generated evidence stays inside the
+stated validation envelope. External research may motivate method qualification
+but is not a Blueprint run result. Physical performance, deployment, safety,
+calibration, and onsite ordering claims require their own evidence. A physical
+outcome updates the learning loop only through an authoritative exact-ID join;
+WebApp does not recalibrate methods.
+
+## Platform Moat
+
+Blueprint's moat should come from assets that get stronger when models
+commoditize:
+
+- better real-site capture coverage
+- better capture quality and provenance
+- better rights / privacy / commercialization handling
+- better Task Evaluation Runs, maintained testbeds, evidence qualification, and
+  physical-outcome learning
+- better buyer UX and operational surfaces
+- better feedback loops from real buyer usage on real sites
+
+If world models become easier to buy, proprietary real-site capture and product
+workflow should become more valuable, not less.
+
+## Product Implication
+
+The company should be able to say:
+
+- we do not depend on owning the single best world model
+- we are the best system for turning real site-task decisions into truthful Task
+  Evaluation Runs, including abstentions and rights-gated evidence use
+- we can use world models, hosted experiences, trust, review, and readiness
+  layers when they help, without making unsupported qualification or world
+  models the center of the company
+
+## Build Priorities Right Now
+
+For the current stage, prioritize:
+
+1. capture quality, coverage, synchronization, provenance, rights, and privacy —
+   the moat and the entry point
+2. maintained versioned testbeds
+3. decision-oriented intake and secure durable state
+4. the deterministic claim router and evaluation engine that convert maintained
+   testbeds into decisions or explicit abstentions through replaceable evidence
+   adapters
+5. packaging captures into strong site/task/scenario/eval artifacts
+6. clear result projection, physical learning joins, hosted access, and buyer
+   usability
+7. stable product contracts that survive backend swaps
+8. swappable evidence backends — generated/model-derived data, world-model,
+   simulation, and readiness support — that improve cost or claim coverage
+   without becoming the product story
+
+"Capture-first" names the moat, the entry point, and the truth hierarchy — it is
+not a claim that most engineering effort sits in capture code at every moment.
+Building the evaluation engine on top of captured sites is how the capture-first
+strategy is executed, not a departure from it. What stays out of bounds: making
+any single world model the public product story, letting evaluator convenience
+weaken capture/provenance truth, or letting engine work starve capture supply
+and package quality so long that the moat stops growing.
+
+Do not push qualification/readiness, world-model access, policy improvement, or
+data exports into separate product stories. They support Task Evaluation Runs.
+
+## Data Priority
+
+Collect and preserve data now as if future world-model training and evaluation
+will depend on it.
+
+That means preserving:
+
+- walkthrough video
+- motion / trajectory logs
+- camera poses
+- intrinsics
+- depth when available
+- timestamps and temporal alignment data
+- device / modality metadata
+- site / scenario / deployment context
+- privacy / consent / rights metadata
+- retrieval / reference relationships when derived
+
+Future model quality and package quality will depend heavily on data quality and
+structure.
+
+## Repo-Level Guidance
+
+Each repo should optimize for the same posture:
+
+- `BlueprintCapture`: capture the richest, cleanest, most reusable real-site
+  evidence possible
+- `BlueprintCapturePipeline`: maintain testbeds and turn decision requests into
+  Task Evaluation Run plans, normalized evidence, decisions/abstentions, optional
+  evidence-use exports, and append-only learning without backend coupling
+- `Blueprint-WebApp`: sell, deliver, and operate those runs through clear buyer
+  and ops surfaces
+
+## Non-Goal
+
+Do not assume the platform is "done" only when a perfect SWM runtime exists.
+
+The correct goal is:
+
+- build everything around capture, packaging, and buyer workflow so stronger
+  world-model backends can be adopted later without a company-wide rebuild
+- keep world-model language as internal compatibility or generated-evidence
+  support unless a public surface clearly labels it as advisory support
+
+## Decision Rule For Future Sessions
+
+When choosing between:
+
+- investing in model-specific hacks
+- investing in reusable capture / packaging / product infrastructure
+
+default toward reusable capture, contract, testbed, evidence, and product
+infrastructure. Adopt model-specific work only when it materially improves a
+qualified claim path or near-term user-visible value without increasing
+long-term coupling or overstating evidence.
 <!-- SHARED_WORLD_MODEL_STRATEGY_END -->

--- a/contracts/shared-doctrine.lock.json
+++ b/contracts/shared-doctrine.lock.json
@@ -1,7 +1,6 @@
 {
   "schema_version": "blueprint.shared_doctrine_lock.v1",
-  "status": "unreconciled",
-  "status_note": "The tracked blocks do not currently agree across repos. Each repo is frozen at its own recorded baseline so no new variant can appear while reconciliation is pending. Flip status to 'locked' and populate canonical_sha256 once the repos are converged.",
+  "status": "locked",
   "reconciliation_reference": "BlueprintCapturePipeline docs/doctrine-shared-block-divergence-2026-07-31.md",
   "measured_at": "2026-07-31",
   "extraction": {
@@ -16,30 +15,16 @@
   "blocks": {
     "SHARED_PLATFORM_CONTEXT": {
       "file": "PLATFORM_CONTEXT.md",
-      "canonical_sha256": null,
-      "observed_sha256": {
-        "BlueprintCapture": null,
-        "BlueprintCapturePipeline": "4b698feb2981cc6c11db939724077e28616674bbc866775b40891fe87e5affa1",
-        "Blueprint-WebApp": "1a104d0898cf52a9d641b26ede65738933fdeef70fd0ab7e537d0d2d442ab7fa"
-      }
+      "canonical_sha256": "b152feafcc47e3d94feaa4c53ef330a5dadede76e9333de9c4b05cc03cf38470"
     },
     "SHARED_VISION": {
       "file": "VISION.md",
-      "canonical_sha256": null,
-      "observed_sha256": {
-        "BlueprintCapture": null,
-        "BlueprintCapturePipeline": "1352aa9a4f576245778b023686f5bad9f1ea38529a5d51009bf2e9167b69a0eb",
-        "Blueprint-WebApp": "f78264d52a3701241d0e2a6dbc1ee24f706b34adb443e82ee0c3326fb279c43a"
-      }
+      "canonical_sha256": "609e936f330d3403d5713c76ddc9d87829387bc3cb80677ef54e7e0008879474"
     },
     "SHARED_WORLD_MODEL_STRATEGY": {
       "file": "WORLD_MODEL_STRATEGY_CONTEXT.md",
-      "canonical_sha256": null,
-      "observed_sha256": {
-        "BlueprintCapture": null,
-        "BlueprintCapturePipeline": "3eee5608d9d52fe9022ad4bec48a0975fe979147158654f3185b11b5c62ed4be",
-        "Blueprint-WebApp": "582deff66c363b1195d5ef50f9dcab68413995c9d0579fb36c2b25e283033be8"
-      }
+      "canonical_sha256": "da28f40a957e6f70d48e447c7b6b7365c219f2836301e00afda0473becfa33e0"
     }
-  }
+  },
+  "canonical_source": "BlueprintCapturePipeline doctrine/"
 }

--- a/contracts/shared-doctrine.lock.json
+++ b/contracts/shared-doctrine.lock.json
@@ -1,0 +1,45 @@
+{
+  "schema_version": "blueprint.shared_doctrine_lock.v1",
+  "status": "unreconciled",
+  "status_note": "The tracked blocks do not currently agree across repos. Each repo is frozen at its own recorded baseline so no new variant can appear while reconciliation is pending. Flip status to 'locked' and populate canonical_sha256 once the repos are converged.",
+  "reconciliation_reference": "BlueprintCapturePipeline docs/doctrine-shared-block-divergence-2026-07-31.md",
+  "measured_at": "2026-07-31",
+  "extraction": {
+    "rule": "Take the lines strictly between the single '<!-- <BLOCK>_START -->' line and the single '<!-- <BLOCK>_END -->' line, join with LF, append one trailing LF, hash the UTF-8 bytes with SHA-256.",
+    "algorithm": "sha256"
+  },
+  "repos": [
+    "BlueprintCapture",
+    "BlueprintCapturePipeline",
+    "Blueprint-WebApp"
+  ],
+  "blocks": {
+    "SHARED_PLATFORM_CONTEXT": {
+      "file": "PLATFORM_CONTEXT.md",
+      "canonical_sha256": null,
+      "observed_sha256": {
+        "BlueprintCapture": null,
+        "BlueprintCapturePipeline": "4b698feb2981cc6c11db939724077e28616674bbc866775b40891fe87e5affa1",
+        "Blueprint-WebApp": "1a104d0898cf52a9d641b26ede65738933fdeef70fd0ab7e537d0d2d442ab7fa"
+      }
+    },
+    "SHARED_VISION": {
+      "file": "VISION.md",
+      "canonical_sha256": null,
+      "observed_sha256": {
+        "BlueprintCapture": null,
+        "BlueprintCapturePipeline": "1352aa9a4f576245778b023686f5bad9f1ea38529a5d51009bf2e9167b69a0eb",
+        "Blueprint-WebApp": "f78264d52a3701241d0e2a6dbc1ee24f706b34adb443e82ee0c3326fb279c43a"
+      }
+    },
+    "SHARED_WORLD_MODEL_STRATEGY": {
+      "file": "WORLD_MODEL_STRATEGY_CONTEXT.md",
+      "canonical_sha256": null,
+      "observed_sha256": {
+        "BlueprintCapture": null,
+        "BlueprintCapturePipeline": "3eee5608d9d52fe9022ad4bec48a0975fe979147158654f3185b11b5c62ed4be",
+        "Blueprint-WebApp": "582deff66c363b1195d5ef50f9dcab68413995c9d0579fb36c2b25e283033be8"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "smoke:launch": "node scripts/launch-smoke.mjs",
     "smoke:launch:local": "node scripts/launch-smoke-local.mjs",
     "deploy:rollback": "node scripts/deploy-rollback.mjs",
+    "doctrine:verify": "tsx scripts/doctrine/verify-shared-doctrine.ts",
     "test": "vitest run",
     "test:rules": "npx -y firebase-tools@13.35.1 emulators:exec --only firestore,storage --project blueprint-rules-test \"npx vitest run --config vitest.rules.config.ts\"",
     "human-replies:poll": "tsx scripts/human-replies/poll-gmail-replies.ts",

--- a/scripts/doctrine/verify-shared-doctrine.ts
+++ b/scripts/doctrine/verify-shared-doctrine.ts
@@ -12,10 +12,17 @@
  * offline, deterministic, and identical on a laptop and in CI.
  *
  * Extraction rule, kept identical to the Python implementation:
+ *   - normalize CRLF and lone CR to LF, then split on LF
  *   - locate the single line containing `<!-- <BLOCK>_START -->`
  *   - locate the single line containing `<!-- <BLOCK>_END -->`
  *   - take the lines strictly between them, join with LF, append one LF
  *   - hash the UTF-8 bytes with SHA-256
+ *
+ * Newline normalization keeps the digest identical on a CRLF checkout, which
+ * matters because no `.gitattributes` rule pins these Markdown files to LF. The
+ * Python side splits explicitly on LF rather than using `str.splitlines()` for
+ * the same reason in reverse: `splitlines()` also breaks on vertical tab, form
+ * feed, and the Unicode line separators, which `split("\n")` here does not.
  *
  * Exits non-zero unless every tracked block matches.
  */
@@ -24,6 +31,7 @@ import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
+import { fileURLToPath } from "node:url";
 
 export const REPO_NAME = "Blueprint-WebApp";
 export const LOCK_RELATIVE_PATH = "contracts/shared-doctrine.lock.json";
@@ -54,10 +62,15 @@ export type BlockResult = {
   matched: boolean;
 };
 
+/** Fold CRLF and lone CR to LF so a CRLF checkout hashes identically. */
+export function normalizeNewlines(text: string): string {
+  return text.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+}
+
 export function extractBlock(text: string, block: string): string {
   const startMarker = `<!-- ${block}_START -->`;
   const endMarker = `<!-- ${block}_END -->`;
-  const lines = text.split("\n");
+  const lines = normalizeNewlines(text).split("\n");
 
   const startHits: number[] = [];
   const endHits: number[] = [];
@@ -198,8 +211,12 @@ function main(): number {
   return 0;
 }
 
+// fileURLToPath, not `new URL(...).pathname`: the latter is percent-encoded, so a
+// checkout path containing a space would not match argv[1] and the gate would
+// silently exit 0 without running. Windows file-URL syntax fails the same way.
 const invokedDirectly =
-  process.argv[1] && path.resolve(process.argv[1]) === path.resolve(new URL(import.meta.url).pathname);
+  Boolean(process.argv[1]) &&
+  path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url));
 
 if (invokedDirectly) {
   process.exit(main());

--- a/scripts/doctrine/verify-shared-doctrine.ts
+++ b/scripts/doctrine/verify-shared-doctrine.ts
@@ -1,0 +1,206 @@
+/**
+ * Fail-closed verifier for cross-repo shared doctrine blocks.
+ *
+ * Byte-for-byte twin of `scripts/verify_shared_doctrine.py` in
+ * BlueprintCapturePipeline. Both read the same `contracts/shared-doctrine.lock.json`
+ * and must agree on every digest.
+ *
+ * Unlike `scripts/pipeline/verify-*-contract.ts`, this does NOT compare against a
+ * sibling checkout. Sibling comparison passes trivially in CI because siblings are
+ * not checked out there, which is how the shared blocks diverged on 2026-07-29
+ * without any gate firing. Digests are committed instead, so the check is
+ * offline, deterministic, and identical on a laptop and in CI.
+ *
+ * Extraction rule, kept identical to the Python implementation:
+ *   - locate the single line containing `<!-- <BLOCK>_START -->`
+ *   - locate the single line containing `<!-- <BLOCK>_END -->`
+ *   - take the lines strictly between them, join with LF, append one LF
+ *   - hash the UTF-8 bytes with SHA-256
+ *
+ * Exits non-zero unless every tracked block matches.
+ */
+
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+export const REPO_NAME = "Blueprint-WebApp";
+export const LOCK_RELATIVE_PATH = "contracts/shared-doctrine.lock.json";
+export const LOCK_SCHEMA_VERSION = "blueprint.shared_doctrine_lock.v1";
+const STATUS_LOCKED = "locked";
+const STATUS_UNRECONCILED = "unreconciled";
+
+export class DoctrineVerificationError extends Error {}
+
+type BlockEntry = {
+  file: string;
+  canonical_sha256: string | null;
+  observed_sha256: Record<string, string | null>;
+};
+
+type DoctrineLock = {
+  schema_version: string;
+  status: string;
+  blocks: Record<string, BlockEntry>;
+  repos: string[];
+};
+
+export type BlockResult = {
+  block: string;
+  file: string;
+  expected_sha256: string;
+  actual_sha256: string;
+  matched: boolean;
+};
+
+export function extractBlock(text: string, block: string): string {
+  const startMarker = `<!-- ${block}_START -->`;
+  const endMarker = `<!-- ${block}_END -->`;
+  const lines = text.split("\n");
+
+  const startHits: number[] = [];
+  const endHits: number[] = [];
+  lines.forEach((line, index) => {
+    if (line.includes(startMarker)) startHits.push(index);
+    if (line.includes(endMarker)) endHits.push(index);
+  });
+
+  if (startHits.length !== 1) {
+    throw new DoctrineVerificationError(
+      `${block}: expected exactly one ${startMarker}, found ${startHits.length}`,
+    );
+  }
+  if (endHits.length !== 1) {
+    throw new DoctrineVerificationError(
+      `${block}: expected exactly one ${endMarker}, found ${endHits.length}`,
+    );
+  }
+  if (endHits[0] <= startHits[0]) {
+    throw new DoctrineVerificationError(`${block}: end marker precedes start marker`);
+  }
+
+  return `${lines.slice(startHits[0] + 1, endHits[0]).join("\n")}\n`;
+}
+
+export function digestBlock(body: string): string {
+  return createHash("sha256").update(Buffer.from(body, "utf-8")).digest("hex");
+}
+
+export function loadLock(root: string): DoctrineLock {
+  const lockPath = path.resolve(root, LOCK_RELATIVE_PATH);
+  if (!fs.existsSync(lockPath)) {
+    throw new DoctrineVerificationError(`missing lock file: ${LOCK_RELATIVE_PATH}`);
+  }
+  const lock = JSON.parse(fs.readFileSync(lockPath, "utf-8")) as DoctrineLock;
+  if (lock.schema_version !== LOCK_SCHEMA_VERSION) {
+    throw new DoctrineVerificationError(
+      `unsupported lock schema_version: ${JSON.stringify(lock.schema_version)}`,
+    );
+  }
+  if (lock.status !== STATUS_LOCKED && lock.status !== STATUS_UNRECONCILED) {
+    throw new DoctrineVerificationError(`unsupported lock status: ${JSON.stringify(lock.status)}`);
+  }
+  return lock;
+}
+
+function expectedDigest(blockName: string, entry: BlockEntry, status: string): string {
+  if (status === STATUS_LOCKED) {
+    if (!entry.canonical_sha256) {
+      throw new DoctrineVerificationError(
+        `${blockName}: lock status is ${STATUS_LOCKED} but canonical_sha256 is absent`,
+      );
+    }
+    return entry.canonical_sha256;
+  }
+  const observed = entry.observed_sha256 ?? {};
+  const baseline = observed[REPO_NAME];
+  if (!baseline) {
+    throw new DoctrineVerificationError(
+      `${blockName}: no baseline recorded for ${REPO_NAME}; ` +
+        "measure this repo's block and add it to the lock before merging",
+    );
+  }
+  return baseline;
+}
+
+export function verify(root: string): BlockResult[] {
+  const lock = loadLock(root);
+  const blockNames = Object.keys(lock.blocks ?? {}).sort();
+  if (blockNames.length === 0) {
+    throw new DoctrineVerificationError("lock declares no blocks");
+  }
+
+  const results: BlockResult[] = [];
+  const failures: string[] = [];
+
+  for (const blockName of blockNames) {
+    const entry = lock.blocks[blockName];
+    const source = path.resolve(root, entry.file);
+    if (!fs.existsSync(source)) {
+      failures.push(`${blockName}: missing source file ${entry.file}`);
+      continue;
+    }
+    let actual: string;
+    let wanted: string;
+    try {
+      actual = digestBlock(extractBlock(fs.readFileSync(source, "utf-8"), blockName));
+      wanted = expectedDigest(blockName, entry, lock.status);
+    } catch (error) {
+      failures.push(error instanceof Error ? error.message : String(error));
+      continue;
+    }
+
+    const matched = actual === wanted;
+    if (!matched) {
+      failures.push(
+        `${blockName}: ${entry.file} does not match the lock ` +
+          `(expected ${wanted}, found ${actual})`,
+      );
+    }
+    results.push({
+      block: blockName,
+      file: entry.file,
+      expected_sha256: wanted,
+      actual_sha256: actual,
+      matched,
+    });
+  }
+
+  if (failures.length > 0) {
+    throw new DoctrineVerificationError(failures.join("; "));
+  }
+  return results;
+}
+
+function main(): number {
+  const root = process.cwd();
+  let results: BlockResult[];
+  try {
+    results = verify(root);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`shared doctrine verification FAILED: ${message}\n`);
+    return 1;
+  }
+
+  for (const row of results) {
+    process.stdout.write(`ok  ${row.block}  ${row.file}  ${row.actual_sha256}\n`);
+  }
+  if (loadLock(root).status === STATUS_UNRECONCILED) {
+    process.stderr.write(
+      "\nNOTE: lock status is 'unreconciled'. Blocks are frozen at their current " +
+        "per-repo baselines so no new variants can appear, but the repos do not yet " +
+        "agree. See BlueprintCapturePipeline " +
+        "docs/doctrine-shared-block-divergence-2026-07-31.md.\n",
+    );
+  }
+  return 0;
+}
+
+const invokedDirectly =
+  process.argv[1] && path.resolve(process.argv[1]) === path.resolve(new URL(import.meta.url).pathname);
+
+if (invokedDirectly) {
+  process.exit(main());
+}


### PR DESCRIPTION
WebApp half of a cross-repo gate against shared doctrine divergence. Pipeline half is ognjhunt/BlueprintCapturePipeline#263.

## Problem

`PLATFORM_CONTEXT.md`, `VISION.md`, and `WORLD_MODEL_STRATEGY_CONTEXT.md` are required by `DOCTRINE_PRECEDENCE.md` to be byte-identical across `BlueprintCapture`, `BlueprintCapturePipeline`, and `Blueprint-WebApp` inside their shared markers. All three have diverged:

| Shared block | Pipeline | WebApp |
| --- | --- | --- |
| `SHARED_PLATFORM_CONTEXT` | 119 lines | 63 |
| `SHARED_WORLD_MODEL_STRATEGY` | 205 lines | 72 |
| `SHARED_VISION` | 282 lines | 270 |

It happened on 2026-07-29, forty minutes apart — `#426` here at 14:11 and `#243` in Pipeline at 13:31 — each editing its own copy. Nothing fired.

The existing mirror pattern (`scripts/pipeline/verify-*-contract.ts`) compares against a sibling checkout and reports `proposed_dependency_unmerged` when the sibling is absent. Siblings are never checked out in CI, so that check passes trivially there.

## Change

- `contracts/shared-doctrine.lock.json` — byte-identical across repos, one SHA-256 per tracked block
- `scripts/doctrine/verify-shared-doctrine.ts` — extracts the local block, compares to the lock, exits non-zero on mismatch
- `npm run doctrine:verify`, wired into the CI `check` job beside the claims guard

No sibling checkout, no network, no provider — identical behavior on a laptop and in CI.

Byte-for-byte twin of `scripts/verify_shared_doctrine.py` in Pipeline. Extraction is specified exactly so both agree: fold CRLF and lone CR to LF, split on LF, take the lines strictly between the single START and END marker lines, join with LF, one trailing LF, hash as UTF-8. Malformed, missing, duplicated, or out-of-order markers fail closed rather than hashing an empty string.

## Scope — what this does and does not do

**Does:** freeze each repo at a recorded baseline so unintentional drift becomes a merge-blocking CI failure, offline, in every repo.

**Does not:** make deliberate divergence impossible. A single PR can edit a shared block and rewrite its digest in the same commit and pass — raised as P1 in review, and correct. Closing that requires the content to stop living in consuming repos at all, which is the single-source generator (`doctrine/` in Pipeline, BlueprintCapturePipeline#263). Once blocks here are generated output, the follow-on gate is "this repo may not modify a shared block," which is offline-checkable and closes the loophole properly. This PR is the enforcement half; it is not sufficient alone.

## Why the lock says `unreconciled`

The blocks do not agree, and picking a winner is a doctrine decision, not a mechanical merge — the more recent copy (this repo's) is not a superset, so mirroring it would delete Pipeline-only sections including Product Center of Gravity, Market Structure, and Platform Moat.

So the lock pins **each repo to its own recorded baseline**. A repo with no recorded baseline fails closed rather than being skipped — which is how `BlueprintCapture` will surface when it is added. Once the repos converge, status flips to `locked` and every repo must match one canonical digest per block.

Reconciliation options: `BlueprintCapturePipeline docs/doctrine-shared-block-divergence-2026-07-31.md`.

## Verification

Positive and negative paths in both languages: clean tree passes; a one-line tamper inside a block exits non-zero naming the block, file, and both digests. LF, CRLF, and CR inputs hash identically across both implementations. The verifier was run from a directory whose name contains a space to confirm the direct-invocation guard does not silently skip `main`. Pipeline adds fast-lane tests over marker handling, digest stability, newline parity, the Unicode line-boundary parity guard, and each fail-closed path.

`tsx` is an existing devDependency and the invocation matches the convention used by `claims:guard`. `node_modules` was not installed in the authoring environment, so local runs used `npx tsx`; CI runs `npm ci` first.

## Not included

`BlueprintCapture` was not available in this session. Its blocks are uncompared and its lock entries are `null`, so the three-way state is unknown rather than resolved.