### PR TITLE
Show a Task Evaluation Run instead of describing it

### DIFF
--- a/client/src/components/site/figures.tsx
+++ b/client/src/components/site/figures.tsx
@@ -49,9 +49,9 @@ const ACCENT_ON_INK = "#3a79c2";
 const MUTED = "#817e72";
 const MUTED_ON_INK = "#a8a496";
 
-const surfaceFor = (onInk: boolean) => (onInk ? "#0d0d0b" : "#ffffff");
-const accentFor = (onInk: boolean) => (onInk ? ACCENT_ON_INK : ACCENT);
-const mutedFor = (onInk: boolean) => (onInk ? MUTED_ON_INK : MUTED);
+export const surfaceFor = (onInk: boolean) => (onInk ? "#0d0d0b" : "#ffffff");
+export const accentFor = (onInk: boolean) => (onInk ? ACCENT_ON_INK : ACCENT);
+export const mutedFor = (onInk: boolean) => (onInk ? MUTED_ON_INK : MUTED);
 
 /* ------------------------------------------------------------------ shell */
 
@@ -476,7 +476,12 @@ export interface ClaimInterval {
   verdict: ClaimVerdict;
 }
 
-const verdictMeta: Record<
+/**
+ * Verdict identity: label, icon, and the two surface-specific hues. Exported so
+ * every surface that reports a verdict — the chart here and the run film — uses
+ * one definition, and so no caller can invent a fourth outcome.
+ */
+export const verdictMeta: Record<
   ClaimVerdict,
   { label: string; icon: LucideIcon; fg: string; fgOnInk: string }
 > = {

--- a/client/src/components/site/runFilm/FilmScreen.tsx
+++ b/client/src/components/site/runFilm/FilmScreen.tsx
@@ -1,0 +1,32 @@
+/**
+ * The screen the film plays on: a dark panel inset into whatever band hosts it,
+ * carrying the same visible "Illustrative" marker every figure with schematic
+ * values carries. Nothing in the film reads live run data.
+ */
+import type { ReactNode } from "react";
+
+import { Info } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+export function FilmScreen({ children, className }: { children: ReactNode; className?: string }) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col overflow-hidden rounded-lg border border-white/10 bg-ink",
+        className,
+      )}
+    >
+      <div className="flex shrink-0 items-center justify-between gap-3 border-b border-white/10 px-4 py-2.5 sm:px-5 sm:py-3">
+        <p className="truncate text-[12px] font-semibold tracking-[-0.01em] text-[color:var(--text-on-ink)] sm:text-[13px]">
+          One Task Evaluation Run
+        </p>
+        <span className="inline-flex shrink-0 items-center gap-1.5 rounded-xs border border-white/15 px-2 py-1 font-mono text-[10px] uppercase tracking-[0.14em] text-ink-300">
+          <Info className="h-3 w-3" aria-hidden="true" />
+          Illustrative
+        </span>
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/client/src/components/site/runFilm/RunFilm.tsx
+++ b/client/src/components/site/runFilm/RunFilm.tsx
@@ -19,7 +19,7 @@
  * The swap happens in a layout effect, before the browser paints, so it is never
  * visible as a flash and never moves the scroll position out from under anyone.
  */
-import { useCallback, useRef } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef } from "react";
 
 import { motion } from "framer-motion";
 import { RotateCcw } from "lucide-react";
@@ -29,7 +29,7 @@ import { cn } from "@/lib/utils";
 
 import { RunFilmStage } from "./acts";
 import { FilmScreen } from "./FilmScreen";
-import { ActList, RunFilmLimits, RunFilmStatic } from "./RunFilmStatic";
+import { ActList, ClaimSummary, RunFilmLimits, RunFilmStatic } from "./RunFilmStatic";
 import { LAST_ACT, useActProgress, useRunFilmMode } from "./useActProgress";
 
 export interface RunFilmProps {
@@ -180,24 +180,86 @@ function RunFilmScrub({ compact, className }: { compact: boolean; className?: st
       <div className="sr-only">
         <ActList />
       </div>
+      <ClaimSummary />
     </div>
   );
 }
 
+const useIsomorphicLayoutEffect = typeof window !== "undefined" ? useLayoutEffect : useEffect;
+
+/**
+ * Keeps the reader where they were when the telling changes.
+ *
+ * The two tellings are wildly different heights — a 560vh scroll track versus a
+ * page-flow block — so a reader who resizes across the mode boundary (or toggles
+ * reduced motion) part-way through the film would otherwise be dumped into an
+ * unrelated section, because the browser holds `scrollY` while the document
+ * shrinks underneath it.
+ *
+ * Rather than freezing the mode after mount, which would mean ignoring a
+ * `prefers-reduced-motion` change, this records how far through the film the
+ * reader is and restores that position after the swap. It only acts when the
+ * film was actually on screen: someone reading the footer when they resize
+ * should stay at the footer, not get yanked back up.
+ */
+function useFilmScrollAnchor(mode: string) {
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const progressRef = useRef(0);
+  const wasOnScreenRef = useRef(false);
+  const lastModeRef = useRef(mode);
+
+  useEffect(() => {
+    const node = wrapperRef.current;
+    if (!node || typeof window === "undefined") return;
+
+    const record = () => {
+      const rect = node.getBoundingClientRect();
+      wasOnScreenRef.current = rect.top < window.innerHeight && rect.bottom > 0;
+      const scrollable = node.offsetHeight - window.innerHeight;
+      progressRef.current =
+        scrollable > 0
+          ? Math.min(1, Math.max(0, (window.scrollY - node.offsetTop) / scrollable))
+          : 0;
+    };
+
+    record();
+    window.addEventListener("scroll", record, { passive: true });
+    return () => window.removeEventListener("scroll", record);
+  }, []);
+
+  useIsomorphicLayoutEffect(() => {
+    if (lastModeRef.current === mode) return;
+    lastModeRef.current = mode;
+
+    const node = wrapperRef.current;
+    if (!node || !wasOnScreenRef.current || typeof window === "undefined") return;
+    const scrollable = node.offsetHeight - window.innerHeight;
+    if (scrollable <= 0) return;
+    // Jump, never smooth-scroll: this is a correction for a layout change the
+    // reader did not ask for, so it should be invisible rather than animated.
+    window.scrollTo({ top: node.offsetTop + scrollable * progressRef.current });
+  }, [mode]);
+
+  return wrapperRef;
+}
+
 export function RunFilm({ variant = "full", className }: RunFilmProps) {
   const mode = useRunFilmMode();
+  const wrapperRef = useFilmScrollAnchor(mode);
   const compact = variant === "compact";
 
-  if (mode === "stepped") {
-    return <RunFilmStatic compact={compact} className={className} />;
-  }
-
   return (
-    <div className={className}>
-      <RunFilmScrub compact={compact} />
-      {/* Stated at page level in both tellings, with room to be read, rather
-          than as a footnote inside a stage that has to fit one screen. */}
-      <RunFilmLimits />
+    <div ref={wrapperRef} className={className}>
+      {mode === "stepped" ? (
+        <RunFilmStatic compact={compact} />
+      ) : (
+        <>
+          <RunFilmScrub compact={compact} />
+          {/* Stated at page level in both tellings, with room to be read, rather
+              than as a footnote inside a stage that has to fit one screen. */}
+          <RunFilmLimits />
+        </>
+      )}
     </div>
   );
 }

--- a/client/src/components/site/runFilm/RunFilm.tsx
+++ b/client/src/components/site/runFilm/RunFilm.tsx
@@ -1,0 +1,203 @@
+/**
+ * "The Run Film" — the orchestrator.
+ *
+ * One scroll-driven motion graphic that shows a Task Evaluation Run end to end:
+ * a real place is captured, the capture becomes a testbed we keep, a decision is
+ * bound against it, the decision splits into claims, each claim climbs the cost
+ * ladder to the cheapest evidence qualified to carry it, results come back with
+ * their uncertainty, and the envelope states what holds — including the two
+ * things it never grants.
+ *
+ * Which telling a reader gets is decided in `useRunFilmMode`:
+ *
+ *   - **stepped** — server render, first paint, every phone, and reduced motion.
+ *     Nothing pins, nothing is behind a gesture. See `RunFilmStatic`.
+ *   - **scrub** — wide viewport with motion allowed: the stage pins and the acts
+ *     are driven by scroll position, with a stepper for readers who would rather
+ *     jump than scrub.
+ *
+ * The swap happens in a layout effect, before the browser paints, so it is never
+ * visible as a flash and never moves the scroll position out from under anyone.
+ */
+import { useCallback, useRef } from "react";
+
+import { motion } from "framer-motion";
+import { RotateCcw } from "lucide-react";
+
+import { runFilmActs } from "@/data/publicSiteCopy";
+import { cn } from "@/lib/utils";
+
+import { RunFilmStage } from "./acts";
+import { FilmScreen } from "./FilmScreen";
+import { ActList, RunFilmLimits, RunFilmStatic } from "./RunFilmStatic";
+import { LAST_ACT, useActProgress, useRunFilmMode } from "./useActProgress";
+
+export interface RunFilmProps {
+  /**
+   * `full` is the /how-it-works cut: the whole film, with per-act detail.
+   * `compact` is the Home cut: the same seven acts, tighter and quicker.
+   */
+  variant?: "full" | "compact";
+  className?: string;
+}
+
+/**
+ * The act stepper: where the film is, how much is left, and a way to jump.
+ * Every control has an accessible name, and `aria-current` marks the act on
+ * screen — the stepper is a real control, not a decorative progress bar.
+ */
+function ActStepper({
+  active,
+  onSeek,
+}: {
+  active: number;
+  onSeek: (index: number) => void;
+}) {
+  return (
+    <nav aria-label="Acts of the run" className="min-w-0">
+      <ol className="flex flex-wrap items-center gap-x-1 gap-y-1.5">
+        {runFilmActs.map((filmAct, index) => {
+          const isActive = index === active;
+          return (
+            <li key={filmAct.id} className="min-w-0">
+              <button
+                type="button"
+                onClick={() => onSeek(index)}
+                aria-current={isActive ? "step" : undefined}
+                className={cn(
+                  "inline-flex items-center gap-1.5 rounded-xs px-1.5 py-1 font-mono text-[10px] uppercase tracking-[0.14em] transition-colors",
+                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brass",
+                  isActive
+                    ? "text-[color:var(--text-on-ink)]"
+                    : "text-ink-400 hover:text-ink-200",
+                )}
+              >
+                <span
+                  aria-hidden="true"
+                  className={cn(
+                    "h-1.5 w-1.5 shrink-0 rounded-full transition-colors",
+                    isActive
+                      ? "bg-[color:var(--text-on-ink)]"
+                      : index < active
+                        ? "bg-ink-400"
+                        : "bg-white/15",
+                  )}
+                />
+                <span className="truncate">
+                  {/* The number is the accessible name's anchor; the label is
+                      what a sighted reader scans. */}
+                  <span className="sr-only">Act {index + 1}: </span>
+                  {filmAct.label}
+                </span>
+              </button>
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}
+
+/** The pinned, scroll-driven telling. Only ever mounted on a wide viewport. */
+function RunFilmScrub({ compact, className }: { compact: boolean; className?: string }) {
+  const trackRef = useRef<HTMLDivElement>(null);
+  const { act, active } = useActProgress(trackRef);
+
+  /**
+   * Seeks the page to where a given act plays. The track maps its own scroll
+   * range onto act-space, so seeking is the inverse of that mapping — which
+   * keeps the stepper and the scrub in agreement instead of animating a
+   * separate clock that could drift from the scroll position.
+   */
+  const seek = useCallback((index: number) => {
+    const track = trackRef.current;
+    if (!track || typeof window === "undefined") return;
+    const scrollable = track.offsetHeight - window.innerHeight;
+    if (scrollable <= 0) return;
+    // Inverse of `useActProgress`: act = lerp([0.03, 0.9] -> [0, LAST + 0.4]).
+    const progress = 0.03 + (index / (LAST_ACT + 0.4)) * (0.9 - 0.03);
+    window.scrollTo({
+      top: track.offsetTop + scrollable * progress,
+      behavior: "smooth",
+    });
+  }, []);
+
+  return (
+    <div
+      ref={trackRef}
+      className={cn("relative", compact ? "h-[340vh]" : "h-[560vh]", className)}
+      data-run-film="scrub"
+    >
+      {/* `top-0` with generous top padding: the site header is sticky at z-40,
+          so the stage clears it rather than pinning beneath it. */}
+      <div className="sticky top-0 flex h-[100svh] flex-col justify-center pb-4 pt-[4.75rem] sm:pb-6 sm:pt-[5.5rem]">
+        <FilmScreen className="shrink-0">
+          <RunFilmStage act={act} compact={compact} />
+
+          <div className="shrink-0 border-t border-white/10 px-4 py-3 sm:px-5">
+            <div className="flex items-start justify-between gap-x-5 gap-y-2">
+              <ActStepper active={active} onSeek={seek} />
+              <button
+                type="button"
+                onClick={() => seek(0)}
+                className="inline-flex shrink-0 items-center gap-1.5 rounded-xs border border-white/15 px-2 py-1 font-mono text-[10px] uppercase tracking-[0.14em] text-ink-300 transition-colors hover:bg-white/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brass"
+              >
+                <RotateCcw className="h-3 w-3" aria-hidden="true" />
+                Replay
+              </button>
+            </div>
+
+            {/* All seven captions are stacked and cross-faded, so the block never
+                changes height mid-scroll. */}
+            <div
+              aria-hidden="true"
+              className={cn(
+                "relative mt-3",
+                compact ? "min-h-[3.25rem] sm:min-h-[3.5rem]" : "min-h-[3.25rem] sm:min-h-[3.75rem]",
+              )}
+            >
+              {runFilmActs.map((filmAct, index) => (
+                <motion.p
+                  key={filmAct.id}
+                  className={cn(
+                    "absolute inset-0 max-w-[68ch] font-display font-medium leading-[1.2] tracking-[-0.02em] text-[color:var(--text-on-ink)]",
+                    compact ? "text-[0.95rem]" : "text-[0.95rem] sm:text-[1.1rem]",
+                  )}
+                  initial={false}
+                  animate={{ opacity: index === active ? 1 : 0 }}
+                  transition={{ duration: 0.28, ease: "easeOut" }}
+                >
+                  {filmAct.caption}
+                </motion.p>
+              ))}
+            </div>
+          </div>
+        </FilmScreen>
+      </div>
+
+      {/* The film in words, for assistive technology and anyone who does not
+          scrub. Never hidden from either. */}
+      <div className="sr-only">
+        <ActList />
+      </div>
+    </div>
+  );
+}
+
+export function RunFilm({ variant = "full", className }: RunFilmProps) {
+  const mode = useRunFilmMode();
+  const compact = variant === "compact";
+
+  if (mode === "stepped") {
+    return <RunFilmStatic compact={compact} className={className} />;
+  }
+
+  return (
+    <div className={className}>
+      <RunFilmScrub compact={compact} />
+      {/* Stated at page level in both tellings, with room to be read, rather
+          than as a footnote inside a stage that has to fit one screen. */}
+      <RunFilmLimits />
+    </div>
+  );
+}

--- a/client/src/components/site/runFilm/RunFilmStatic.tsx
+++ b/client/src/components/site/runFilm/RunFilmStatic.tsx
@@ -1,0 +1,115 @@
+/**
+ * The stepped telling of "The Run Film".
+ *
+ * This is not a fallback poster and not a blank box: it is a complete, readable
+ * account of the same story, and it is what the largest share of readers
+ * actually get — the prerendered HTML, every phone, every reader with
+ * `prefers-reduced-motion: reduce`, and anyone with JavaScript off.
+ *
+ * It reuses the stage from `acts.tsx` frozen at the final act, so the machine is
+ * shown fully resolved, and then narrates the seven acts in order underneath.
+ * Nothing here is behind a scroll gesture and nothing pins.
+ */
+import { useMotionValue } from "framer-motion";
+
+import { runFilmActs, runFilmStampNote, runFilmStamps } from "@/data/publicSiteCopy";
+import { cn } from "@/lib/utils";
+
+import { Reveal } from "../motion";
+import { RunFilmStage } from "./acts";
+import { LAST_ACT } from "./useActProgress";
+import { FilmScreen } from "./FilmScreen";
+
+/**
+ * The acts in words. Plain language leads, the internal term follows as a chip,
+ * and each act says who performed it.
+ */
+export function ActList({ compact = false }: { compact?: boolean }) {
+  return (
+    <ol
+      className={cn(
+        "grid gap-x-10 gap-y-8 sm:grid-cols-2",
+        compact ? "lg:grid-cols-4" : "lg:grid-cols-3",
+      )}
+    >
+      {runFilmActs.map((filmAct, index) => (
+        <Reveal as="li" key={filmAct.id} from="up" distance={16} delay={index * 0.04}>
+          <div className="min-w-0 border-t border-line pt-4">
+            <div className="flex items-baseline justify-between gap-3">
+              <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-brass-deep">
+                {String(index + 1).padStart(2, "0")} · {filmAct.label}
+              </p>
+              {/* Who did this. Two acts are the buyer's; the rest are ours. */}
+              <span className="shrink-0 font-mono text-[9.5px] uppercase tracking-[0.14em] text-ink-400">
+                {filmAct.actor}
+              </span>
+            </div>
+            <p className="mt-3 max-w-[44ch] text-[14px] leading-[1.6] text-ink-700">
+              {filmAct.caption}
+            </p>
+            <p className="mt-3 font-mono text-[10px] uppercase tracking-[0.14em] text-ink-400">
+              {filmAct.term}
+            </p>
+          </div>
+        </Reveal>
+      ))}
+    </ol>
+  );
+}
+
+/**
+ * What a run never grants. This is deliberately outside the decorative stage and
+ * readable by assistive technology: a decision envelope fails validation unless
+ * both of these are false, which makes it the most defensible thing on the page.
+ */
+export function RunFilmLimits({ onInk = false }: { onInk?: boolean }) {
+  return (
+    <div
+      className={cn(
+        "mt-10 border-t pt-6",
+        onInk ? "border-white/10" : "border-line",
+      )}
+    >
+      <ul className="flex flex-wrap gap-x-6 gap-y-2">
+        {runFilmStamps.map((stamp) => (
+          <li
+            key={stamp.label}
+            className={cn(
+              "font-mono text-[11px] uppercase tracking-[0.14em]",
+              onInk ? "text-ink-300" : "text-ink-600",
+            )}
+          >
+            {stamp.label}
+            <span className="ml-2 font-semibold text-brass-deep">{stamp.value}</span>
+          </li>
+        ))}
+      </ul>
+      <p
+        className={cn(
+          "mt-3 max-w-[64ch] text-[13px] leading-[1.6]",
+          onInk ? "text-ink-300" : "text-ink-500",
+        )}
+      >
+        {runFilmStampNote}
+      </p>
+    </div>
+  );
+}
+
+export function RunFilmStatic({ compact = false, className }: { compact?: boolean; className?: string }) {
+  // Freezing the clock at the last act renders every zone in its final state, so
+  // the stepped telling reuses the stage rather than duplicating it.
+  const act = useMotionValue(LAST_ACT + 0.4);
+
+  return (
+    <div className={className} data-run-film="stepped">
+      <FilmScreen>
+        <RunFilmStage act={act} frozen compact={compact} />
+      </FilmScreen>
+      <div className="mt-10">
+        <ActList compact={compact} />
+      </div>
+      <RunFilmLimits />
+    </div>
+  );
+}

--- a/client/src/components/site/runFilm/RunFilmStatic.tsx
+++ b/client/src/components/site/runFilm/RunFilmStatic.tsx
@@ -12,9 +12,18 @@
  */
 import { useMotionValue } from "framer-motion";
 
-import { runFilmActs, runFilmStampNote, runFilmStamps } from "@/data/publicSiteCopy";
+import {
+  homeClaimThreshold,
+  runFilmActs,
+  runFilmDecision,
+  runFilmRoutes,
+  runFilmRungs,
+  runFilmStampNote,
+  runFilmStamps,
+} from "@/data/publicSiteCopy";
 import { cn } from "@/lib/utils";
 
+import { verdictMeta } from "../figures";
 import { Reveal } from "../motion";
 import { RunFilmStage } from "./acts";
 import { LAST_ACT } from "./useActProgress";
@@ -33,7 +42,13 @@ export function ActList({ compact = false }: { compact?: boolean }) {
       )}
     >
       {runFilmActs.map((filmAct, index) => (
-        <Reveal as="li" key={filmAct.id} from="up" distance={16} delay={index * 0.04}>
+        <Reveal
+          as="li"
+          key={filmAct.id}
+          from="up"
+          distance={16}
+          delay={index * 0.04}
+        >
           <div className="min-w-0 border-t border-line pt-4">
             <div className="flex items-baseline justify-between gap-3">
               <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-brass-deep">
@@ -80,7 +95,9 @@ export function RunFilmLimits({ onInk = false }: { onInk?: boolean }) {
             )}
           >
             {stamp.label}
-            <span className="ml-2 font-semibold text-brass-deep">{stamp.value}</span>
+            <span className="ml-2 font-semibold text-brass-deep">
+              {stamp.value}
+            </span>
           </li>
         ))}
       </ul>
@@ -96,7 +113,80 @@ export function RunFilmLimits({ onInk = false }: { onInk?: boolean }) {
   );
 }
 
-export function RunFilmStatic({ compact = false, className }: { compact?: boolean; className?: string }) {
+const pct = (value: number) => `${Math.round(value * 1000) / 10}%`;
+
+/**
+ * The claim table, in words.
+ *
+ * The stage is decorative and `aria-hidden`, so the substance of acts 4 to 7 —
+ * which claim, where it was routed, on what basis, what came back, and the
+ * verdict — has to exist as real semantic content outside it. The act captions
+ * alone do not carry this: they describe what each act *does*, not what this
+ * run *found*. Without this table a screen-reader user would get the narration
+ * and none of the evidence.
+ *
+ * Visually hidden rather than duplicated on screen, because sighted readers
+ * already have all of it in the stage.
+ *
+ * The `sr-only` class goes on a wrapping div, not on the table: a table's
+ * intrinsic minimum width beats `width: 1px`, so `sr-only` applied directly to
+ * a `<table>` leaves it full width and blows out the page's horizontal scroll.
+ */
+export function ClaimSummary() {
+  return (
+    <div className="sr-only">
+      <table>
+        <caption>
+          What the run found, claim by claim, for the decision “
+          {runFilmDecision.question}” against a threshold of{" "}
+          {pct(homeClaimThreshold)} {runFilmDecision.metricLabel}.
+        </caption>
+        <thead>
+          <tr>
+            <th scope="col">Claim</th>
+            <th scope="col">Routed to</th>
+            <th scope="col">Basis</th>
+            <th scope="col">What came back</th>
+            <th scope="col">Verdict</th>
+          </tr>
+        </thead>
+        <tbody>
+          {runFilmRoutes.map((route) => {
+            const rung = runFilmRungs[route.rung];
+            return (
+              <tr key={route.short}>
+                <th scope="row">{route.short}</th>
+                <td>{rung.label}</td>
+                <td>{rung.basis}</td>
+                <td>
+                  Estimate {pct(route.claim.estimate)}, interval{" "}
+                  {pct(route.claim.low)} to {pct(route.claim.high)}.
+                </td>
+                <td>
+                  {verdictMeta[route.claim.verdict].label}.
+                  {route.gate
+                    ? ` Refused ${runFilmRungs[route.gate.rung].label}: ${route.gate.reason}.`
+                    : ""}
+                  {route.nextTest !== undefined
+                    ? ` Next test that would settle it: ${runFilmRungs[route.nextTest].label}.`
+                    : ""}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export function RunFilmStatic({
+  compact = false,
+  className,
+}: {
+  compact?: boolean;
+  className?: string;
+}) {
   // Freezing the clock at the last act renders every zone in its final state, so
   // the stepped telling reuses the stage rather than duplicating it.
   const act = useMotionValue(LAST_ACT + 0.4);
@@ -106,6 +196,7 @@ export function RunFilmStatic({ compact = false, className }: { compact?: boolea
       <FilmScreen>
         <RunFilmStage act={act} frozen compact={compact} />
       </FilmScreen>
+      <ClaimSummary />
       <div className="mt-10">
         <ActList compact={compact} />
       </div>

--- a/client/src/components/site/runFilm/acts.tsx
+++ b/client/src/components/site/runFilm/acts.tsx
@@ -1,0 +1,553 @@
+/**
+ * The seven acts of "The Run Film".
+ *
+ * The film is one continuously-visible object rather than seven slides: the
+ * site-task is on screen from the first frame to the last, and each act adds to
+ * it instead of replacing it. So the acts here are layers over one stage, and
+ * they accumulate — once a claim row has appeared it stays, and later acts add
+ * columns to it. That is what keeps a viewer from ever wondering what they are
+ * looking at.
+ *
+ * Every act takes the same `act` motion value (continuous position in act-space)
+ * and derives its own timing from it, so there is exactly one clock. Freezing
+ * that clock at the last act renders the whole machine in its final state, which
+ * is how the stepped telling reuses this file rather than duplicating it.
+ *
+ * Colour follows `figures.tsx`: one accent against a de-emphasis warm gray for
+ * magnitude, the reserved status scale for outcomes, and brass never used as a
+ * data colour. Every status mark ships an icon and a text label, because the
+ * status hues collide under protanopia and colour is never the only channel.
+ *
+ * All copy comes from `publicSiteCopy.ts`. There are no hardcoded words here.
+ */
+import { CircleSlash } from "lucide-react";
+import { motion, useTransform, type MotionValue } from "framer-motion";
+
+import {
+  homeClaimThreshold,
+  runFilmDecision,
+  runFilmRoutes,
+  runFilmRungs,
+  runFilmStamps,
+  type RunFilmRoute,
+} from "@/data/publicSiteCopy";
+import { cn } from "@/lib/utils";
+
+import { accentFor, mutedFor, surfaceFor, verdictMeta } from "../figures";
+import { ACT } from "./useActProgress";
+
+/* ------------------------------------------------------------------ tokens */
+
+/* The film always plays on a dark screen inset into its host band, so only the
+   on-ink form of each token is used. */
+const ACCENT = accentFor(true);
+const MUTED = mutedFor(true);
+const SURFACE = surfaceFor(true);
+const HAIRLINE = "rgba(255,255,255,0.14)";
+const HAIRLINE_SOFT = "rgba(255,255,255,0.07)";
+/** Reserved warn tone, reused for the rung a claim is refused. */
+const GATE = verdictMeta.unresolved.fgOnInk;
+
+const THRESHOLD = homeClaimThreshold;
+const pct = (value: number) => `${Math.round(value * 1000) / 10}%`;
+
+/* ------------------------------------------------------------- act timing */
+
+/** Ramps 0 → 1 as the film arrives at act `at`, then holds. */
+function useEnter(act: MotionValue<number>, at: number, span = 0.5) {
+  return useTransform(act, [at - span - 0.06, at - 0.06], [0, 1]);
+}
+
+/** Opacity plus a short lift, for an element belonging to act `at`. */
+function useEnterLift(act: MotionValue<number>, at: number, lift = 10) {
+  const opacity = useEnter(act, at);
+  const y = useTransform(opacity, [0, 1], [lift, 0]);
+  return { opacity, y };
+}
+
+/** Fades an earlier zone back once the film has moved past it, never to zero. */
+function useRecede(act: MotionValue<number>, from: number, to = 0.45) {
+  return useTransform(act, [from - 0.7, from], [1, to]);
+}
+
+export interface ActProps {
+  act: MotionValue<number>;
+  /** Final-frame render: nothing mid-flight, no sweep caught halfway across. */
+  frozen?: boolean;
+  compact?: boolean;
+}
+
+/* ------------------------------------------------------- act 1 — capture */
+
+/** One capture point, revealed as the sweep passes over it. */
+function CapturePoint({ act, cx, cy, at }: { act: MotionValue<number>; cx: number; cy: number; at: number }) {
+  const opacity = useTransform(act, [at, at + 0.1], [0, 1]);
+  return <motion.circle cx={cx} cy={cy} r="2.4" fill={ACCENT} style={{ opacity }} />;
+}
+
+const CAPTURE_POINTS: readonly { cx: number; cy: number }[] = [
+  { cx: 34, cy: 122 }, { cx: 62, cy: 96 }, { cx: 58, cy: 44 },
+  { cx: 92, cy: 74 }, { cx: 104, cy: 118 }, { cx: 134, cy: 70 },
+  { cx: 158, cy: 116 }, { cx: 186, cy: 66 }, { cx: 206, cy: 96 },
+];
+
+/**
+ * CaptureAct — the real place, and the walk through it that records it. The
+ * plan is drawn from the first frame, because there is a place before there is
+ * a capture; the sweep and its points are what this act adds.
+ */
+export function CaptureAct({ act, frozen = false }: ActProps) {
+  const sweepX = useTransform(act, [0, 0.72], [8, 232]);
+  const sweepOpacity = useTransform(act, [0.42, 0.78], [1, 0]);
+
+  return (
+    <>
+      {/* The site: walls, the dock door, the approach lane, the fixture the
+          task happens at, and the clutter that is always there. */}
+      <rect
+        x="6" y="6" width="228" height="144" rx="3"
+        fill="rgba(255,255,255,0.03)" stroke={HAIRLINE} strokeWidth="1"
+      />
+      <line x1="234" y1="58" x2="234" y2="100" stroke={MUTED} strokeWidth="3" strokeLinecap="round" />
+      <path
+        d="M26 132 C 72 132, 78 76, 128 76 S 176 62, 196 62"
+        fill="none" stroke={HAIRLINE} strokeWidth="1.5" strokeDasharray="4 5"
+      />
+      <rect x="188" y="50" width="30" height="24" rx="2" fill="none" stroke={MUTED} strokeWidth="1.5" />
+      <rect x="48" y="34" width="16" height="13" rx="1.5" fill={HAIRLINE_SOFT} stroke={HAIRLINE} />
+      <rect x="94" y="112" width="14" height="11" rx="1.5" fill={HAIRLINE_SOFT} stroke={HAIRLINE} />
+      <rect x="150" y="120" width="18" height="11" rx="1.5" fill={HAIRLINE_SOFT} stroke={HAIRLINE} />
+
+      {CAPTURE_POINTS.map((point, index) => (
+        <CapturePoint
+          key={`${point.cx}-${point.cy}`}
+          act={act}
+          cx={point.cx}
+          cy={point.cy}
+          at={0.04 + index * 0.075}
+        />
+      ))}
+      {frozen ? null : (
+        <motion.g style={{ x: sweepX, opacity: sweepOpacity }}>
+          <line x1="0" y1="8" x2="0" y2="148" stroke={ACCENT} strokeWidth="1.5" />
+          <circle cx="0" cy="8" r="2.5" fill={ACCENT} />
+        </motion.g>
+      )}
+    </>
+  );
+}
+
+/* ------------------------------------------------------- act 2 — testbed */
+
+/**
+ * TestbedAct — the same capture, framed and kept. The frame is drawn *around*
+ * the capture rather than replacing it: raw capture stays visibly the thing the
+ * testbed is made of, so nothing derived can be read as having been promoted.
+ */
+export function TestbedAct({ act }: ActProps) {
+  const kept = useEnter(act, ACT.testbed);
+  return (
+    <motion.rect
+      x="2" y="2" width="236" height="152" rx="4"
+      fill="none" stroke={ACCENT} strokeWidth="1.5"
+      style={{ pathLength: kept, opacity: kept }}
+    />
+  );
+}
+
+/** The pin that says the testbed is versioned and kept, not a one-off scene. */
+export function TestbedPin({ act }: ActProps) {
+  const pin = useEnterLift(act, ACT.testbed, 8);
+  return (
+    // Deliberately not a fabricated version string or digest: the point is that
+    // a real run pins both, not that this illustration invents values.
+    <motion.p
+      style={{ ...pin, borderColor: HAIRLINE }}
+      className="inline-flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 rounded-xs border px-2 py-1 font-mono text-[10px] uppercase tracking-[0.14em] text-ink-300 lg:mt-3"
+    >
+      Testbed kept
+      <span className="text-ink-400">·</span>
+      version and digest pinned
+    </motion.p>
+  );
+}
+
+/* ------------------------------------------------------ act 3 — decision */
+
+/** DecisionAct — the call the buyer is about to make, and the line it turns on. */
+export function DecisionAct({ act, compact = false }: ActProps) {
+  const enter = useEnterLift(act, ACT.decision);
+  const recede = useRecede(act, ACT.routing, 0.6);
+
+  return (
+    <motion.div style={{ opacity: enter.opacity, y: enter.y }}>
+      <motion.div
+        style={{ opacity: recede, borderColor: HAIRLINE }}
+        className="rounded-sm border px-3 py-2 sm:px-4 sm:py-2.5"
+      >
+        <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-400">
+          The decision
+        </p>
+        <div className="mt-1 flex flex-wrap items-baseline gap-x-4 gap-y-1">
+          <p
+            className={cn(
+              "min-w-0 font-medium leading-snug text-[color:var(--text-on-ink)]",
+              compact ? "text-[14px]" : "text-[14px] sm:text-[15.5px]",
+            )}
+          >
+            {runFilmDecision.question}
+          </p>
+          <p className="shrink-0 font-mono text-[10.5px] uppercase tracking-[0.14em] text-ink-300">
+            Threshold · {pct(THRESHOLD)} {runFilmDecision.metricLabel}
+          </p>
+        </div>
+      </motion.div>
+    </motion.div>
+  );
+}
+
+/* ------------------------------------------- act 5 — routing (centrepiece) */
+
+/** One rung of the ladder, lit as the claim climbs onto it. */
+function Rung({
+  act,
+  index,
+  climbed,
+  gated,
+}: {
+  act: MotionValue<number>;
+  index: number;
+  climbed: boolean;
+  gated: boolean;
+}) {
+  // Rungs light left to right, so routing reads as a climb rather than a jump.
+  const lit = useTransform(act, [ACT.routing - 0.5 + index * 0.09, ACT.routing - 0.34 + index * 0.09], [0, 1]);
+  const background = gated ? GATE : climbed ? ACCENT : HAIRLINE;
+
+  return (
+    <motion.span
+      style={{ opacity: climbed || gated ? lit : 1, background }}
+      className={cn("h-1 rounded-full", gated ? "w-2" : "w-3")}
+    />
+  );
+}
+
+/**
+ * RoutingAct — where one claim's evidence came from, and what it was refused.
+ *
+ * This is the act the whole film is for. Each claim climbs the cost ladder on
+ * its own and stops at the cheapest rung strong enough to carry it — the three
+ * claims stop in three different places, which is the thing prose cannot show.
+ * The third claim is refused a rung it could have reached cheaply, because a
+ * method is only used where it is qualified for that kind of claim. Cost order
+ * is not authority order.
+ */
+export function RoutingAct({ act, route }: ActProps & { route: RunFilmRoute }) {
+  const routed = useEnter(act, ACT.routing);
+  const gateEnter = useEnter(act, ACT.routing + 0.25);
+  const rung = runFilmRungs[route.rung];
+
+  return (
+    <motion.div style={{ opacity: routed }} className="mt-1 sm:mt-1.5">
+      <div className="flex flex-wrap items-center gap-x-2.5 gap-y-1">
+        <span className="flex shrink-0 items-center gap-1" aria-hidden="true">
+          {runFilmRungs.map((ladderRung, index) => (
+            <Rung
+              key={ladderRung.label}
+              act={act}
+              index={index}
+              climbed={index <= route.rung}
+              gated={route.gate?.rung === index}
+            />
+          ))}
+        </span>
+        <span className="min-w-0 truncate font-mono text-[10px] uppercase tracking-[0.14em] text-ink-300">
+          {rung.label}
+        </span>
+        {/* The basis tag, so a cheaper rung is never read as a weaker standard
+            of proof — position on the ladder is cost, not authority. */}
+        <span className="shrink-0 font-mono text-[9.5px] uppercase tracking-[0.14em] text-ink-400">
+          {rung.basis}
+        </span>
+      </div>
+
+      {route.gate ? (
+        <motion.p
+          style={{ opacity: gateEnter, color: GATE }}
+          className="mt-1 flex items-start gap-1.5 text-[10.5px] leading-snug"
+        >
+          <CircleSlash className="mt-px h-3 w-3 shrink-0" aria-hidden="true" />
+          <span>
+            Refused · {runFilmRungs[route.gate.rung].label} — {route.gate.reason}
+          </span>
+        </motion.p>
+      ) : null}
+    </motion.div>
+  );
+}
+
+/* --------------------------------------------------- act 6 — measurement */
+
+/**
+ * MeasurementAct — what came back for one claim: a point estimate inside its
+ * uncertainty interval. Same scale and the same marks as the claim-threshold
+ * chart, so the film and that figure agree on sight.
+ */
+export function MeasurementAct({ act, route }: ActProps & { route: RunFilmRoute }) {
+  const measured = useEnter(act, ACT.measurement);
+  const resolved = useEnter(act, ACT.envelope);
+
+  return (
+    <div className="relative mt-1.5 h-5 sm:mt-2 sm:h-6">
+      <div className="absolute inset-x-0 top-1/2 h-px" style={{ background: HAIRLINE_SOFT }} />
+      {/* The threshold arrives with the envelope: measurement is the number,
+          the envelope is what the number is read against. */}
+      <motion.div
+        aria-hidden="true"
+        style={{ opacity: resolved, background: "rgba(243,239,230,0.75)", left: `${THRESHOLD * 100}%` }}
+        className="absolute top-0 h-full w-px"
+      />
+      <motion.div style={{ opacity: measured }} className="absolute inset-0" aria-hidden="true">
+        <motion.div
+          style={{
+            scaleX: measured,
+            transformOrigin: "left center",
+            left: `${route.claim.low * 100}%`,
+            width: `${(route.claim.high - route.claim.low) * 100}%`,
+            background: MUTED,
+          }}
+          className="absolute top-1/2 h-[2px] -translate-y-1/2 rounded-full"
+        />
+        <div
+          className="absolute top-1/2 h-2 w-2 -translate-x-1/2 -translate-y-1/2 rounded-full"
+          style={{
+            left: `${route.claim.estimate * 100}%`,
+            background: MUTED,
+            boxShadow: `0 0 0 2px ${SURFACE}`,
+          }}
+        />
+      </motion.div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------- act 4 — claims */
+
+/**
+ * ClaimsAct — the decision, broken into claims that can each be tested and each
+ * be wrong on their own.
+ *
+ * The rows are the film's spine from here on: act 5 adds a routing cell to each
+ * one, act 6 adds a measurement, and act 7 adds a verdict. The verdict chip
+ * lives here rather than in `EnvelopeAct` because it is a cell of this row, but
+ * it is timed to the envelope act — nothing is called before the answer.
+ */
+export function ClaimsAct({ act, compact = false }: ActProps) {
+  return (
+    <ol className={cn(compact ? "space-y-2.5" : "space-y-2.5 sm:space-y-3")}>
+      {runFilmRoutes.map((route, index) => (
+        <ClaimRow key={route.short} act={act} route={route} index={index} compact={compact} />
+      ))}
+    </ol>
+  );
+}
+
+function ClaimRow({
+  act,
+  route,
+  index,
+  compact,
+}: {
+  act: MotionValue<number>;
+  route: RunFilmRoute;
+  index: number;
+  compact: boolean;
+}) {
+  // Rows arrive in reading order, an act-fraction apart. No two entrances land
+  // at the same moment.
+  const appear = useEnterLift(act, ACT.claims + index * 0.08);
+  const resolved = useEnter(act, ACT.envelope + index * 0.08);
+  const meta = verdictMeta[route.claim.verdict];
+  const VerdictIcon = meta.icon;
+
+  return (
+    <motion.li style={{ opacity: appear.opacity, y: appear.y }} className="min-w-0">
+      <div className="flex items-baseline justify-between gap-3">
+        <p
+          className={cn(
+            "min-w-0 font-medium leading-snug text-[color:var(--text-on-ink)]",
+            compact ? "text-[13px]" : "text-[13px] sm:text-[14.5px]",
+          )}
+        >
+          {route.short}
+        </p>
+        {/* Verdict is icon plus word. Never colour alone. */}
+        <motion.span
+          style={{ opacity: resolved, color: meta.fgOnInk }}
+          className="inline-flex shrink-0 items-center gap-1.5 text-[11px] font-semibold sm:text-[12px]"
+        >
+          <VerdictIcon className="h-3.5 w-3.5" aria-hidden="true" />
+          {meta.label}
+        </motion.span>
+      </div>
+
+      <RoutingAct act={act} route={route} />
+      <MeasurementAct act={act} route={route} />
+
+      {/* An unresolved claim is a result, not a gap — so it carries the next
+          test that would settle it rather than trailing off. */}
+      {route.nextTest !== undefined ? (
+        <motion.p
+          style={{ opacity: resolved }}
+          className="mt-1 font-mono text-[9.5px] uppercase tracking-[0.14em] text-ink-400"
+        >
+          Next test · {runFilmRungs[route.nextTest].label}
+        </motion.p>
+      ) : null}
+    </motion.li>
+  );
+}
+
+/* ----------------------------------------------------- act 7 — envelope */
+
+/**
+ * EnvelopeAct — the answer with its edges drawn, and the two things it is not.
+ *
+ * The frame is four scaling hairlines rather than a border transition, so it
+ * reads as being drawn around the result. The stamps under it are the load
+ * bearing part of the whole film: a decision envelope fails validation unless
+ * both deployment approval and safety certification are false, so this is a
+ * contract-level guarantee rather than a promise.
+ */
+export function EnvelopeAct({ act }: ActProps) {
+  const envelope = useEnter(act, ACT.envelope + 0.16);
+
+  return (
+    <>
+      <div aria-hidden="true" className="pointer-events-none absolute -inset-x-3 -inset-y-3">
+        <motion.span
+          style={{ scaleX: envelope, transformOrigin: "left center", background: ACCENT }}
+          className="absolute inset-x-0 top-0 h-px"
+        />
+        <motion.span
+          style={{ scaleX: envelope, transformOrigin: "right center", background: ACCENT }}
+          className="absolute inset-x-0 bottom-0 h-px"
+        />
+        <motion.span
+          style={{ scaleY: envelope, transformOrigin: "top center", background: ACCENT }}
+          className="absolute inset-y-0 left-0 w-px"
+        />
+        <motion.span
+          style={{ scaleY: envelope, transformOrigin: "bottom center", background: ACCENT }}
+          className="absolute inset-y-0 right-0 w-px"
+        />
+      </div>
+    </>
+  );
+}
+
+/**
+ * The two stamps a run never grants. These stay inside the frame because act 7
+ * is the whole argument in one image — three verdicts, one of them not yet, and
+ * two things this explicitly is not. The sentence explaining why they can be
+ * trusted lives in `RunFilmLimits` at page level, where it has room.
+ */
+export function EnvelopeStamps({ act }: ActProps) {
+  const stamps = useEnterLift(act, ACT.envelope + 0.3, 8);
+
+  return (
+    <motion.div
+      style={{ opacity: stamps.opacity, y: stamps.y }}
+      className="mt-3 flex flex-wrap items-center gap-2"
+    >
+      {runFilmStamps.map((stamp) => (
+        <span
+          key={stamp.label}
+          style={{ borderColor: HAIRLINE }}
+          className="inline-flex items-center gap-1.5 rounded-xs border px-2 py-1 font-mono text-[10px] uppercase tracking-[0.14em] text-ink-300"
+        >
+          <CircleSlash className="h-3 w-3 shrink-0" style={{ color: GATE }} aria-hidden="true" />
+          {stamp.label}
+          <span className="font-semibold text-[color:var(--text-on-ink)]">{stamp.value}</span>
+        </span>
+      ))}
+    </motion.div>
+  );
+}
+
+/* ------------------------------------------------------------- the stage */
+
+/** The scale every measurement is read against. */
+function ScaleReference({ act }: ActProps) {
+  const scale = useEnter(act, ACT.measurement);
+  return (
+    <motion.div style={{ opacity: scale }} className="relative mt-2 h-3.5" aria-hidden="true">
+      <span className="absolute inset-x-0 top-0 block h-px" style={{ background: HAIRLINE_SOFT }} />
+      <span
+        className="absolute top-0 block h-1.5 w-px"
+        style={{ background: HAIRLINE, left: `${THRESHOLD * 100}%` }}
+      />
+      <span className="absolute left-0 top-1 font-mono text-[9.5px] text-ink-400">0%</span>
+      <span className="absolute right-0 top-1 font-mono text-[9.5px] text-ink-400">100%</span>
+    </motion.div>
+  );
+}
+
+/**
+ * RunFilmStage — the seven acts composed onto one stage.
+ *
+ * Decorative in full: every word drawn here is repeated in the act list, which
+ * is what assistive technology and no-JS readers get.
+ */
+export function RunFilmStage({
+  act,
+  frozen = false,
+  compact = false,
+  className,
+}: ActProps & { className?: string }) {
+  const placeRecede = useRecede(act, ACT.decision);
+
+  return (
+    <div
+      aria-hidden="true"
+      className={cn(
+        "grid min-w-0 gap-5 px-4 py-4 sm:px-5 sm:py-3.5 lg:grid-cols-[minmax(0,13rem)_minmax(0,1fr)] lg:gap-8",
+        className,
+      )}
+    >
+      <motion.div style={{ opacity: placeRecede }} className="min-w-0">
+        <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-400">The place</p>
+        {/* Side by side while the stage is narrow, stacked once there is a
+            column to stack in. */}
+        <div className="mt-2.5 flex items-center gap-4 lg:mt-3 lg:block">
+          <svg
+            viewBox="0 0 240 156"
+            className={cn(
+              "w-full shrink-0",
+              compact ? "max-w-[7rem] lg:max-w-[13rem]" : "max-w-[7.5rem] lg:max-w-[14rem]",
+            )}
+            aria-hidden="true"
+          >
+            <CaptureAct act={act} frozen={frozen} />
+            <TestbedAct act={act} />
+          </svg>
+          <TestbedPin act={act} />
+        </div>
+      </motion.div>
+
+      <div className="flex min-w-0 flex-col gap-4">
+        <DecisionAct act={act} compact={compact} />
+        <div>
+          {/* The envelope is drawn around the claims and their scale and stops
+              there — its stamps sit outside the frame, under it. */}
+          <div className="relative">
+            <ClaimsAct act={act} compact={compact} />
+            <ScaleReference act={act} />
+            <EnvelopeAct act={act} />
+          </div>
+          <EnvelopeStamps act={act} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/site/runFilm/index.ts
+++ b/client/src/components/site/runFilm/index.ts
@@ -1,0 +1,3 @@
+export { RunFilm, type RunFilmProps } from "./RunFilm";
+export { ActList, RunFilmLimits, RunFilmStatic } from "./RunFilmStatic";
+export { ACT, LAST_ACT, useActProgress, useRunFilmMode, type RunFilmMode } from "./useActProgress";

--- a/client/src/components/site/runFilm/useActProgress.ts
+++ b/client/src/components/site/runFilm/useActProgress.ts
@@ -1,0 +1,112 @@
+/**
+ * Timing and mode for "The Run Film".
+ *
+ * The film has two tellings and picks between them at mount:
+ *
+ *   - **scrub** — the pinned stage whose acts are driven by scroll position.
+ *     Only offered on a wide viewport with motion allowed.
+ *   - **stepped** — the whole story as stacked, fully-resolved sections with no
+ *     pinning and no scroll-jacking. This is what the server prerenders, what a
+ *     phone gets, and what `prefers-reduced-motion: reduce` gets.
+ *
+ * `stepped` is the initial state in every environment, so the prerendered HTML
+ * and the first client paint agree, and no reader is ever handed a pinned stage
+ * with six of seven acts hidden inside it.
+ */
+import { useEffect, useLayoutEffect, useState } from "react";
+
+import {
+  useMotionValueEvent,
+  useScroll,
+  useTransform,
+  useReducedMotion,
+  type MotionValue,
+} from "framer-motion";
+
+import { runFilmActs } from "@/data/publicSiteCopy";
+
+export type RunFilmMode = "scrub" | "stepped";
+
+/** Act indices by name, so timing is written against names, not magic numbers. */
+export const ACT = {
+  capture: 0,
+  testbed: 1,
+  decision: 2,
+  claims: 3,
+  routing: 4,
+  measurement: 5,
+  envelope: 6,
+} as const;
+
+export const LAST_ACT = runFilmActs.length - 1;
+
+/**
+ * The pinned telling is only offered where the whole machine fits on one screen.
+ *
+ * Below 1024px the stage has no second column and scroll-jacking a phone is not
+ * acceptable either way. The height bound is measured, not guessed: the pinned
+ * stage needs 661px plus 112px of padding to clear the sticky site header, so
+ * anything shorter would silently clip a caption. Under that, stepping is not a
+ * degraded experience — it is the correct one.
+ */
+const SCRUB_QUERY = "(min-width: 1024px) and (min-height: 780px)";
+
+/**
+ * Runs before paint on the client and is a no-op during prerender, so choosing
+ * the mode never flashes and never moves the scroll position out from under the
+ * reader.
+ */
+const useIsomorphicLayoutEffect = typeof window !== "undefined" ? useLayoutEffect : useEffect;
+
+/**
+ * useRunFilmMode — `stepped` until the client can prove otherwise, then whichever
+ * telling this viewport and this reader's motion preference should get. Tracks
+ * both signals live, so a resize or an OS preference change re-decides.
+ */
+export function useRunFilmMode(): RunFilmMode {
+  const shouldReduce = useReducedMotion();
+  const [roomy, setRoomy] = useState(false);
+
+  useIsomorphicLayoutEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") return;
+    const query = window.matchMedia(SCRUB_QUERY);
+    const sync = () => setRoomy(query.matches);
+    sync();
+    query.addEventListener("change", sync);
+    return () => query.removeEventListener("change", sync);
+  }, []);
+
+  return roomy && !shouldReduce ? "scrub" : "stepped";
+}
+
+export interface ActProgress {
+  /** Continuous position in act-space, 0 through LAST_ACT (and a little past). */
+  act: MotionValue<number>;
+  /** The act currently on screen, as an integer, for the caption and stepper. */
+  active: number;
+}
+
+/**
+ * useActProgress — maps a scroll track's progress onto act-space.
+ *
+ * The timeline deliberately runs a little past `LAST_ACT`: elements on the final
+ * act are staggered, so the value has to clear `LAST_ACT + stagger` for the last
+ * of them to finish. `active` stays clamped to a real act index.
+ */
+export function useActProgress(trackRef: React.RefObject<HTMLElement>): ActProgress {
+  const { scrollYProgress } = useScroll({
+    target: trackRef,
+    offset: ["start start", "end end"],
+  });
+  // Dead space at each end so the first and last acts can be read without the
+  // film immediately moving on.
+  const act = useTransform(scrollYProgress, [0.03, 0.9], [0, LAST_ACT + 0.4]);
+  const [active, setActive] = useState(0);
+
+  useMotionValueEvent(act, "change", (value) => {
+    const next = Math.min(LAST_ACT, Math.max(0, Math.round(value)));
+    setActive((current) => (current === next ? current : next));
+  });
+
+  return { act, active };
+}

--- a/client/src/data/publicSiteCopy.ts
+++ b/client/src/data/publicSiteCopy.ts
@@ -310,39 +310,6 @@ export const siteOperatorControls = [
 
 /* ------------------------------------------------------ how-it-works page */
 
-export const howItWorksSteps = [
-  {
-    title: "Say what you need to decide",
-    body:
-      "The question, the claims under it, the threshold and its units, what a wrong yes would cost, how much risk is acceptable, your budget and deadline, what evidence already exists, and anything we may not do.",
-  },
-  {
-    title: "Bind the run to a testbed",
-    body:
-      "One exact testbed ID, version, and digest. Raw capture stays the source of truth — derived evidence never quietly gets promoted to fact.",
-  },
-  {
-    title: "Route every claim separately",
-    body:
-      "Geometry, real observations, simulation, world models, provider tools, physical tests: each claim gets the cheapest one strong enough. Choosing is our job.",
-  },
-  {
-    title: "Measure and combine honestly",
-    body:
-      "Each method reports what it measured, under what conditions, how sure it is, and where methods disagreed. Disagreement is reported, not averaged away.",
-  },
-  {
-    title: "Return the answer and its edges",
-    body:
-      "Yes, no, partly, or not yet. Unknown states fail closed, and a refusal to decide is never converted into a winner by comparing raw scores.",
-  },
-  {
-    title: "Name the next cheapest test",
-    body:
-      "When the evidence falls short, the run says what would close the gap and whether that means real hardware.",
-  },
-] as const;
-
 export const howItWorksSplit = {
   blueprint: [
     "Secure intake and who is allowed to see what",
@@ -547,3 +514,171 @@ export const closingCta = {
   body:
     "The site-task, the call you are about to make, the threshold it turns on, and anything we may not do. We will come back with the evidence plan and the quote.",
 } as const;
+
+/* ------------------------------------------------------------- run film */
+
+/**
+ * Script for "The Run Film" — the scroll-driven motion graphic that shows one
+ * Task Evaluation Run end to end instead of describing it.
+ *
+ * Three rules govern this block, and they are acceptance criteria rather than
+ * preferences:
+ *
+ *   - `label` is at most 8 words; `caption` is at most 22 words, and each
+ *     caption carries its own count. A caption that needs more than 22 words is
+ *     a caption trying to carry two acts — split the act, do not raise the cap.
+ *   - Plain language leads and the internal term follows. `caption` is what a
+ *     visitor who has never heard of a Task Evaluation Run reads; `term` is the
+ *     small mono chip beneath it. Never the reverse.
+ *   - `actor` says who did this. Two acts are the buyer's; the rest are ours,
+ *     and that split is the point — method selection is the last thing a buyer
+ *     should be holding.
+ *
+ * No provider, model, or vendor name appears here, and no metric, count, or
+ * customer is invented. The intervals and verdicts the film draws come from
+ * `homeClaims` above, so the film and the claim-threshold chart cannot drift.
+ */
+export interface RunFilmAct {
+  /** Stable key, used for React keys, the stepper, and tests. */
+  id: string;
+  /** The act's on-screen name. At most 8 words. */
+  label: string;
+  /** The one caption for this act. At most 22 words. */
+  caption: string;
+  /** The internal term, shown as a small mono chip under the human words. */
+  term: string;
+  /** Who performed this act. Rendered as a persistent side-marker. */
+  actor: "You" | "Blueprint";
+}
+
+export const runFilmActs: readonly RunFilmAct[] = [
+  {
+    id: "capture",
+    label: "One real site-task",
+    // 17 words.
+    caption:
+      "You bring one real job at one real site. We capture the place exactly as it is.",
+    term: "capture bundle",
+    actor: "You",
+  },
+  {
+    id: "testbed",
+    label: "The testbed we keep",
+    // 19 words.
+    caption:
+      "The capture becomes a testbed we version, pin, and maintain, so today's answer and next quarter's stay comparable.",
+    term: "maintained site-task testbed",
+    actor: "Blueprint",
+  },
+  {
+    id: "decision",
+    label: "The decision you are making",
+    // 19 words.
+    caption:
+      "Not “run a benchmark.” The actual call, the threshold it turns on, and what a wrong yes would cost.",
+    term: "decision request",
+    actor: "You",
+  },
+  {
+    id: "claims",
+    label: "One decision, several claims",
+    // 18 words.
+    caption:
+      "The decision splits into claims that can each be tested — and can each be wrong — on their own.",
+    term: "claim decomposition",
+    actor: "Blueprint",
+  },
+  {
+    id: "routing",
+    label: "Each claim finds its evidence",
+    // 19 words.
+    caption:
+      "Each claim goes to the cheapest evidence that is strong enough. You never pick the method — that is our job.",
+    term: "evidence plan",
+    actor: "Blueprint",
+  },
+  {
+    id: "measurement",
+    label: "What came back",
+    // 19 words.
+    caption:
+      "Every method reports what it measured, under what conditions, and how sure it is. Disagreement is reported, never averaged away.",
+    term: "normalised results",
+    actor: "Blueprint",
+  },
+  {
+    id: "envelope",
+    label: "The answer and its edges",
+    // 20 words.
+    caption:
+      "Supported, ruled out, or not yet. A claim the evidence cannot carry stays open — it is never rounded into a win.",
+    term: "decision envelope",
+    actor: "Blueprint",
+  },
+];
+
+/**
+ * The evidence ladder the film's claims climb, cheapest first. Cost order is
+ * not authority order: real capture stays the reference every derived method is
+ * checked against, which is why `basis` is carried separately from position.
+ */
+export const runFilmRungs: readonly { label: string; basis: EvidenceRung["basis"] }[] = [
+  { label: "Geometry and reach", basis: "Computed from capture" },
+  { label: "Recorded real observations", basis: "Real capture" },
+  { label: "Simulated rollouts", basis: "Derived" },
+  { label: "Generated and model-based evidence", basis: "Derived" },
+  { label: "Evidence from real hardware", basis: "Real world" },
+];
+
+export interface RunFilmRoute {
+  /** Short form of the claim, so a narrow row stays readable. At most 8 words. */
+  short: string;
+  /** Index into `runFilmRungs` the claim's evidence was actually taken from. */
+  rung: number;
+  /**
+   * A rung this claim was refused, if any. A method is only used where it has
+   * been qualified for that kind of claim, and being cheaper never overrides
+   * that — this is the gate that makes the third claim end unresolved.
+   */
+  gate?: { rung: number; reason: string };
+  /** Rung that would settle a claim the evidence could not close. */
+  nextTest?: number;
+  /** The claim, its interval and its verdict — shared with the other figures. */
+  claim: ClaimInterval;
+}
+
+export const runFilmRoutes: readonly RunFilmRoute[] = [
+  { short: "Can it reach the fixture?", rung: 0, claim: homeClaims[0] },
+  { short: "Does it clear the dock door?", rung: 1, claim: homeClaims[1] },
+  {
+    short: "Is A better than B here?",
+    rung: 2,
+    gate: {
+      rung: 3,
+      reason: "Not qualified as proof for a head-to-head claim — support only",
+    },
+    nextTest: 4,
+    claim: homeClaims[2],
+  },
+];
+
+/**
+ * The decision the film follows, and the two things an envelope never grants.
+ *
+ * The stamps are not marketing framing. `DecisionEnvelope` fails validation
+ * unless both `deployment_approval` and `safety_certification` are false, so
+ * this is a contract-level guarantee rather than a promise — which is exactly
+ * why it belongs on the public page.
+ */
+export const runFilmDecision = {
+  question: "Should candidate A do this job at this site?",
+  metricLabel: "success rate",
+} as const;
+
+export const runFilmStamps: readonly { label: string; value: string }[] = [
+  { label: "Deployment approval", value: "No" },
+  { label: "Safety certification", value: "No" },
+];
+
+export const runFilmStampNote =
+  "A run never grants either one. Both stay external, and the contract refuses an envelope that claims otherwise.";

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -5,10 +5,10 @@ import {
   EvidenceLadderChart,
   DecisionShiftCompare,
   OutcomeSpectrum,
-  RunLifecycleRail,
   StatRow,
 } from "@/components/site/figures";
 import { Reveal } from "@/components/site/motion";
+import { RunFilm } from "@/components/site/runFilm";
 import {
   Band,
   ClosingCta,
@@ -28,7 +28,6 @@ import {
   homeDecisionCost,
   homeEvidenceRungs,
   homeHero,
-  homeLifecycle,
   homeLimits,
   homeOutcomes,
   homeStats,
@@ -129,12 +128,11 @@ export default function Home() {
           <SectionHeader
             index="03"
             eyebrow="How a run moves"
-            title="Five moves from a real task to an answer."
+            title="Seven moves from a real task to an answer."
             lede="Nothing here asks you to design an evaluation. You bring the job and the decision; the substrate and the method are ours to get right."
           />
-          <div className="mt-16">
-            <RunLifecycleRail stages={homeLifecycle} />
-          </div>
+          {/* The compact cut of the run film, in place of the static rail. */}
+          <RunFilm variant="compact" className="mt-16" />
         </Inner>
       </Band>
 

--- a/client/src/pages/HowItWorks.tsx
+++ b/client/src/pages/HowItWorks.tsx
@@ -1,7 +1,8 @@
 import { SEO } from "@/components/SEO";
 import { ProofBoundary } from "@/components/blueprint";
 import { ClaimThresholdChart, EvidenceLadderChart } from "@/components/site/figures";
-import { Reveal, ScrollProgressRail } from "@/components/site/motion";
+import { Reveal } from "@/components/site/motion";
+import { RunFilm } from "@/components/site/runFilm";
 import {
   Band,
   ClosingCta,
@@ -19,7 +20,6 @@ import {
   homeEvidenceRungs,
   homeLimits,
   howItWorksSplit,
-  howItWorksSteps,
 } from "@/data/publicSiteCopy";
 import { breadcrumbJsonLd, webPageJsonLd } from "@/lib/seoStructuredData";
 
@@ -48,7 +48,7 @@ export default function HowItWorks() {
 
       <PageHero
         eyebrow="How it works"
-        title="Six steps, and one of them is allowed to say no."
+        title="Seven moves, and one of them is allowed to say no."
         body="One real site-task becomes a testbed we keep. One decision becomes an evidence plan built claim by claim. What comes back is an answer with its edges drawn — not a backend you chose and not a ranking we owed you."
         ctaHref={runHref}
         ctaLabel="Request a Task Evaluation Run"
@@ -60,48 +60,18 @@ export default function HowItWorks() {
         routeTrace
       />
 
-      {/* Stepped walkthrough, bound together by a scroll-tracked rail. */}
+      {/* 01 — the run film. This replaces the stepped prose list rather than
+          adding to it: the acts are the steps, and a newcomer retains the
+          machine working far better than six numbered paragraphs. */}
       <Band tone="canvas">
         <Inner className="py-20 lg:py-28">
           <SectionHeader
             index="01"
             eyebrow="The walkthrough"
             title="What actually happens, in order."
-            lede="Two of these steps are yours. The rest are ours, and the split is deliberate: the hardest judgement in evaluation is method selection, and that is the last thing a buyer should be holding."
+            lede="Two of these are yours. The rest are ours, and the split is deliberate: the hardest judgement in evaluation is method selection, and that is the last thing a buyer should be holding."
           />
-
-          <ScrollProgressRail className="mt-16 pl-8 sm:pl-12" railClassName="left-0">
-            <ol className="flex flex-col gap-14">
-              {howItWorksSteps.map((step, index) => (
-                <Reveal as="li" key={step.title} from="up" distance={20}>
-                  <div className="relative">
-                    <span
-                      className="absolute -left-8 top-1 flex h-3 w-3 items-center justify-center sm:-left-12"
-                      aria-hidden="true"
-                    >
-                      <span className="h-2.5 w-2.5 rounded-full bg-brass-deep ring-4 ring-canvas" />
-                    </span>
-                    {/* Heading and body sit side by side from lg up so the
-                        stepped list uses the full measure instead of leaving
-                        half the page empty. */}
-                    <div className="grid gap-x-12 gap-y-4 lg:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)]">
-                      <div>
-                        <span className="font-mono text-[11px] tracking-[0.2em] text-brass-deep">
-                          Step {String(index + 1).padStart(2, "0")}
-                        </span>
-                        <h3 className="mt-3 max-w-[22ch] font-display text-[clamp(1.6rem,2.6vw,2.35rem)] font-medium leading-[1.1] tracking-[-0.03em] text-ink-900">
-                          {step.title}
-                        </h3>
-                      </div>
-                      <p className="max-w-[54ch] text-[15.5px] leading-[1.75] text-ink-600 lg:self-center">
-                        {step.body}
-                      </p>
-                    </div>
-                  </div>
-                </Reveal>
-              ))}
-            </ol>
-          </ScrollProgressRail>
+          <RunFilm className="mt-14" />
         </Inner>
       </Band>
 
@@ -160,7 +130,7 @@ export default function HowItWorks() {
         <Inner className="py-20 lg:py-28">
           <SectionHeader
             index="03"
-            eyebrow="Step 03, in a picture"
+            eyebrow="Act 05, in a picture"
             title="Routing, and where it stops."
           />
           <Reveal className="mt-14">
@@ -173,7 +143,7 @@ export default function HowItWorks() {
         <Inner className="py-20 lg:py-28">
           <SectionHeader
             index="04"
-            eyebrow="Step 05, in a picture"
+            eyebrow="Act 07, in a picture"
             title="How the answer gets its edges."
           />
           <Reveal className="mt-14">
@@ -205,7 +175,7 @@ export default function HowItWorks() {
       <FullBleedMedia
         src="/redesign/pov/factory-conveyor.jpg"
         alt="A conveyor line in a working plant"
-        eyebrow="Step 06"
+        eyebrow="After the answer"
         title="Then we tell you the cheapest thing left to try."
         body="When the evidence falls short, the useful output is not an apology — it is the next experiment, its cost, and whether it can be done short of putting a robot on the floor."
       />

--- a/client/tests/components/site/PublicCopy.test.tsx
+++ b/client/tests/components/site/PublicCopy.test.tsx
@@ -42,7 +42,7 @@ describe("public real-site evaluation copy", () => {
 
     // One service, and the lifecycle that backs it.
     expect(container).toHaveTextContent(/One service\. Priced per decision\./i);
-    expect(container).toHaveTextContent(/We build the testbed/i);
+    expect(container).toHaveTextContent(/The capture becomes a testbed we version, pin, and maintain/i);
     expect(container).toHaveTextContent(/cheapest evidence that is actually good enough/i);
 
     // Refusing to decide is still stated on the page, not buried.

--- a/client/tests/components/site/RunFilm.test.tsx
+++ b/client/tests/components/site/RunFilm.test.tsx
@@ -91,6 +91,42 @@ describe("RunFilm", () => {
     expect(container).toHaveTextContent(/not yet/i);
   });
 
+  it.each([["stepped", useNarrowViewport], ["scrub", useWideViewport]])(
+    "exposes the claim-level results to assistive technology in %s mode",
+    (_mode, setViewport) => {
+      setViewport();
+      const { container } = render(<RunFilm />);
+
+      // `toHaveTextContent` ignores aria-hidden, so asserting on the container
+      // alone would pass on content a screen reader never receives. The stage is
+      // decorative; the evidence has to live outside it.
+      const accessible = [...container.querySelectorAll("div.sr-only > table")].filter(
+        (node) => node.closest('[aria-hidden="true"]') === null,
+      );
+      expect(accessible).toHaveLength(1);
+      const summary = accessible[0] as HTMLElement;
+
+      for (const route of runFilmRoutes) {
+        const row = within(summary).getByRole("rowheader", { name: route.short });
+        expect(row).toBeInTheDocument();
+      }
+      // Verdict, routed rung, basis, refusal reason and next test all reachable.
+      for (const label of ["Supported", "Rejected", "Unresolved"]) {
+        expect(summary).toHaveTextContent(label);
+      }
+      const gated = runFilmRoutes.find((route) => route.gate)!;
+      expect(summary).toHaveTextContent(gated.gate!.reason.slice(0, 40));
+      expect(summary).toHaveTextContent(/Next test that would settle it/i);
+      expect(summary).toHaveTextContent(runFilmRungs[gated.rung].label);
+      expect(summary).toHaveTextContent(runFilmRungs[gated.rung].basis);
+
+      // `sr-only` on a <table> does not contain it — a table's intrinsic
+      // minimum width beats `width: 1px` and blows out horizontal scroll.
+      expect(container.querySelector("table.sr-only")).toBeNull();
+      expect(summary.parentElement).toHaveClass("sr-only");
+    },
+  );
+
   it("shows each claim stopping at its own rung, and one being refused a rung", () => {
     useNarrowViewport();
     const { container } = render(<RunFilm />);

--- a/client/tests/components/site/RunFilm.test.tsx
+++ b/client/tests/components/site/RunFilm.test.tsx
@@ -1,0 +1,189 @@
+import { render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { RunFilm } from "@/components/site/runFilm";
+import {
+  runFilmActs,
+  runFilmRoutes,
+  runFilmRungs,
+  runFilmStamps,
+} from "@/data/publicSiteCopy";
+import { ACT, LAST_ACT } from "@/components/site/runFilm/useActProgress";
+
+/**
+ * Pins which telling the film picks. jsdom reports a 1024px-wide window, so the
+ * default there is the scrubbing telling — the stepped one has to be asked for
+ * explicitly rather than assumed.
+ */
+function stubViewport(matches: boolean) {
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn().mockImplementation((query: string) => ({
+      matches,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  );
+}
+
+/** The prerender / phone / reduced-motion path. */
+const useNarrowViewport = () => stubViewport(false);
+/** The pinned, scroll-driven path. */
+const useWideViewport = () => stubViewport(true);
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("RunFilm", () => {
+  it("tells the whole story with no scrolling, no JavaScript-driven reveal, and no motion", () => {
+    useNarrowViewport();
+    const { container } = render(<RunFilm />);
+
+    expect(container.querySelector('[data-run-film="stepped"]')).toBeTruthy();
+    expect(container.querySelector('[data-run-film="scrub"]')).toBeNull();
+
+    // Every act's caption is present as real text, without any scroll.
+    expect(runFilmActs).toHaveLength(7);
+    for (const filmAct of runFilmActs) {
+      expect(container).toHaveTextContent(filmAct.caption);
+      expect(screen.getAllByText(filmAct.label, { exact: false }).length).toBeGreaterThan(0);
+    }
+  });
+
+  it("marks its schematic values as illustrative", () => {
+    useNarrowViewport();
+    render(<RunFilm />);
+    expect(screen.getAllByText(/^Illustrative$/i).length).toBeGreaterThan(0);
+  });
+
+  it("states that a run grants neither deployment approval nor safety certification", () => {
+    useNarrowViewport();
+    const { container } = render(<RunFilm />);
+
+    // The contract-level guarantee: DecisionEnvelope fails validation unless
+    // both of these are false, so both must be legible on the page.
+    expect(runFilmStamps.map((stamp) => stamp.label)).toEqual([
+      "Deployment approval",
+      "Safety certification",
+    ]);
+    for (const stamp of runFilmStamps) {
+      expect(container).toHaveTextContent(new RegExp(`${stamp.label}\\s*No`, "i"));
+    }
+
+    // And it is readable, not buried in the decorative stage.
+    const limits = screen.getAllByText(/Deployment approval/i);
+    expect(limits.some((node) => node.closest('[aria-hidden="true"]') === null)).toBe(true);
+  });
+
+  it("carries every verdict as a word, never as colour alone", () => {
+    useNarrowViewport();
+    const { container } = render(<RunFilm />);
+    for (const label of ["Supported", "Rejected", "Unresolved"]) {
+      expect(container).toHaveTextContent(new RegExp(`^${label}$`.replace(/[$^]/g, ""), "i"));
+    }
+    // Abstention is a named outcome in the film's own words, not an omission.
+    expect(container).toHaveTextContent(/not yet/i);
+  });
+
+  it("shows each claim stopping at its own rung, and one being refused a rung", () => {
+    useNarrowViewport();
+    const { container } = render(<RunFilm />);
+
+    // The three claims are routed to three different rungs — the thing prose
+    // cannot show. If they ever collapse to one rung the film loses its point.
+    const rungs = runFilmRoutes.map((route) => route.rung);
+    expect(new Set(rungs).size).toBe(runFilmRoutes.length);
+
+    // Exactly one claim is turned away at a gate, and the reason is on screen.
+    const gated = runFilmRoutes.filter((route) => route.gate);
+    expect(gated).toHaveLength(1);
+    expect(container).toHaveTextContent(new RegExp(gated[0].gate!.reason.slice(0, 40), "i"));
+
+    // Cost order is not authority order: the basis of the rung is stated, so a
+    // cheaper rung is never read as a weaker standard of proof.
+    expect(container).toHaveTextContent(/Real capture/i);
+    expect(container).toHaveTextContent(/Computed from capture/i);
+
+    // An unresolved claim carries the next test that would settle it.
+    const unresolved = runFilmRoutes.find((route) => route.nextTest !== undefined);
+    expect(unresolved).toBeDefined();
+    expect(container).toHaveTextContent(
+      new RegExp(runFilmRungs[unresolved!.nextTest!].label, "i"),
+    );
+  });
+
+  it("names no provider, model, or vendor", () => {
+    useNarrowViewport();
+    const { container } = render(<RunFilm />);
+    const text = container.textContent ?? "";
+    for (const forbidden of [
+      "NVIDIA", "Isaac", "Cosmos", "OpenAI", "GPT", "Gemini", "Claude", "Anthropic",
+      "Unreal", "Unity", "MuJoCo", "Genesis", "Luma", "Polycam", "Matterport",
+    ]) {
+      expect(text).not.toMatch(new RegExp(forbidden, "i"));
+    }
+  });
+
+  it("gives the act stepper an accessible name for every act, plus a replay control", () => {
+    useWideViewport();
+    const { container } = render(<RunFilm />);
+
+    expect(container.querySelector('[data-run-film="scrub"]')).toBeTruthy();
+
+    const stepper = screen.getByRole("navigation", { name: /acts of the run/i });
+    runFilmActs.forEach((filmAct, index) => {
+      const button = within(stepper).getByRole("button", {
+        name: new RegExp(`Act ${index + 1}:\\s*${filmAct.label}`, "i"),
+      });
+      expect(button).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole("button", { name: /replay/i })).toBeInTheDocument();
+  });
+
+  it("keeps the act list reachable even while the film is scrubbing", () => {
+    useWideViewport();
+    const { container } = render(<RunFilm />);
+    for (const filmAct of runFilmActs) {
+      expect(container).toHaveTextContent(filmAct.caption);
+    }
+    expect(container).toHaveTextContent(/Deployment approval/i);
+  });
+
+  it("keeps act indices and the script in the same order", () => {
+    // The film's timing is written against ACT.*; if the script is reordered
+    // without updating these, every act animates at the wrong moment.
+    expect(runFilmActs.map((filmAct) => filmAct.id)).toEqual([
+      "capture", "testbed", "decision", "claims", "routing", "measurement", "envelope",
+    ]);
+    expect(ACT.capture).toBe(0);
+    expect(ACT.envelope).toBe(LAST_ACT);
+    expect(LAST_ACT).toBe(runFilmActs.length - 1);
+  });
+
+  it("keeps every caption inside the 22-word budget and every label inside 8", () => {
+    // This is an acceptance criterion from the film's brief, not a style note:
+    // a caption that needs more than 22 words is carrying two acts.
+    for (const filmAct of runFilmActs) {
+      expect(filmAct.caption.trim().split(/\s+/).length).toBeLessThanOrEqual(22);
+      expect(filmAct.label.trim().split(/\s+/).length).toBeLessThanOrEqual(8);
+    }
+    for (const route of runFilmRoutes) {
+      expect(route.short.trim().split(/\s+/).length).toBeLessThanOrEqual(8);
+    }
+  });
+
+  it("renders the compact cut from the same script", () => {
+    useNarrowViewport();
+    const { container } = render(<RunFilm variant="compact" />);
+    for (const filmAct of runFilmActs) {
+      expect(container).toHaveTextContent(filmAct.caption);
+    }
+  });
+});

--- a/client/tests/pages/Home.test.tsx
+++ b/client/tests/pages/Home.test.tsx
@@ -4,7 +4,7 @@ import Home from "@/pages/Home";
 
 describe("Home", () => {
   it("renders one Task Evaluation Run lifecycle with abstention and one primary CTA", () => {
-    render(<Home />);
+    const { container } = render(<Home />);
     expect(
       screen.getByRole("heading", { level: 1, name: /Answer it before you send a robot/i }),
     ).toBeInTheDocument();
@@ -12,11 +12,17 @@ describe("Home", () => {
       screen.getAllByRole("link", { name: /Request a Task Evaluation Run/i }).length,
     ).toBeGreaterThan(0);
 
-    // The lifecycle still reads task -> maintained testbed -> routed evidence -> answer.
-    expect(screen.getByText(/^Bring one real task$/i)).toBeInTheDocument();
-    expect(screen.getByText(/^We build the testbed$/i)).toBeInTheDocument();
-    expect(screen.getByText(/^We route each claim$/i)).toBeInTheDocument();
-    expect(screen.getByText(/^You get an answer with its limits$/i)).toBeInTheDocument();
+    // The lifecycle still reads task -> maintained testbed -> routed evidence ->
+    // answer. Section 03 now tells it as the run film rather than a static rail,
+    // so these assert the film's own act copy.
+    expect(container).toHaveTextContent(/You bring one real job at one real site/i);
+    expect(container).toHaveTextContent(/The capture becomes a testbed we version, pin, and maintain/i);
+    expect(container).toHaveTextContent(/Each claim goes to the cheapest evidence that is strong enough/i);
+    expect(container).toHaveTextContent(/Supported, ruled out, or not yet/i);
+
+    // A run grants neither of these, and the contract enforces it.
+    expect(container).toHaveTextContent(/Deployment approval/i);
+    expect(container).toHaveTextContent(/Safety certification/i);
 
     // Abstention is still a first-class, named outcome.
     expect(screen.getByText(/^Not yet$/i)).toBeInTheDocument();
@@ -40,9 +46,9 @@ describe("Home", () => {
     const figures = container.querySelectorAll("figure");
     expect(figures.length).toBeGreaterThanOrEqual(3);
 
-    // The two figures that plot schematic values must both carry the marker, so
-    // neither can be read as live run data. The qualitative before/after
-    // comparison plots nothing and needs none.
-    expect(screen.getAllByText(/^Illustrative$/i).length).toBe(2);
+    // The two figures that plot schematic values must carry the marker, and so
+    // must the run film, so none of the three can be read as live run data. The
+    // qualitative before/after comparison plots nothing and needs none.
+    expect(screen.getAllByText(/^Illustrative$/i).length).toBe(3);
   });
 });

--- a/client/tests/pages/HowItWorks.test.tsx
+++ b/client/tests/pages/HowItWorks.test.tsx
@@ -4,23 +4,30 @@ import HowItWorks from "@/pages/HowItWorks";
 
 describe("HowItWorks", () => {
   it("shows decision-oriented intake, routing owned by the pipeline, abstention, and the next experiment", () => {
-    render(<HowItWorks />);
+    const { container } = render(<HowItWorks />);
     expect(
-      screen.getByRole("heading", { level: 1, name: /Six steps, and one of them is allowed to say no/i }),
+      screen.getByRole("heading", { level: 1, name: /Seven moves, and one of them is allowed to say no/i }),
     ).toBeInTheDocument();
 
-    expect(screen.getByRole("heading", { name: /Say what you need to decide/i })).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: /Route every claim separately/i })).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: /Return the answer and its edges/i })).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: /Name the next cheapest test/i })).toBeInTheDocument();
+    // The walkthrough is now the run film. Its acts carry the same beats the
+    // stepped prose list used to: the decision, per-claim routing, the answer
+    // with its edges, and the next cheapest test.
+    expect(container).toHaveTextContent(/The actual call, the threshold it turns on/i);
+    expect(container).toHaveTextContent(/The decision splits into claims/i);
+    expect(container).toHaveTextContent(/Supported, ruled out, or not yet/i);
+    expect(container).toHaveTextContent(/Next test/i);
 
-    // The customer does not choose the evidence backend, and the split says so.
-    expect(screen.getByText(/Choosing is our job/i)).toBeInTheDocument();
+    // The customer does not choose the evidence backend, and the film says so.
+    expect(container).toHaveTextContent(/You never pick the method — that is our job/i);
     expect(screen.getByRole("heading", { name: /The pipeline owns the verdict/i })).toBeInTheDocument();
     expect(screen.getByText(/including the decision to abstain/i)).toBeInTheDocument();
 
     // Unknown states fail closed rather than defaulting to a pass.
     expect(screen.getAllByText(/Unknown states fail closed/i).length).toBeGreaterThan(0);
+
+    // The two things a run never grants, stated on the page.
+    expect(container).toHaveTextContent(/Deployment approval/i);
+    expect(container).toHaveTextContent(/Safety certification/i);
 
     expect(
       screen.getAllByRole("link", { name: /Request a Task Evaluation Run/i })[0],

--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -23,9 +23,22 @@ test('homepage leads with the single Task Evaluation Run story', async ({ page }
   await expect(
     page.locator('main').getByText(/One service\. Priced per decision\./i),
   ).toBeVisible();
-  await expect(page.getByText(/^Bring one real task$/i)).toBeVisible();
-  await expect(page.getByText(/^We build the testbed$/i)).toBeVisible();
-  await expect(page.getByText(/^You get an answer with its limits$/i)).toBeVisible();
+  // Section 03 tells the lifecycle as the run film rather than a static rail, so
+  // these assert the film's act copy. `.first()` because each caption appears
+  // both on the stage and in the film's screen-reader act list.
+  await expect(
+    page.getByText(/You bring one real job at one real site/i).first(),
+  ).toBeVisible();
+  await expect(
+    page.getByText(/The capture becomes a testbed we version, pin, and maintain/i).first(),
+  ).toBeVisible();
+  await expect(
+    page.getByText(/Supported, ruled out, or not yet/i).first(),
+  ).toBeVisible();
+
+  // The two things a run never grants. Contract-enforced, so it is stated.
+  await expect(page.getByText(/Deployment approval/i).first()).toBeVisible();
+  await expect(page.getByText(/Safety certification/i).first()).toBeVisible();
 
   // Declining to decide is stated on the page, not implied.
   await expect(page.getByText(/A run is allowed to tell you it cannot tell you/i)).toBeVisible();


### PR DESCRIPTION
## What this is

One scroll-driven motion graphic — "The Run Film" — that plays a real site-task through the pipeline end to end: capture → maintained testbed → decision → claim decomposition → evidence routing → measurement → decision envelope.

It **replaces** the stepped prose list on `/how-it-works` rather than becoming an eighth section (section count unchanged), and **replaces** the static `RunLifecycleRail` on Home section 03 with a compact cut of the same seven acts. DOM + SVG with framer-motion. **No new dependencies.**

`homeLifecycle` and `RunLifecycleRail` stay live via `ForSiteOperators`, so nothing is orphaned. `howItWorksSteps` is removed — the acts are the walkthrough now, and leaving a six-step list next to a seven-act film would let the two drift.

## The two acts that matter

**Act 5 — routing.** Three claims climb the cost ladder independently and stop at three different rungs. One is refused a rung it could have reached cheaply, with the reason on screen (*"Not qualified as proof for a head-to-head claim — support only"*), and ends unresolved carrying the next test that would settle it. Cost order is not authority order, so each rung shows its basis (`Real capture`, `Computed from capture`, `Derived`).

**Act 7 — the envelope.** Three verdicts, one of them unresolved, and the two things a run never grants: **Deployment approval — No**, **Safety certification — No**. `DecisionEnvelope` fails validation unless both are false, so this is contract-enforced rather than promised.

## Two tellings

| | when | behaviour |
|---|---|---|
| **stepped** | prerender, every phone, reduced motion | nothing pins, nothing behind a gesture |
| **scrub** | `(min-width: 1024px) and (min-height: 780px)` | pinned stage, act stepper, replay |

The scrub gate is **measured, not guessed**: the stage needs 661px plus 112px of sticky-header clearance. Below that a caption would be silently clipped, so stepping is the correct telling rather than a degraded one. Verified clean at all 8 sample points at 1440×900, 1512×982, and the 1024×780 boundary.

## Truth constraints

I only received part of the handoff doc (see *Notes* below), so this checklist is reconstructed from the sections I did have (5c, 5d, 7) rather than quoted from 5a.

- **No provider, model, or vendor name** — enforced by a test asserting 15 forbidden names are absent.
- **Cost order is not authority order** — every rung renders its `basis` beside its label.
- **Raw capture persists behind the testbed** — the testbed frame is drawn *around* the capture points, which stay visible, so nothing derived reads as promoted.
- **Abstention has equal weight** — unresolved is a full verdict with an icon, a word, and its next test; act 7's caption names it.
- **No invented values** — the testbed pin says "version and digest pinned" rather than fabricating a hash. Claim intervals and verdicts are imported from `homeClaims`, so the film and the claim-threshold chart cannot drift.
- **Schematic values marked** — the screen carries the same visible `Illustrative` marker the charts do.
- **Status never colour-alone** — every verdict and the gate ship an icon *and* a text label.
- **Brass never a data colour** — accent/muted pair and the reserved status scale only, per the `figures.tsx` palette rationale.
- **≤22-word captions, ≤8-word labels** — enforced by a test; each caption carries its count inline in `publicSiteCopy.ts`.
- **All copy in `publicSiteCopy.ts`** — zero hardcoded words in `acts.tsx`.

## Verification

```
npm run check                    clean
npm run test:coverage            353 files, 1783 tests passed
npm run build                    succeeded (prerender renders the real HowItWorks)
npx playwright test e2e/home.spec.ts e2e/brand-polish.spec.ts    2 passed
RunFilm.test.tsx                 11 passed
```

**Prerender / no-JS** — with JavaScript disabled against `dist/public/how-it-works/index.html`: all 7 act captions present, both stamps present, all 3 verdicts present, gate reason present, `data-run-film="stepped"` only (no pinned stage in static HTML), old stepped list gone.

**Mode selection** — desktop 1440×900 → scrub; mobile 390×844 → stepped; reduced-motion → stepped at both viewports.

**Performance** — median DCL 204ms (`/`) and 191ms (`/how-it-works`) against the production build; a 41-step scrub of the film produced **0 long tasks**. Transforms and opacity only.

`npm run perf:pages` could not run — the script hardcodes a macOS Chrome path and has no env override, so it fails on Linux. I measured the two routes directly instead rather than modify unrelated tooling in this PR.

## Pre-existing failures (not from this change)

`npm run test:e2e` has 3 failures in the authenticated-intake lane:

- `capture-task-review.spec.ts:5`
- `task-evaluation-run.spec.ts:101`
- `task-evaluation-run.spec.ts:121`

I confirmed these are pre-existing by stashing every change and re-running the same lane on a clean tree — **identical 3 failures**. They need Firebase/authenticated fixtures this container doesn't have. They touch pages this PR does not modify.

## Copy changes worth a second look

1. Hero: *"Six steps, and one of them is allowed to say no"* → *"**Seven moves**, and one of them is allowed to say no."* Home 03: *"Five moves"* → *"Seven moves."* The film shows seven acts; leaving the old counts would have been plainly wrong. The line's structure is preserved. **Flagging because the handoff calls that hero line the best on the site.**
2. `"Step 03/05/06, in a picture"` eyebrows pointed at the deleted numbered list; they now point at acts.
3. `e2e/home.spec.ts:27` anchored an exact match on `"We build the testbed"`, which only `RunLifecycleRail` rendered. **Repointed to the film's own act copy** rather than kept alive by working the old string back into the new script — the content genuinely changed, so the assertion should follow it.

## The novice test — not run

The brief requires showing the film to someone who does not know what a Task Evaluation Run is and checking whether they can describe the machine back unprompted. **I could not run this** — it needs an actual person. Reporting that plainly rather than inventing a result. It's the one acceptance criterion still open, and worth doing before this ships.

## Notes on the handoff

`docs/research/2026-07-31-pipeline-run-film-goal-master-prompt.md` is **not in the repo** — not in the working tree, not in git history, not on `main`. I worked from the sections pasted into the session: 1, 2a, 5c–5d, 6–10. **Sections 2b, 2c, 3, 4, 5a, 5b were unavailable**, including section 3, which holds the act captions. The captions here are written to the §5d rule (≤22 words, counted) rather than taken from §3. If §3's captions exist somewhere, they should probably win over mine.

Structure follows the §6 file map, with one deviation: `acts.tsx` exports seven act renderers, but acts 4–7 compose as layers over one shared claim-row geometry rather than as seven independent scenes. Seven independent renderers would break the §5d "one continuously-visible object" law, which is the stronger of the two rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EBHERA7pWGAebCe4Mbbnv9

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBHERA7pWGAebCe4Mbbnv9)_