### PR TITLE
Lead the public site with screening, then a ranking that states its resolution

### DIFF
--- a/client/src/components/site/figures.tsx
+++ b/client/src/components/site/figures.tsx
@@ -523,8 +523,8 @@ export function ClaimThresholdChart({
 
   return (
     <Figure
-      title="Why a run can decline to pick a winner"
-      subtitle={`Each claim is read against the threshold you set. When the uncertainty interval crosses the line, the claim stays open — the point estimate is not rounded into a verdict.`}
+      title="Each claim, against the line you set"
+      subtitle={`Every claim is read against your threshold. A claim whose uncertainty interval clears the line is called; one whose interval crosses it is reported as still open, at the width it actually has.`}
       illustrative
       onInk={onInk}
       tableView={
@@ -728,6 +728,621 @@ export function ClaimThresholdChart({
         <span>
           An unresolved claim is a result, not a gap in the report. It comes with
           the reason, and the cheapest next test that would settle it.
+        </span>
+      </p>
+    </Figure>
+  );
+}
+
+/* ------------------------------------------- 3b. screening margin chart */
+
+export interface ScreeningMarginRow {
+  check: string;
+  measured: string;
+  required: string;
+  /** Measured minus required, in metres. Negative means it does not fit. */
+  marginM: number;
+  /** Calibration uncertainty on the margin, in metres. */
+  toleranceM: number;
+}
+
+type ScreeningVerdict = "clears" | "ruled_out" | "under_precision";
+
+/**
+ * Derive the verdict from the interval rather than accepting an authored one.
+ *
+ * This mirrors the Pipeline's analytic reachability adapter exactly: a margin
+ * counts only when the *whole* calibration interval sits on one side of zero.
+ * An interval that straddles zero is not a soft pass and not a soft fail — it
+ * is a measurement this capture cannot separate at its current precision, and
+ * saying so is a statement about the instrument, not about our confidence.
+ */
+function screeningVerdict(row: ScreeningMarginRow): ScreeningVerdict {
+  if (row.marginM - row.toleranceM > 0) return "clears";
+  if (row.marginM + row.toleranceM < 0) return "ruled_out";
+  return "under_precision";
+}
+
+const screeningMeta: Record<
+  ScreeningVerdict,
+  { label: string; icon: LucideIcon; fg: string; fgOnInk: string }
+> = {
+  clears: {
+    label: "Clears",
+    icon: CheckCircle2,
+    fg: verdictMeta.supported.fg,
+    fgOnInk: verdictMeta.supported.fgOnInk,
+  },
+  ruled_out: {
+    label: "Ruled out",
+    icon: XCircle,
+    fg: verdictMeta.rejected.fg,
+    fgOnInk: verdictMeta.rejected.fgOnInk,
+  },
+  under_precision: {
+    label: "Under capture precision",
+    icon: MinusCircle,
+    fg: verdictMeta.unresolved.fg,
+    fgOnInk: verdictMeta.unresolved.fgOnInk,
+  },
+};
+
+const signedMetres = (value: number) =>
+  `${value > 0 ? "+" : value < 0 ? "−" : ""}${Math.abs(value).toFixed(2)} m`;
+
+/**
+ * ClearanceMarginChart — the screening pass, on one signed axis in metres.
+ *
+ * This is the only figure on the public site whose rows can name a *cause*.
+ * Every value here is arithmetic over a measured place and a published robot
+ * envelope: there is no policy, no rollout, and no transfer assumption between
+ * the capture and the answer. That is the whole reason a screening row can say
+ * "misses the opening by 18 cm" while a ranking row can only say "ahead of".
+ *
+ * One measure (metres), one axis, zero at the centre. Bars use the emphasis
+ * pair rather than the status hues — verdict identity is carried by an icon and
+ * a written label per row, so nothing depends on colour.
+ */
+export function ClearanceMarginChart({
+  rows,
+  onInk = false,
+}: {
+  rows: readonly ScreeningMarginRow[];
+  onInk?: boolean;
+}) {
+  const [hovered, setHovered] = useState<string | null>(null);
+  const accent = accentFor(onInk);
+  const muted = mutedFor(onInk);
+  const surface = surfaceFor(onInk);
+
+  // Symmetric domain so zero stays centred and the two sides stay comparable.
+  const span =
+    Math.max(...rows.map((row) => Math.abs(row.marginM) + row.toleranceM), 0.01) * 1.2;
+  const x = (value: number) => 50 + (value / span) * 50;
+
+  return (
+    <Figure
+      title="What the building will not take"
+      subtitle="Measured minus required, in metres, with the calibration uncertainty on each. A bar has to clear zero by its whole interval to count."
+      illustrative
+      onInk={onInk}
+      tableView={
+        <table className="w-full text-left text-[13px]">
+          <caption className="sr-only">
+            Per-check measured value, requirement, signed margin with calibration
+            tolerance, and the resulting screening verdict
+          </caption>
+          <thead>
+            <tr className={onInk ? "text-ink-300" : "text-ink-500"}>
+              <th scope="col" className="py-1 pr-4 font-semibold">Check</th>
+              <th scope="col" className="py-1 pr-4 font-semibold">Measured</th>
+              <th scope="col" className="py-1 pr-4 font-semibold">Required</th>
+              <th scope="col" className="py-1 pr-4 font-semibold">Margin</th>
+              <th scope="col" className="py-1 font-semibold">Verdict</th>
+            </tr>
+          </thead>
+          <tbody className={onInk ? "text-ink-200" : "text-ink-700"}>
+            {rows.map((row) => (
+              <tr
+                key={row.check}
+                className={onInk ? "border-t border-white/10" : "border-t border-line-soft"}
+              >
+                <th scope="row" className="py-2 pr-4 font-medium">{row.check}</th>
+                <td className="py-2 pr-4">{row.measured}</td>
+                <td className="py-2 pr-4">{row.required}</td>
+                <td className="py-2 pr-4 font-mono">
+                  {signedMetres(row.marginM)} ± {row.toleranceM.toFixed(2)}
+                </td>
+                <td className="py-2">{screeningMeta[screeningVerdict(row)].label}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      }
+    >
+      <div
+        className={cn(
+          "mb-5 flex flex-wrap items-center gap-x-5 gap-y-2 text-[12px]",
+          onInk ? "text-ink-300" : "text-ink-500",
+        )}
+      >
+        <span className="inline-flex items-center gap-2">
+          <svg width="18" height="8" aria-hidden="true">
+            <rect x="0" y="1" width="12" height="6" rx="1" fill={muted} />
+            <line x1="12" y1="4" x2="18" y2="4" stroke={muted} strokeWidth="2" strokeLinecap="round" />
+          </svg>
+          Margin, with calibration tolerance
+        </span>
+        <span className="inline-flex items-center gap-2">
+          <svg width="10" height="10" aria-hidden="true">
+            <line
+              x1="5"
+              y1="0"
+              x2="5"
+              y2="10"
+              stroke={onInk ? "#f3efe6" : "#0d0d0b"}
+              strokeWidth="1.5"
+            />
+          </svg>
+          Zero · exactly fits
+        </span>
+      </div>
+
+      {/* Scale reference: the two ends and the centre. */}
+      <div className="relative mb-1 h-4" aria-hidden="true">
+        <span
+          className={cn("absolute top-0 font-mono text-[10px]", onInk ? "text-ink-400" : "text-ink-400")}
+          style={{ left: 0 }}
+        >
+          −{span.toFixed(2)} m
+        </span>
+        <span
+          className={cn(
+            "absolute top-0 font-mono text-[10px] font-semibold",
+            onInk ? "text-[color:var(--text-on-ink)]" : "text-ink-900",
+          )}
+          style={{ left: "50%", transform: "translateX(-50%)" }}
+        >
+          0
+        </span>
+        <span
+          className={cn("absolute top-0 font-mono text-[10px]", onInk ? "text-ink-400" : "text-ink-400")}
+          style={{ right: 0 }}
+        >
+          +{span.toFixed(2)} m
+        </span>
+      </div>
+
+      <div className="flex flex-col gap-5">
+        {rows.map((row, index) => {
+          const verdict = screeningVerdict(row);
+          const meta = screeningMeta[verdict];
+          const VerdictIcon = meta.icon;
+          const isHovered = hovered === row.check;
+          const markColor = isHovered ? accent : muted;
+          const lowX = x(row.marginM - row.toleranceM);
+          const highX = x(row.marginM + row.toleranceM);
+          const barLeft = Math.min(x(0), x(row.marginM));
+          const barWidth = Math.abs(x(row.marginM) - x(0));
+
+          return (
+            <div
+              key={row.check}
+              tabIndex={0}
+              onMouseEnter={() => setHovered(row.check)}
+              onMouseLeave={() => setHovered(null)}
+              onFocus={() => setHovered(row.check)}
+              onBlur={() => setHovered(null)}
+              className="rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
+                <p
+                  className={cn(
+                    "max-w-[46ch] text-[13px] font-medium leading-snug",
+                    onInk ? "text-[color:var(--text-on-ink)]" : "text-ink-900",
+                  )}
+                >
+                  {row.check}
+                </p>
+                <span
+                  className="inline-flex shrink-0 items-center gap-1.5 text-[12px] font-semibold"
+                  style={{ color: onInk ? meta.fgOnInk : meta.fg }}
+                >
+                  <VerdictIcon className="h-3.5 w-3.5" aria-hidden="true" />
+                  {meta.label}
+                </span>
+              </div>
+
+              <div className="relative mt-2.5 h-9">
+                <div
+                  className="absolute inset-x-0 top-1/2 h-px"
+                  style={{ background: onInk ? "rgba(255,255,255,0.12)" : "#ebe4d7" }}
+                  aria-hidden="true"
+                />
+                {/* Zero rule — the line a margin has to clear outright. */}
+                <div
+                  className="absolute top-0 h-full w-px"
+                  style={{
+                    left: "50%",
+                    background: onInk ? "rgba(243,239,230,0.75)" : "rgba(13,13,11,0.75)",
+                  }}
+                  aria-hidden="true"
+                />
+                <GrowIn origin="left" delay={index * 0.08} className="absolute inset-0">
+                  {/* Tolerance whisker. */}
+                  <div
+                    className="absolute top-1/2 h-[2px] -translate-y-1/2 rounded-full transition-colors duration-200"
+                    style={{
+                      left: `${lowX}%`,
+                      width: `${highX - lowX}%`,
+                      background: markColor,
+                    }}
+                    aria-hidden="true"
+                  />
+                  {/* Margin bar, drawn from zero. */}
+                  <div
+                    className="absolute top-1/2 h-2.5 -translate-y-1/2 rounded-[2px] transition-colors duration-200"
+                    style={{
+                      left: `${barLeft}%`,
+                      width: `${barWidth}%`,
+                      background: markColor,
+                      opacity: 0.55,
+                    }}
+                    aria-hidden="true"
+                  />
+                  {/* Margin marker. */}
+                  <div
+                    className="absolute top-1/2 h-2 w-2 -translate-x-1/2 -translate-y-1/2 rounded-full transition-colors duration-200"
+                    style={{
+                      left: `${x(row.marginM)}%`,
+                      background: markColor,
+                      boxShadow: `0 0 0 2px ${surface}`,
+                    }}
+                    aria-hidden="true"
+                  />
+                </GrowIn>
+
+                <span
+                  className={cn(
+                    "pointer-events-none absolute top-0 font-mono text-[11px] transition-opacity duration-150",
+                    isHovered ? "opacity-100" : "opacity-0",
+                  )}
+                  style={{
+                    left: `${x(row.marginM)}%`,
+                    transform: "translateX(-50%)",
+                    color: onInk ? "#f3efe6" : "#0d0d0b",
+                  }}
+                >
+                  {signedMetres(row.marginM)}
+                </span>
+              </div>
+
+              <p className="sr-only">
+                {row.measured} against {row.required}. Margin{" "}
+                {signedMetres(row.marginM)}, calibration tolerance plus or minus{" "}
+                {row.toleranceM.toFixed(2)} metres. {meta.label}.
+              </p>
+            </div>
+          );
+        })}
+      </div>
+
+      <p
+        className={cn(
+          "mt-6 flex gap-2 border-t pt-4 text-[12.5px] leading-[1.65]",
+          onInk ? "border-white/10 text-ink-300" : "border-line-soft text-ink-500",
+        )}
+      >
+        <Info
+          className="mt-0.5 h-4 w-4 shrink-0"
+          style={{ color: onInk ? ACCENT_ON_INK : ACCENT }}
+          aria-hidden="true"
+        />
+        <span>
+          None of these rows is a prediction. They are distances in a place we
+          measured, checked against an envelope the robot's maker publishes —
+          which is why a screening result can tell you what stopped it, and by
+          how much.
+        </span>
+      </p>
+    </Figure>
+  );
+}
+
+/* -------------------------------------------- 3c. ranking margin chart */
+
+export interface RankingCandidateRow {
+  candidate: string;
+  /** Success rate on the testbed, 0–1. */
+  rate: number;
+  /** Lower bound of the 95% interval, 0–1. */
+  low: number;
+  /** Upper bound of the 95% interval, 0–1. */
+  high: number;
+}
+
+/**
+ * Interval on the gap between two candidates, in points of success rate.
+ *
+ * Normal approximation to the difference of two proportions at 95%. Computed
+ * here rather than authored in the copy file so the ordering, the margins, and
+ * the separation calls can never drift apart: change a rate and every derived
+ * number in the figure moves with it.
+ */
+function gapInterval(
+  ahead: RankingCandidateRow,
+  behind: RankingCandidateRow,
+  rollouts: number,
+) {
+  const diff = ahead.rate - behind.rate;
+  const variance =
+    (ahead.rate * (1 - ahead.rate)) / rollouts + (behind.rate * (1 - behind.rate)) / rollouts;
+  const halfWidth = 1.96 * Math.sqrt(variance);
+  const low = diff - halfWidth;
+  return {
+    diffPp: diff * 100,
+    lowPp: low * 100,
+    highPp: (diff + halfWidth) * 100,
+    /** Separated only when the whole interval on the gap stays above zero. */
+    separated: low > 0,
+  };
+}
+
+const roundPp = (value: number) => Math.round(value);
+
+/**
+ * RankingMarginChart — the ordering, and the resolution that comes with it.
+ *
+ * The rank alone is the least interesting thing here. What makes it a
+ * deliverable is the gap between adjacent candidates, the interval on that gap,
+ * and the floor: the smallest difference this design can separate at all. A
+ * pair whose gap sits inside the floor is reported as tied at this rollout
+ * count rather than ordered, because ordering it would be reporting noise with
+ * a chart around it.
+ *
+ * Every derived number — gap, interval, separation call — is computed from the
+ * rates and the rollout count in `gapInterval`, so the figure cannot claim a
+ * separation its own inputs do not support.
+ */
+export function RankingMarginChart({
+  candidates,
+  rolloutsPerCandidate,
+  resolutionFloorPp,
+  testbedVersion,
+  oodAxes,
+  metricLabel,
+  onInk = false,
+}: {
+  candidates: readonly RankingCandidateRow[];
+  rolloutsPerCandidate: number;
+  resolutionFloorPp: number;
+  testbedVersion: string;
+  oodAxes: readonly string[];
+  metricLabel: string;
+  onInk?: boolean;
+}) {
+  const [hovered, setHovered] = useState<string | null>(null);
+  const accent = accentFor(onInk);
+  const muted = mutedFor(onInk);
+  const surface = surfaceFor(onInk);
+  const pct = (value: number) => `${Math.round(value * 1000) / 10}%`;
+
+  const gaps = candidates.slice(1).map((row, index) => ({
+    ahead: candidates[index],
+    behind: row,
+    ...gapInterval(candidates[index], row, rolloutsPerCandidate),
+  }));
+
+  return (
+    <Figure
+      title="The ordering, and what it can resolve"
+      subtitle={`${candidates.length} candidates on ${testbedVersion}, ${rolloutsPerCandidate} rollouts each. Adjacent gaps carry their own interval; anything inside the floor is reported as tied.`}
+      illustrative
+      onInk={onInk}
+      tableView={
+        <table className="w-full text-left text-[13px]">
+          <caption className="sr-only">
+            Per-candidate {metricLabel} with its 95% interval, and the gap to the
+            next candidate with the interval on that gap
+          </caption>
+          <thead>
+            <tr className={onInk ? "text-ink-300" : "text-ink-500"}>
+              <th scope="col" className="py-1 pr-4 font-semibold">Candidate</th>
+              <th scope="col" className="py-1 pr-4 font-semibold">Rate</th>
+              <th scope="col" className="py-1 pr-4 font-semibold">95% interval</th>
+              <th scope="col" className="py-1 font-semibold">Gap to next</th>
+            </tr>
+          </thead>
+          <tbody className={onInk ? "text-ink-200" : "text-ink-700"}>
+            {candidates.map((row, index) => {
+              const gap = gaps[index];
+              return (
+                <tr
+                  key={row.candidate}
+                  className={onInk ? "border-t border-white/10" : "border-t border-line-soft"}
+                >
+                  <th scope="row" className="py-2 pr-4 font-medium">{row.candidate}</th>
+                  <td className="py-2 pr-4 font-mono">{pct(row.rate)}</td>
+                  <td className="py-2 pr-4 font-mono">
+                    {pct(row.low)}–{pct(row.high)}
+                  </td>
+                  <td className="py-2 font-mono">
+                    {gap
+                      ? `${roundPp(gap.diffPp)} pp [${roundPp(gap.lowPp)}, ${roundPp(gap.highPp)}]${
+                          gap.separated ? "" : " · tied"
+                        }`
+                      : "—"}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      }
+    >
+      <div
+        className={cn(
+          "mb-5 flex flex-wrap items-center gap-x-5 gap-y-2 text-[12px]",
+          onInk ? "text-ink-300" : "text-ink-500",
+        )}
+      >
+        <span className="inline-flex items-center gap-2">
+          <svg width="18" height="8" aria-hidden="true">
+            <line x1="0" y1="4" x2="18" y2="4" stroke={muted} strokeWidth="2" strokeLinecap="round" />
+            <circle cx="9" cy="4" r="4" fill={muted} stroke={surface} strokeWidth="2" />
+          </svg>
+          {metricLabel} and its 95% interval
+        </span>
+        <span className="inline-flex items-center gap-2 font-mono">
+          floor · {resolutionFloorPp.toFixed(1)} pp
+        </span>
+      </div>
+
+      <div className="relative mb-1 h-4" aria-hidden="true">
+        {[0, 0.5, 1].map((tick) => (
+          <span
+            key={tick}
+            className={cn("absolute top-0 font-mono text-[10px]", onInk ? "text-ink-400" : "text-ink-400")}
+            style={{
+              left: `${tick * 100}%`,
+              transform:
+                tick === 0 ? "none" : tick === 1 ? "translateX(-100%)" : "translateX(-50%)",
+            }}
+          >
+            {pct(tick)}
+          </span>
+        ))}
+      </div>
+
+      <ol className="flex flex-col gap-1">
+        {candidates.map((row, index) => {
+          const isHovered = hovered === row.candidate;
+          const markColor = isHovered ? accent : muted;
+          const gap = gaps[index];
+
+          return (
+            <li key={row.candidate}>
+              <div
+                tabIndex={0}
+                onMouseEnter={() => setHovered(row.candidate)}
+                onMouseLeave={() => setHovered(null)}
+                onFocus={() => setHovered(row.candidate)}
+                onBlur={() => setHovered(null)}
+                className="rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
+                  <p
+                    className={cn(
+                      "text-[13px] font-medium leading-snug",
+                      onInk ? "text-[color:var(--text-on-ink)]" : "text-ink-900",
+                    )}
+                  >
+                    <span className="mr-2 font-mono text-[11px] opacity-60">{index + 1}</span>
+                    {row.candidate}
+                  </p>
+                  <span
+                    className={cn(
+                      "shrink-0 font-mono text-[12px]",
+                      onInk ? "text-ink-200" : "text-ink-700",
+                    )}
+                  >
+                    {pct(row.rate)}
+                  </span>
+                </div>
+
+                <div className="relative mt-2 h-7">
+                  <div
+                    className="absolute inset-x-0 top-1/2 h-px"
+                    style={{ background: onInk ? "rgba(255,255,255,0.12)" : "#ebe4d7" }}
+                    aria-hidden="true"
+                  />
+                  <GrowIn origin="left" delay={index * 0.08} className="absolute inset-0">
+                    <div
+                      className="absolute top-1/2 h-[2px] -translate-y-1/2 rounded-full transition-colors duration-200"
+                      style={{
+                        left: `${row.low * 100}%`,
+                        width: `${(row.high - row.low) * 100}%`,
+                        background: markColor,
+                      }}
+                      aria-hidden="true"
+                    />
+                    <div
+                      className="absolute top-1/2 h-2 w-2 -translate-x-1/2 -translate-y-1/2 rounded-full transition-colors duration-200"
+                      style={{
+                        left: `${row.rate * 100}%`,
+                        background: markColor,
+                        boxShadow: `0 0 0 2px ${surface}`,
+                      }}
+                      aria-hidden="true"
+                    />
+                  </GrowIn>
+                </div>
+
+                <p className="sr-only">
+                  Rank {index + 1}. {row.candidate}, {metricLabel} {pct(row.rate)},
+                  95% interval {pct(row.low)} to {pct(row.high)}.
+                </p>
+              </div>
+
+              {/* The gap to the next candidate, and whether it survives the floor. */}
+              {gap ? (
+                <div
+                  className={cn(
+                    "my-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 border-l-2 py-1 pl-3 text-[12px]",
+                    onInk ? "border-white/15" : "border-line",
+                  )}
+                >
+                  <span
+                    className="inline-flex items-center gap-1.5 font-semibold"
+                    style={{
+                      color: gap.separated
+                        ? onInk
+                          ? verdictMeta.supported.fgOnInk
+                          : verdictMeta.supported.fg
+                        : onInk
+                          ? verdictMeta.unresolved.fgOnInk
+                          : verdictMeta.unresolved.fg,
+                    }}
+                  >
+                    {gap.separated ? (
+                      <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
+                    ) : (
+                      <MinusCircle className="h-3.5 w-3.5" aria-hidden="true" />
+                    )}
+                    {gap.separated ? "Separated" : "Tied at this rollout count"}
+                  </span>
+                  <span className={cn("font-mono", onInk ? "text-ink-300" : "text-ink-500")}>
+                    {roundPp(gap.diffPp)} pp · 95% CI [{roundPp(gap.lowPp)},{" "}
+                    {roundPp(gap.highPp)}]
+                  </span>
+                  {!gap.separated ? (
+                    <span className={onInk ? "text-ink-300" : "text-ink-500"}>
+                      — inside the {resolutionFloorPp.toFixed(1)} pp floor
+                    </span>
+                  ) : null}
+                </div>
+              ) : null}
+            </li>
+          );
+        })}
+      </ol>
+
+      <p
+        className={cn(
+          "mt-6 flex gap-2 border-t pt-4 text-[12.5px] leading-[1.65]",
+          onInk ? "border-white/10 text-ink-300" : "border-line-soft text-ink-500",
+        )}
+      >
+        <Info
+          className="mt-0.5 h-4 w-4 shrink-0"
+          style={{ color: onInk ? ACCENT_ON_INK : ACCENT }}
+          aria-hidden="true"
+        />
+        <span>
+          At {rolloutsPerCandidate} rollouts each, this design separates gaps of
+          about {resolutionFloorPp.toFixed(1)} points and no smaller. The ordering
+          is reported across {oodAxes.join(", ")}, and it holds on{" "}
+          {testbedVersion} — not on a floor we have not measured.
         </span>
       </p>
     </Figure>

--- a/client/src/components/site/runFilm/acts.tsx
+++ b/client/src/components/site/runFilm/acts.tsx
@@ -448,9 +448,10 @@ export function EnvelopeAct({ act }: ActProps) {
 
 /**
  * The two stamps a run never grants. These stay inside the frame because act 7
- * is the whole argument in one image — three verdicts, one of them not yet, and
- * two things this explicitly is not. The sentence explaining why they can be
- * trusted lives in `RunFilmLimits` at page level, where it has room.
+ * has to carry both halves of the result in one image: the ordering the run
+ * produced, and the two things that ordering explicitly is not. The sentence
+ * explaining why they can be trusted lives in `RunFilmLimits` at page level,
+ * where it has room.
  */
 export function EnvelopeStamps({ act }: ActProps) {
   const stamps = useEnterLift(act, ACT.envelope + 0.3, 8);

--- a/client/src/data/publicSiteCopy.ts
+++ b/client/src/data/publicSiteCopy.ts
@@ -28,13 +28,13 @@ import type { EvidenceRung, ClaimInterval, OutcomeBand, DecisionCostRow, StatTil
 
 export const homeHero = {
   eyebrow: "One service · Task Evaluation Runs",
-  title: "Rank your candidates against a real site before you send one.",
+  title: "Rank your candidates on the site you are bidding on, before the pilot.",
   body:
-    "A Task Evaluation Run captures one real site-task, rules out the candidates the building physically will not accept, and orders the rest — with the margin, the interval, and the smallest gap the run can actually resolve.",
+    "You already walk the floor before you quote. A Task Evaluation Run turns that visit into a testbed we keep — ruling out the candidates the building physically will not take, then ordering the rest with the margin, the interval on it, and the smallest gap the run can resolve.",
   chips: [
+    "From walkthrough to measured testbed",
     "Incompatibilities measured, not predicted",
-    "An ordering with its margin",
-    "Stated resolution, not a bare rank",
+    "An ordering with its resolution",
   ],
 } as const;
 
@@ -354,7 +354,7 @@ export const robotTeamHero = {
   eyebrow: "Task Evaluation Runs · for robot teams",
   title: "Spend field time on the candidate that earned it.",
   body:
-    "You have more checkpoints than sites, and more sites than weeks. Bring the candidates and the site-task. We drop the ones the building will not physically take, then order the rest on one pinned testbed — with the margin on every gap and the smallest gap the design can separate.",
+    "You can already rank checkpoints in your own simulator. What that will not tell you is how they order in the building you are quoting — the one you walked for an hour and wrote a proposal against. Bring the candidates and that site-task, and get the incompatibilities in metres and the survivors in order.",
   chips: ["Bring policies or checkpoints", "Screened on measurement", "Ordered with a stated resolution"],
 } as const;
 

--- a/client/src/data/publicSiteCopy.ts
+++ b/client/src/data/publicSiteCopy.ts
@@ -10,9 +10,17 @@
 //   - one customer-facing service, no package tiers or add-ons
 //   - no published fixed price
 //   - the customer never selects a simulator, world model, or provider
-//   - a run may end in a refusal to decide, and that is a valid result
 //   - virtual evidence is never presented as a physical or safety guarantee
 //   - figure values on the public site are schematic, never live run data
+//
+// On how a run reports what it could not settle. A run still has an
+// `abstained` terminal state — that is a Pipeline-owned contract value, not a
+// copy decision, and nothing here removes it. What changed is the framing: an
+// unsettled claim is stated as a *resolution* fact ("this design separates
+// gaps of 20 points or more; these two candidates are 4 apart") rather than as
+// a stance about honesty. The site sells the ordering. Resolution is the spec
+// on the ordering, the way a scale has a readability. It is never a section
+// header, a headline, or a virtue.
 
 import type { EvidenceRung, ClaimInterval, OutcomeBand, DecisionCostRow, StatTile, LifecycleStage } from "@/components/site/figures";
 
@@ -20,13 +28,13 @@ import type { EvidenceRung, ClaimInterval, OutcomeBand, DecisionCostRow, StatTil
 
 export const homeHero = {
   eyebrow: "One service · Task Evaluation Runs",
-  title: "Answer it before you send a robot.",
+  title: "Rank your candidates against a real site before you send one.",
   body:
-    "Field time is the most expensive possible way to learn that a policy does not work at your site. A Task Evaluation Run turns one real site-task into a testbed we maintain, tests the claims your decision actually rests on, and tells you what the evidence supports — including when it supports nothing yet.",
+    "A Task Evaluation Run captures one real site-task, rules out the candidates the building physically will not accept, and orders the rest — with the margin, the interval, and the smallest gap the run can actually resolve.",
   chips: [
-    "One service, one intake",
-    "Answers claim by claim",
-    "We say “not yet” out loud",
+    "Incompatibilities measured, not predicted",
+    "An ordering with its margin",
+    "Stated resolution, not a bare rank",
   ],
 } as const;
 
@@ -37,21 +45,140 @@ export const homeStats: readonly StatTile[] = [
     detail: "A Task Evaluation Run. No tiers, no packages, no separate add-ons.",
   },
   {
-    label: "Ways a run can end",
-    value: "Five",
-    detail: "Yes, no, partly, not yet — and the cheapest test that would settle it.",
+    label: "Ruled out by measurement",
+    value: "First",
+    detail:
+      "Reach, clearance, footprint, and sightlines come off the capture itself — before a single rollout is spent on a candidate the building will not take.",
+  },
+  {
+    label: "Every ordering ships with",
+    value: "Its margin",
+    detail:
+      "The gap between candidates, the 95% interval on that gap, and the smallest gap the design can separate at all.",
   },
   {
     label: "Backends you pick",
     value: "Zero",
     detail: "You describe the decision. Choosing the method is our job, not yours.",
   },
+];
+
+/**
+ * The screening pass — hard incompatibilities, measured off the capture.
+ *
+ * These rows are the one place a run says *why* rather than *which*. Reach,
+ * clearance, footprint, and sightlines are arithmetic over a measured place and
+ * a published robot envelope; there is no policy, no rollout, and no transfer
+ * assumption between the capture and the answer. That is why a screening result
+ * can name a cause ("misses the opening by 18 cm") when a ranking result can
+ * only name an order.
+ *
+ * `marginM` is measured minus required, in metres, and `toleranceM` is the
+ * calibration uncertainty on it. The verdict is **derived** from those two
+ * numbers rather than authored, which mirrors the Pipeline's analytic
+ * reachability adapter: clears only when the whole interval is above zero,
+ * ruled out only when the whole interval is below it, and otherwise reported as
+ * a measurement the capture cannot separate at its current precision.
+ */
+export interface ScreeningMargin {
+  /** The check, in the words a site lead would use. */
+  check: string;
+  /** What the capture measured, with its unit. */
+  measured: string;
+  /** What the candidate needs, with its unit. */
+  required: string;
+  /** Measured minus required, in metres. Negative means it does not fit. */
+  marginM: number;
+  /** Calibration uncertainty on the margin, in metres. */
+  toleranceM: number;
+}
+
+export const homeScreeningMargins: readonly ScreeningMargin[] = [
   {
-    label: "Published fixed prices",
-    value: "None",
-    detail: "Each run is scoped and quoted from the decision and evidence it needs.",
+    check: "Base reach to the pick fixture",
+    measured: "0.94 m from the approach pose",
+    required: "0.38–1.18 m envelope",
+    marginM: 0.24,
+    toleranceM: 0.03,
+  },
+  {
+    check: "Dock door at loaded height",
+    measured: "2.16 m opening",
+    required: "2.34 m loaded",
+    marginM: -0.18,
+    toleranceM: 0.02,
+  },
+  {
+    check: "Aisle width against the footprint",
+    measured: "1.42 m clear",
+    required: "1.31 m with clearance",
+    marginM: 0.11,
+    toleranceM: 0.04,
+  },
+  {
+    check: "Swept path past the rack upright",
+    measured: "0.06 m nearest approach",
+    required: "0.10 m minimum",
+    marginM: -0.04,
+    toleranceM: 0.05,
   },
 ];
+
+/**
+ * The ordering, and the resolution that comes with it.
+ *
+ * A rank on its own is not a deliverable — a rank you cannot separate is a coin
+ * toss with a chart around it. So every candidate carries its interval, every
+ * adjacent pair carries the gap and the interval on the gap, and the figure
+ * carries the floor: the smallest difference a design at this rollout count can
+ * resolve at all.
+ *
+ * The numbers below are schematic but internally consistent, and the floor is
+ * real arithmetic rather than a chosen round number. At 100 rollouts per
+ * candidate, the pooled two-proportion design resolves about 19.8 points at 80%
+ * power — so a 24-point gap separates and a 4-point gap does not, no matter how
+ * confident the ordering looks.
+ */
+export interface RankingCandidate {
+  candidate: string;
+  /** Success rate on the testbed, 0–1. */
+  rate: number;
+  /** Lower bound of the 95% interval, 0–1. */
+  low: number;
+  /** Upper bound of the 95% interval, 0–1. */
+  high: number;
+}
+
+export const homeRankingCandidates: readonly RankingCandidate[] = [
+  { candidate: "Candidate A", rate: 0.62, low: 0.522, high: 0.709 },
+  { candidate: "Candidate C", rate: 0.38, low: 0.291, high: 0.478 },
+  { candidate: "Candidate D", rate: 0.34, low: 0.255, high: 0.437 },
+];
+
+/** Rollouts per candidate behind the figure above. Sets the resolution floor. */
+export const homeRankingRolloutsPerCandidate = 100;
+
+/**
+ * Smallest gap the design above can separate, in points of success rate.
+ * Pooled two-proportion approximation at alpha 0.05 and 80% power.
+ */
+export const homeRankingResolutionFloorPp = 19.8;
+
+/** The testbed version an ordering is pinned to. Schematic. */
+export const homeRankingTestbedVersion = "testbed v3 · digest-pinned";
+
+/**
+ * The out-of-distribution axes an ordering is reported across. These are the
+ * five the Pipeline's decision-grade ranking requires — an ordering that does
+ * not cover all five is blocked rather than published.
+ */
+export const homeRankingOodAxes = [
+  "site",
+  "task",
+  "embodiment",
+  "viewpoint",
+  "appearance",
+] as const;
 
 export const homeLifecycle: readonly LifecycleStage[] = [
   {
@@ -67,44 +194,44 @@ export const homeLifecycle: readonly LifecycleStage[] = [
   {
     label: "You state the decision",
     detail:
-      "Not “run a benchmark.” The actual call you are about to make, the threshold it turns on, and what a wrong yes would cost.",
+      "Not “run a benchmark.” The actual call you are about to make, the candidates in front of you, and what a wrong yes would cost.",
   },
   {
-    label: "We route each claim",
+    label: "We screen on measurement",
     detail:
-      "Every claim goes to the cheapest evidence strong enough to carry it, and climbs only when that is not enough.",
+      "Reach, clearance, footprint, and sightlines come off the capture. Candidates the building will not take are out before anyone spends a rollout on them.",
   },
   {
-    label: "You get an answer with its limits",
+    label: "We order what survives",
     detail:
-      "What holds, what does not, what is still open, where the answer stops applying, and what to test next.",
+      "The remaining candidates are ranked on the same testbed version, with the margin, the interval on it, and the smallest gap the run can resolve.",
   },
 ];
 
 export const homeOutcomes: readonly OutcomeBand[] = [
   {
-    label: "Yes, within these conditions",
-    body: "The call is supported — and the report states exactly where that stops being true.",
+    label: "Ordered, with margin",
+    body: "The candidates are ranked and the gaps clear the run's resolution. You get the order, each margin, and the conditions it holds under.",
     tone: "supported",
   },
   {
-    label: "No",
-    body: "The evidence supports ruling the option out. A clear no is often the cheapest result you can buy.",
+    label: "Ruled out on measurement",
+    body: "A candidate does not physically fit the site. The cheapest finding in a run, and the one that names its own cause.",
     tone: "rejected",
   },
   {
-    label: "Partly",
-    body: "Some claims settled, others did not. You see which is which instead of an average that hides both.",
+    label: "Ordered in part",
+    body: "Some pairs separate and some sit inside the resolution. You see which is which, instead of a full ranking implying precision the design does not have.",
     tone: "partial",
   },
   {
-    label: "Not yet",
-    body: "The evidence is not strong enough to answer. We say so rather than dress a guess up as a finding.",
+    label: "Inside the resolution",
+    body: "The gaps are smaller than this design can separate. The run reports the floor and what it would take to get under it.",
     tone: "abstained",
   },
   {
     label: "Test this next",
-    body: "The least expensive experiment that would move the decision — including when that means real hardware.",
+    body: "The least expensive experiment that would move the decision — more rollouts, a recapture, or real hardware.",
     tone: "next",
   },
 ];
@@ -177,19 +304,19 @@ export const homeClaimMetricLabel = "success rate";
 
 export const homeDecisionCost: readonly DecisionCostRow[] = [
   {
-    label: "When you find out a policy will not work here",
-    beforeLabel: "After the robot is already on site",
-    afterLabel: "Before you schedule the visit",
+    label: "How you pick which candidate ships",
+    beforeLabel: "Whichever one demoed best somewhere else",
+    afterLabel: "An ordering measured on your site",
   },
   {
-    label: "What a negative answer costs you",
-    beforeLabel: "A trip, a crew, and a slot on the floor",
-    afterLabel: "A run, and the reason it failed",
+    label: "When you find out one will not fit",
+    beforeLabel: "After the robot is already on the floor",
+    afterLabel: "Before you schedule the visit",
   },
   {
     label: "What you can put in front of a reviewer",
     beforeLabel: "A demo reel and a judgement call",
-    afterLabel: "Claims, the evidence behind each, and stated limits",
+    afterLabel: "The order, each margin, and the resolution behind them",
   },
 ];
 
@@ -200,9 +327,14 @@ export const homeLimits = [
       "Nothing we return is a safety approval, a certification, or a licence to operate. Those stay with you and your regulator.",
   },
   {
-    title: "Virtual evidence has an edge",
+    title: "An ordering is bounded by its testbed",
     body:
-      "Every estimate comes with the conditions it was measured under. Outside them it is not a weaker claim — it is not a claim.",
+      "A ranking holds on the testbed version it was measured on, under the conditions stated. We have not measured how our orderings track real-world orderings, and we do not inherit anyone else's correlation figures as if they were ours.",
+  },
+  {
+    title: "Resolution is a property of the design",
+    body:
+      "Every run can only separate gaps above a certain size. We publish that floor with the ordering, because a rank you cannot separate is not a result.",
   },
   {
     title: "Some claims need hardware",
@@ -222,25 +354,25 @@ export const robotTeamHero = {
   eyebrow: "Task Evaluation Runs · for robot teams",
   title: "Spend field time on the candidate that earned it.",
   body:
-    "You have more checkpoints than sites, and more sites than weeks. Bring the candidates and the site-task, and find out which questions the current evidence can already close — and which ones only a real robot will settle.",
-  chips: ["Bring policies or checkpoints", "Incompatibility found early", "A no is a useful result"],
+    "You have more checkpoints than sites, and more sites than weeks. Bring the candidates and the site-task. We drop the ones the building will not physically take, then order the rest on one pinned testbed — with the margin on every gap and the smallest gap the design can separate.",
+  chips: ["Bring policies or checkpoints", "Screened on measurement", "Ordered with a stated resolution"],
 } as const;
 
 export const robotTeamValue = [
   {
-    title: "Compare your own candidates",
+    title: "Screen on measurement, not on rollouts",
     body:
-      "Several checkpoints, one task, one threshold, one set of conditions. Same substrate for every candidate, so the comparison means something.",
+      "Reach, footprint, clearance, and sightlines are computed from the capture. A candidate that cannot fit is out before it costs you a single rollout — and the run tells you by how much it missed.",
   },
   {
-    title: "Find the disqualifiers first",
+    title: "Order what survives, on one substrate",
     body:
-      "Reach, footprint, embodiment, observation and action mismatches, environmental limits. Cheap to discover here, expensive to discover on site.",
+      "Several checkpoints, one task, one testbed version, one set of conditions, reported across site, task, embodiment, viewpoint, and appearance. Same substrate for every candidate, so the comparison means something.",
   },
   {
-    title: "Decide what to do next",
+    title: "Know what the ordering can resolve",
     body:
-      "Test physically, recapture, narrow the task, or stop. The run names the next move and what it would cost you.",
+      "Every design has a smallest separable gap. We give you the ordering, the interval on each margin, and that floor — so you can tell a real lead from two checkpoints that are simply tied.",
   },
 ] as const;
 
@@ -255,12 +387,12 @@ export const robotTeamFlow: readonly LifecycleStage[] = [
     detail: "The run is bound to one exact testbed version and digest, so results stay comparable later.",
   },
   {
-    label: "Claims get routed",
-    detail: "Each claim goes to the cheapest evidence strong enough to carry it. You do not choose the method.",
+    label: "Screen on measurement",
+    detail: "Reach, clearance, and footprint come off the capture. Candidates the site will not take are out, with the shortfall in metres.",
   },
   {
-    label: "Read what holds",
-    detail: "Supported, ruled out, still open — per claim, with the conditions attached. Not one number.",
+    label: "Read the ordering",
+    detail: "The survivors ranked, each margin with its interval, and the smallest gap this design separates. Not one number.",
   },
   {
     label: "Commit the field time",
@@ -321,7 +453,7 @@ export const howItWorksSplit = {
     "Whether a method is qualified for a given claim",
     "Which evidence a claim is routed to, and when to escalate",
     "What was measured, and how sure the measurement is",
-    "The verdict — including the decision to abstain",
+    "The ordering, its margin, and anything the evidence could not separate",
   ],
 } as const;
 
@@ -347,10 +479,12 @@ export const pricingIncluded = [
   "One decision-shaped request against a real site-task",
   "A versioned testbed reference the result is bound to",
   "Claim, threshold, risk, budget, and deadline scoping",
+  "A measured screening pass, with the shortfall on anything ruled out",
   "An evidence plan chosen per claim, and the reasoning",
-  "The answer: yes, no, partly, or not yet",
+  "The ordering of the surviving candidates, with each margin",
+  "The interval on every margin, and the gap the design can separate",
   "The conditions it holds under, and where it stops",
-  "Uncertainty, and any disagreement between methods",
+  "Any disagreement between methods, reported rather than averaged",
   "The next cheapest test, and whether hardware is required",
   "Exact provenance, and what each artifact may be used for",
 ] as const;
@@ -359,7 +493,7 @@ export const pricingBoundaries = [
   {
     title: "A quote buys the work, not the answer you wanted",
     body:
-      "Authorising a run does not purchase a winner, a green light, a field recommendation, or a passing result. It purchases an honest one.",
+      "Authorising a run does not purchase a particular winner, a green light, a field recommendation, or a passing result. It purchases the ordering the evidence actually supports.",
   },
   {
     title: "Price is set on our side",
@@ -385,9 +519,9 @@ export const aboutStats: readonly StatTile[] = [
     detail: "A Task Evaluation Run. Every other product name is retired, not renamed.",
   },
   {
-    label: "Ways a run can end",
-    value: "Five",
-    detail: "Yes, no, partly, not yet — and the cheapest test that would settle it.",
+    label: "Orderings without a margin",
+    value: "None",
+    detail: "A rank ships with its gap, the interval on that gap, and the floor the design can separate.",
   },
   {
     label: "Backends you pick",
@@ -410,7 +544,7 @@ export const aboutPrinciples = [
   {
     title: "An estimate is never a guarantee",
     body:
-      "We report what the evidence supports inside stated conditions. Partial answers and outright refusals to decide are first-class results, not failures to be dressed up.",
+      "We report what the evidence supports inside stated conditions, and we publish the resolution alongside the ordering — because a gap the design cannot separate is not a lead.",
   },
   {
     title: "Generated frames are review support",
@@ -608,10 +742,10 @@ export const runFilmActs: readonly RunFilmAct[] = [
   },
   {
     id: "envelope",
-    label: "The answer and its edges",
-    // 20 words.
+    label: "The order and its resolution",
+    // 17 words.
     caption:
-      "Supported, ruled out, or not yet. A claim the evidence cannot carry stays open — it is never rounded into a win.",
+      "The order, each margin, and the interval on it — plus the smallest gap this run could separate.",
     term: "decision envelope",
     actor: "Blueprint",
   },

--- a/client/src/data/robotPolicyEvaluationClaims.ts
+++ b/client/src/data/robotPolicyEvaluationClaims.ts
@@ -3,37 +3,47 @@
 // collects the decision request and projects the returned evidence envelope.
 
 export const robotPolicyEvaluationBoundary =
-  "A Task Evaluation Run returns only the decisions supported inside its stated validation envelope. Estimates are not physical guarantees, safety approval remains external, and claims that cannot be supported virtually still require physical evidence.";
+  "A Task Evaluation Run returns only the decisions supported inside its stated validation envelope. An ordering holds on the testbed version and conditions it was measured under; Blueprint has not measured how its orderings correlate with real-world orderings and does not inherit external rank-fidelity figures. Estimates are not physical guarantees, safety approval remains external, and claims that cannot be supported virtually still require physical evidence.";
 
 export const robotPolicyScreeningValue =
-  "Test candidate policies or checkpoints against a prospective real-site task, discover failure conditions, and decide whether field time is justified.";
+  "Rule out candidate policies or checkpoints that a real site will not physically accept, then rank the remainder against that site-task with the margin, its interval, and the resolution floor of the design.";
 
 export const blueprintPositioning =
-  "Blueprint turns a real site-task into a maintained testbed, routes each claim to the least expensive currently qualified evidence, and returns a bounded decision or an explicit abstention.";
+  "Blueprint turns a real site-task into a maintained testbed, eliminates candidates on measured incompatibility, and ranks the rest — reporting each margin, the interval on it, and the smallest difference the design can separate.";
 
 export const siteSpecificRankingSummary =
-  "Blueprint captures the site-task, maintains the testbed, evaluates the decision-relevant claims, and reports what is supported, rejected, unresolved, or still needs physical evidence.";
+  "Blueprint captures the site-task, maintains the testbed, screens candidates on measured geometry, and reports the ordering of the survivors with per-gap intervals and the resolution floor.";
 
+/**
+ * Two claim families, deliberately separated.
+ *
+ * Screening claims are arithmetic over a measured site and a published robot
+ * envelope, so they can name a cause and a magnitude. Ranking claims are
+ * ordinal: they say which candidate led on this testbed, by how much, and
+ * whether the design could separate the pair at all. Nothing in this product
+ * infers *why* a policy would fail in the real world from a simulated or
+ * generated rollout, and no copy on this site may imply that it does.
+ */
 export const rankingOutcomeCategories = [
   {
-    label: "Bounded positive decision",
-    body: "The requested action is supported only inside the stated conditions and claim ceiling.",
+    label: "Measured incompatibility",
+    body: "The candidate does not fit the captured site. Reported as a signed margin in metres with its calibration tolerance — the one result that names its own cause.",
   },
   {
-    label: "Bounded negative decision",
-    body: "The evidence supports rejecting an option or action inside the stated scope.",
+    label: "Separated ordering",
+    body: "The candidates are ranked and each adjacent gap has an interval that stays clear of zero, inside the stated conditions and claim ceiling.",
   },
   {
-    label: "Partial decision",
-    body: "Some claims are resolved while other decision-relevant claims remain unknown.",
+    label: "Partial ordering",
+    body: "Some adjacent pairs separate and others fall inside the resolution floor, which is reported per pair rather than smoothed into one rank.",
   },
   {
-    label: "Explicit abstention",
-    body: "The current evidence is not trustworthy enough to support the requested decision.",
+    label: "Inside the resolution floor",
+    body: "The observed gaps are smaller than the design can separate at the rollout count used. Reported as tied at that count, with the floor stated.",
   },
   {
     label: "Next evidence required",
-    body: "Blueprint identifies the least expensive stronger experiment needed to move the decision forward.",
+    body: "Blueprint identifies the least expensive stronger experiment needed to move the decision forward, including the rollout count that would close a given gap.",
   },
 ] as const;
 
@@ -45,21 +55,25 @@ export const robotPolicyBeachheadShort =
 
 export const robotPolicyComparisonUseCases = [
   {
-    title: "Compare internal candidates",
-    body: "Evaluate checkpoints or policies under one decision, task, threshold, and provenance scope.",
+    title: "Screen on measured geometry",
+    body: "Rule out reach, footprint, clearance, and sightline incompatibilities from the capture itself, before any rollout budget is committed.",
   },
   {
-    title: "Test task compatibility",
-    body: "Find reach, embodiment, observation, action, and environmental incompatibilities before field time.",
+    title: "Rank internal candidates",
+    body: "Order checkpoints or policies under one decision, task, threshold, testbed version, and provenance scope.",
+  },
+  {
+    title: "Read the resolution before the rank",
+    body: "Use the interval on each gap and the design's minimum separable difference to tell a real lead from two candidates that are simply tied.",
   },
   {
     title: "Choose the next experiment",
-    body: "Use unresolved claims, uncertainty, and the claim ceiling to decide whether to test physically, recapture, narrow the task, or stop.",
+    body: "Use unseparated pairs, uncertainty, and the claim ceiling to decide whether to add rollouts, test physically, recapture, narrow the task, or stop.",
   },
 ] as const;
 
 export const robotPolicyResearchSignalsNote =
-  "External research can motivate an evidence method, but it is not a Blueprint result. Each method must be qualified for the claim and validation envelope in the current run.";
+  "External research can motivate an evidence method, but it is not a Blueprint result. Published rank-fidelity figures in this field are computed over roughly seven to eight policies, which leaves their confidence intervals wide; Blueprint neither inherits those point estimates nor reports one of its own until independently accepted real-world anchors exist. Each method must be qualified for the claim and validation envelope in the current run.";
 
 export const robotPolicyResearchSignals = [
   {

--- a/client/src/data/robotPolicyEvaluationClaims.ts
+++ b/client/src/data/robotPolicyEvaluationClaims.ts
@@ -6,7 +6,7 @@ export const robotPolicyEvaluationBoundary =
   "A Task Evaluation Run returns only the decisions supported inside its stated validation envelope. An ordering holds on the testbed version and conditions it was measured under; Blueprint has not measured how its orderings correlate with real-world orderings and does not inherit external rank-fidelity figures. Estimates are not physical guarantees, safety approval remains external, and claims that cannot be supported virtually still require physical evidence.";
 
 export const robotPolicyScreeningValue =
-  "Rule out candidate policies or checkpoints that a real site will not physically accept, then rank the remainder against that site-task with the margin, its interval, and the resolution floor of the design.";
+  "Turn a pre-sales site walkthrough into a maintained testbed: rule out candidate policies or checkpoints the site will not physically accept, then rank the remainder against that site-task with the margin, its interval, and the resolution floor of the design.";
 
 export const blueprintPositioning =
   "Blueprint turns a real site-task into a maintained testbed, eliminates candidates on measured incompatibility, and ranks the rest — reporting each margin, the interval on it, and the smallest difference the design can separate.";

--- a/client/src/pages/About.tsx
+++ b/client/src/pages/About.tsx
@@ -118,7 +118,7 @@ export default function About() {
           <SectionHeader
             index="02"
             eyebrow="What we hold to"
-            title="Five rules that decide what we refuse to say."
+            title="Five rules that decide what a result may claim."
             lede="These are the constraints behind every page on this site: what gets shown, what gets labelled, and what never gets claimed regardless of how well it would sell."
           />
           <NoteCards items={aboutPrinciples} className="mt-12" />

--- a/client/src/pages/FAQ.tsx
+++ b/client/src/pages/FAQ.tsx
@@ -16,7 +16,7 @@ export const faqItems = [
   {
     question: "What does Blueprint sell?",
     answer:
-      "One service: a Task Evaluation Run. It turns a real job at a real site into a testbed we maintain, tests the claims your decision rests on, and returns an answer with the conditions it holds under — or tells you the evidence will not carry it yet.",
+      "One service: a Task Evaluation Run. It turns a real job at a real site into a testbed we maintain, rules out the candidates the building will not physically take, and ranks the rest — with the margin on every gap, the interval on that margin, and the smallest gap the run can resolve.",
   },
   {
     question: "Do robot teams and site operators use different products?",
@@ -31,7 +31,7 @@ export const faqItems = [
   {
     question: "Does every run produce a ranking?",
     answer:
-      "No. A run can support a call, rule an option out, settle some claims and not others, or decline to answer. Comparing raw scores to manufacture a winner after the evidence has declined to produce one is exactly the thing this service will not do.",
+      "Ranking is what the service is for, so most runs do. Two things change its shape. A candidate the site physically will not take is ruled out on measurement rather than ranked — you get the shortfall in metres instead of a position. And a pair whose gap falls inside the run's resolution is reported as tied at that rollout count, with the floor and what it would cost to get under it, because ordering a gap the design cannot separate is just reporting noise.",
   },
   {
     question: "What is in a result?",
@@ -89,7 +89,8 @@ export default function FAQ() {
             </h1>
             <p className="mt-7 max-w-[46ch] text-[1.05rem] leading-[1.75] text-ink-600">
               The questions below are the ones worth asking before you spend
-              anything — including the ones whose honest answer is a no.
+              anything — what a run ranks, what it rules out, and how small a
+              difference it can actually see.
             </p>
           </Reveal>
           <Reveal delay={0.1} className="mt-14">
@@ -106,8 +107,8 @@ export default function FAQ() {
         <Inner className="py-20 lg:py-24">
           <SectionHeader
             eyebrow="For reference"
-            title="The five ways a run can end."
-            lede="Worth reading once, because four of them are not a winner and all five are valid deliveries."
+            title="The five shapes a result can take."
+            lede="Worth reading once. Most runs come back ordered; the rest tell you exactly which pairs the design could not separate, and what closing that would take."
           />
           <div className="mt-14">
             <OutcomeSpectrum bands={homeOutcomes} />

--- a/client/src/pages/ForRobotTeams.tsx
+++ b/client/src/pages/ForRobotTeams.tsx
@@ -1,9 +1,9 @@
 import { SEO } from "@/components/SEO";
 import { ProofBoundary } from "@/components/blueprint";
 import {
-  ClaimThresholdChart,
   EvidenceLadderChart,
   OutcomeSpectrum,
+  RankingMarginChart,
   RunLifecycleRail,
 } from "@/components/site/figures";
 import { Reveal } from "@/components/site/motion";
@@ -20,11 +20,14 @@ import { robotPolicyEvaluationBoundary } from "@/data/robotPolicyEvaluationClaim
 import {
   closingCta,
   homeClaimMetricLabel,
-  homeClaimThreshold,
-  homeClaims,
   homeEvidenceRungs,
   homeLimits,
   homeOutcomes,
+  homeRankingCandidates,
+  homeRankingOodAxes,
+  homeRankingResolutionFloorPp,
+  homeRankingRolloutsPerCandidate,
+  homeRankingTestbedVersion,
   robotTeamFlow,
   robotTeamHero,
   robotTeamValue,
@@ -41,7 +44,7 @@ export default function ForRobotTeams() {
     <>
       <SEO
         title="Task Evaluation Runs for robot teams | Blueprint"
-        description="Compare your own checkpoints against a real site-task, find the disqualifiers early, and decide whether field time is justified."
+        description="Rank your own checkpoints against a real site-task: incompatibilities ruled out on measurement, the rest ordered with the margin on every gap."
         canonical="/for-robot-teams"
         jsonLd={[
           webPageJsonLd({
@@ -76,8 +79,8 @@ export default function ForRobotTeams() {
           <SectionHeader
             index="01"
             eyebrow="The wedge"
-            title="Bring candidates. A ranking is not the promise."
-            lede="A run is organised around your decision, not around a tournament. A candidate can be supported, ruled out, eliminated as flatly incompatible, or left open — and “left open” is reported as itself."
+            title="Bring candidates. Get them screened, then ordered."
+            lede="A run is organised around your decision, not around a tournament. Candidates the site will not physically take are eliminated on measurement; the rest come back ranked, and any pair the design cannot separate is named as tied rather than ordered."
             onInk
           />
           <div className="mt-14 grid gap-x-10 gap-y-10 lg:grid-cols-3">
@@ -105,13 +108,16 @@ export default function ForRobotTeams() {
           <SectionHeader
             index="02"
             eyebrow="What a result looks like"
-            title="Per claim, with the line it was read against."
-            lede="Your threshold, your units, your definition of a wrong yes. Each claim is answered against that, and the ones that will not resolve are named."
+            title="An order, each margin, and the gap you cannot see."
+            lede="Your threshold, your units, your definition of a wrong yes. The candidates come back ordered on one pinned testbed, and every adjacent gap carries the interval that says whether it is a lead or a tie."
           />
           <Reveal className="mt-14">
-            <ClaimThresholdChart
-              claims={homeClaims}
-              threshold={homeClaimThreshold}
+            <RankingMarginChart
+              candidates={homeRankingCandidates}
+              rolloutsPerCandidate={homeRankingRolloutsPerCandidate}
+              resolutionFloorPp={homeRankingResolutionFloorPp}
+              testbedVersion={homeRankingTestbedVersion}
+              oodAxes={homeRankingOodAxes}
               metricLabel={homeClaimMetricLabel}
             />
           </Reveal>

--- a/client/src/pages/ForRobotTeams.tsx
+++ b/client/src/pages/ForRobotTeams.tsx
@@ -44,7 +44,7 @@ export default function ForRobotTeams() {
     <>
       <SEO
         title="Task Evaluation Runs for robot teams | Blueprint"
-        description="Rank your own checkpoints against a real site-task: incompatibilities ruled out on measurement, the rest ordered with the margin on every gap."
+        description="Rank your own checkpoints in the building you are quoting: incompatibilities ruled out on measurement, the rest ordered with the margin on every gap."
         canonical="/for-robot-teams"
         jsonLd={[
           webPageJsonLd({

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -241,8 +241,9 @@ export default function Home() {
         <Inner className="py-20 lg:py-28">
           <SectionHeader
             index="07"
-            eyebrow="Two ways in"
-            title="Same run. Different starting point."
+            eyebrow="Who this is for"
+            title="Robot teams buy the run. Site operators set its terms."
+            lede="One service, one intake, one call to action — the difference is what you arrive with. A robot team arrives with candidates and a deal to win. A site operator arrives with a floor, a job, and the conditions anyone testing on it has to accept."
           />
           <div className="mt-14 grid gap-12 lg:grid-cols-2 lg:gap-16">
             <Reveal>
@@ -262,8 +263,8 @@ export default function Home() {
                 imageSrc="/redesign/pov/retail-backroom.jpg"
                 imageAlt="A retail backroom being considered for robot work"
                 eyebrow="For site operators"
-                title="Find out what a robot could do here first."
-                body="You do not need a vendor or a policy to start. Describe the job and the terms, and keep control of access, privacy, and whether anyone tests on your floor."
+                title="Decide what may be tested here, and on what terms."
+                body="You do not need a vendor or a policy to start. Describe the job and the conditions, and keep control of access, privacy, and whether anyone runs a robot on your floor."
                 linkLabel="Site-operator use case"
               />
             </Reveal>

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1,10 +1,10 @@
 import { SEO } from "@/components/SEO";
 import { ProofBoundary } from "@/components/blueprint";
 import {
-  ClaimThresholdChart,
+  ClearanceMarginChart,
   EvidenceLadderChart,
   DecisionShiftCompare,
-  OutcomeSpectrum,
+  RankingMarginChart,
   StatRow,
 } from "@/components/site/figures";
 import { Reveal } from "@/components/site/motion";
@@ -23,13 +23,16 @@ import { blueprintPositioning } from "@/data/robotPolicyEvaluationClaims";
 import {
   closingCta,
   homeClaimMetricLabel,
-  homeClaimThreshold,
-  homeClaims,
   homeDecisionCost,
   homeEvidenceRungs,
   homeHero,
   homeLimits,
-  homeOutcomes,
+  homeRankingCandidates,
+  homeRankingOodAxes,
+  homeRankingResolutionFloorPp,
+  homeRankingRolloutsPerCandidate,
+  homeRankingTestbedVersion,
+  homeScreeningMargins,
   homeStats,
 } from "@/data/publicSiteCopy";
 import { webPageJsonLd } from "@/lib/seoStructuredData";
@@ -44,7 +47,7 @@ export default function Home() {
     <>
       <SEO
         title="Blueprint | Task Evaluation Runs for real site-tasks"
-        description="Blueprint turns a real site-task into a maintained testbed and answers the decision claim by claim — including when the evidence cannot answer it yet."
+        description="Blueprint captures one real site-task, rules out the candidates the building will not physically take, and ranks the rest — with the margin on every gap and the smallest gap the run can resolve."
         canonical="/"
         jsonLd={[
           webPageJsonLd({
@@ -136,54 +139,76 @@ export default function Home() {
         </Inner>
       </Band>
 
-      {/* 04 — the abstention chart: the centrepiece */}
+      {/* 04 — the screening pass: the only claims that name a cause */}
       <Band tone="canvas">
         <Inner className="py-20 lg:py-28">
           <SectionHeader
             index="04"
-            eyebrow="The honest part"
-            title="A run is allowed to tell you it cannot tell you."
-            lede="Most evaluation products always produce a ranking, because a ranking is what looks like a deliverable. If the evidence under a claim will not carry it, we report that instead of rounding a guess into a verdict."
+            eyebrow="Ruled out first"
+            title="Some candidates the building will not take."
+            lede="Reach, clearance, footprint, sightlines. These come off the capture as distances, not as predictions — which makes this the one part of a run that can tell you what stopped a candidate and by how much. It is also the cheapest, so it runs before anything else."
           />
           <Reveal className="mt-14">
-            <ClaimThresholdChart
-              claims={homeClaims}
-              threshold={homeClaimThreshold}
-              metricLabel={homeClaimMetricLabel}
-            />
+            <ClearanceMarginChart rows={homeScreeningMargins} />
           </Reveal>
           <div className="mt-8 grid gap-5 lg:grid-cols-2">
             <Reveal>
               <ProofBoundary level="info" title="Read the figure this way">
-                Reachability clears the line with room to spare, so it is
-                supported. Dock clearance falls short, so it is ruled out. Onsite
-                outperformance has a point estimate above the line and an
-                interval that crosses it — which is not a win, and is not
-                reported as one.
+                The dock door misses by 18 cm against a 2 cm tolerance — the
+                whole interval sits below zero, so that candidate is out on
+                measurement. The rack upright is 4 cm short against a 5 cm
+                tolerance, so this capture cannot call it either way, and the run
+                says which one it is rather than picking.
               </ProofBoundary>
             </Reveal>
             <Reveal delay={0.08}>
-              <ProofBoundary level="warn" title="What that means commercially">
-                You can buy a run and be told no. You can buy a run and be told
-                not yet. Both are cheaper than the version of that answer you get
-                from a robot standing in a warehouse.
+              <ProofBoundary level="warn" title="What screening does not tell you">
+                That a candidate fits is not that a candidate works. Screening
+                clears the floor for the comparison; it says nothing about
+                whether the policy is any good. That is the next section, and it
+                is a weaker kind of claim.
               </ProofBoundary>
             </Reveal>
           </div>
         </Inner>
       </Band>
 
-      {/* 05 — outcome spectrum */}
+      {/* 05 — the ordering, with its resolution: the centrepiece */}
       <Band tone="paper" rule>
         <Inner className="py-20 lg:py-28">
           <SectionHeader
             index="05"
-            eyebrow="What comes back"
-            title="Five ways a run can end. Four of them are not a winner."
-            lede="The result is a set of per-claim findings with their conditions attached — never one score standing in for the whole decision."
+            eyebrow="The ordering"
+            title="Then the survivors get ranked, with the margin."
+            lede="One task, one pinned testbed version, the same conditions for every candidate. You get the order, the gap between each pair, the interval on that gap, and the smallest gap the design can separate at all."
           />
-          <div className="mt-14">
-            <OutcomeSpectrum bands={homeOutcomes} />
+          <Reveal className="mt-14">
+            <RankingMarginChart
+              candidates={homeRankingCandidates}
+              rolloutsPerCandidate={homeRankingRolloutsPerCandidate}
+              resolutionFloorPp={homeRankingResolutionFloorPp}
+              testbedVersion={homeRankingTestbedVersion}
+              oodAxes={homeRankingOodAxes}
+              metricLabel={homeClaimMetricLabel}
+            />
+          </Reveal>
+          <div className="mt-8 grid gap-5 lg:grid-cols-2">
+            <Reveal>
+              <ProofBoundary level="info" title="Read the figure this way">
+                A leads C by 24 points and the interval on that gap stays clear
+                of zero, so it is a real lead. C leads D by 4 points, inside the
+                floor this design can resolve, so they are reported as tied at
+                this rollout count instead of ordered.
+              </ProofBoundary>
+            </Reveal>
+            <Reveal delay={0.08}>
+              <ProofBoundary level="warn" title="Where the ordering stops">
+                This is an ordering on this testbed, under these conditions. We
+                have not measured how our orderings track real-world orderings,
+                and we do not inherit anyone else's correlation figures as if
+                they were ours.
+              </ProofBoundary>
+            </Reveal>
           </div>
         </Inner>
       </Band>
@@ -227,7 +252,7 @@ export default function Home() {
                 imageAlt="A robot arm working a tote task at a real site"
                 eyebrow="For robot teams"
                 title="Spend field time on the candidate that earned it."
-                body="Bring checkpoints or policies. Find the disqualifiers early, see which claims the current evidence can already close, and decide whether the trip is justified."
+                body="Bring checkpoints or policies. The ones the site will not take are ruled out on measurement, and the rest come back ordered — with the margin on every gap."
                 linkLabel="Robot-team use case"
               />
             </Reveal>

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -47,7 +47,7 @@ export default function Home() {
     <>
       <SEO
         title="Blueprint | Task Evaluation Runs for real site-tasks"
-        description="Blueprint captures one real site-task, rules out the candidates the building will not physically take, and ranks the rest — with the margin on every gap and the smallest gap the run can resolve."
+        description="Blueprint turns the site walkthrough you already do into a maintained testbed: candidates the building will not physically take are ruled out in metres, and the rest come back ordered with the margin on every gap."
         canonical="/"
         jsonLd={[
           webPageJsonLd({
@@ -253,7 +253,7 @@ export default function Home() {
                 imageAlt="A robot arm working a tote task at a real site"
                 eyebrow="For robot teams"
                 title="Spend field time on the candidate that earned it."
-                body="Bring checkpoints or policies. The ones the site will not take are ruled out on measurement, and the rest come back ordered — with the margin on every gap."
+                body="You can already rank checkpoints in your own simulator. What it will not tell you is how they order in the building you are quoting — so bring them, and that site-task."
                 linkLabel="Robot-team use case"
               />
             </Reveal>

--- a/client/src/pages/HowItWorks.tsx
+++ b/client/src/pages/HowItWorks.tsx
@@ -48,8 +48,8 @@ export default function HowItWorks() {
 
       <PageHero
         eyebrow="How it works"
-        title="Seven moves, and one of them is allowed to say no."
-        body="One real site-task becomes a testbed we keep. One decision becomes an evidence plan built claim by claim. What comes back is an answer with its edges drawn — not a backend you chose and not a ranking we owed you."
+        title="Seven moves from a real site-task to a ranked shortlist."
+        body="One real site-task becomes a testbed we keep. Candidates the building will not physically take are ruled out on measurement. What comes back is an ordering of the rest, with the margin on every gap and the smallest gap the run can resolve."
         ctaHref={runHref}
         ctaLabel="Request a Task Evaluation Run"
         secondaryHref="/pricing"
@@ -82,7 +82,7 @@ export default function HowItWorks() {
             index="02"
             eyebrow="Who owns what"
             title="A clean line between the record and the science."
-            lede="Worth knowing, because it explains why the site will never turn a refusal to decide into a winner: the site does not get a vote on the verdict."
+            lede="Worth knowing, because it explains why the ordering you get is the one the evidence produced: the site collects the request and shows the result, but it does not get a vote on the verdict."
             onInk
           />
           <div className="mt-14 grid gap-10 lg:grid-cols-2 lg:gap-16">
@@ -144,7 +144,7 @@ export default function HowItWorks() {
           <SectionHeader
             index="04"
             eyebrow="Act 07, in a picture"
-            title="How the answer gets its edges."
+            title="How each claim gets read."
           />
           <Reveal className="mt-14">
             <ClaimThresholdChart

--- a/client/tests/build-output.test.ts
+++ b/client/tests/build-output.test.ts
@@ -203,8 +203,9 @@ describe("build output", () => {
     const pricingHtml = fs.readFileSync(distPath("pricing/index.html"), "utf8");
     const proofHtml = fs.readFileSync(distPath("proof/index.html"), "utf8");
 
-    expect(homeHtml).toContain("Answer it before you send a robot.");
-    expect(homeHtml).toContain("A run is allowed to tell you it cannot tell you.");
+    expect(homeHtml).toContain("Rank your candidates against a real site before you send one.");
+    expect(homeHtml).toContain("Some candidates the building will not take.");
+    expect(homeHtml).toContain("Then the survivors get ranked, with the margin.");
     expect(homeHtml).toContain("cheapest evidence that is actually good enough");
     // Schematic figure values must be marked as such in the prerendered HTML too.
     expect(homeHtml).toContain("Illustrative");
@@ -247,6 +248,6 @@ describe("build output", () => {
     expect(browserJavaScript).not.toMatch(/pplx-[A-Za-z0-9_-]{12,}/);
     expect(browserJavaScript).not.toMatch(/fc-[A-Za-z0-9_-]{12,}/);
     expect(browserJavaScript).toContain("Task Evaluation Run");
-    expect(browserJavaScript).toContain("You get an answer with its limits");
+    expect(browserJavaScript).toContain("We order what survives");
   });
 });

--- a/client/tests/build-output.test.ts
+++ b/client/tests/build-output.test.ts
@@ -203,7 +203,7 @@ describe("build output", () => {
     const pricingHtml = fs.readFileSync(distPath("pricing/index.html"), "utf8");
     const proofHtml = fs.readFileSync(distPath("proof/index.html"), "utf8");
 
-    expect(homeHtml).toContain("Rank your candidates against a real site before you send one.");
+    expect(homeHtml).toContain("Rank your candidates on the site you are bidding on, before the pilot.");
     expect(homeHtml).toContain("Some candidates the building will not take.");
     expect(homeHtml).toContain("Then the survivors get ranked, with the margin.");
     expect(homeHtml).toContain("cheapest evidence that is actually good enough");

--- a/client/tests/components/site/PublicCopy.test.tsx
+++ b/client/tests/components/site/PublicCopy.test.tsx
@@ -35,7 +35,7 @@ describe("public real-site evaluation copy", () => {
     expect(
       screen.getByRole("heading", {
         level: 1,
-        name: /Answer it before you send a robot/i,
+        name: /Rank your candidates against a real site before you send one/i,
       }),
     ).toBeInTheDocument();
     expect(screen.getAllByRole("link", { name: /Request a Task Evaluation Run/i }).length).toBeGreaterThan(0);
@@ -45,9 +45,11 @@ describe("public real-site evaluation copy", () => {
     expect(container).toHaveTextContent(/The capture becomes a testbed we version, pin, and maintain/i);
     expect(container).toHaveTextContent(/cheapest evidence that is actually good enough/i);
 
-    // Refusing to decide is still stated on the page, not buried.
-    expect(container).toHaveTextContent(/A run is allowed to tell you it cannot tell you/i);
-    expect(container).toHaveTextContent(/is not reported as one/i);
+    // Screening leads, the ordering follows, and the ordering carries the
+    // resolution that makes it readable.
+    expect(container).toHaveTextContent(/Some candidates the building will not take/i);
+    expect(container).toHaveTextContent(/Then the survivors get ranked, with the margin/i);
+    expect(container).toHaveTextContent(/Tied at this rollout count/i);
 
     // Withdrawn products, fixed prices, and outcome guarantees stay absent.
     expect(container).not.toHaveTextContent(/Policy Shortlist/i);

--- a/client/tests/components/site/PublicCopy.test.tsx
+++ b/client/tests/components/site/PublicCopy.test.tsx
@@ -35,7 +35,7 @@ describe("public real-site evaluation copy", () => {
     expect(
       screen.getByRole("heading", {
         level: 1,
-        name: /Rank your candidates against a real site before you send one/i,
+        name: /Rank your candidates on the site you are bidding on, before the pilot/i,
       }),
     ).toBeInTheDocument();
     expect(screen.getAllByRole("link", { name: /Request a Task Evaluation Run/i }).length).toBeGreaterThan(0);

--- a/client/tests/components/site/RunFilm.test.tsx
+++ b/client/tests/components/site/RunFilm.test.tsx
@@ -87,8 +87,9 @@ describe("RunFilm", () => {
     for (const label of ["Supported", "Rejected", "Unresolved"]) {
       expect(container).toHaveTextContent(new RegExp(`^${label}$`.replace(/[$^]/g, ""), "i"));
     }
-    // Abstention is a named outcome in the film's own words, not an omission.
-    expect(container).toHaveTextContent(/not yet/i);
+    // The closing act names the ordering and the resolution that bounds it,
+    // rather than leading on what the run declined to say.
+    expect(container).toHaveTextContent(/the smallest gap this run could separate/i);
   });
 
   it.each([["stepped", useNarrowViewport], ["scrub", useWideViewport]])(

--- a/client/tests/pages/About.test.tsx
+++ b/client/tests/pages/About.test.tsx
@@ -13,7 +13,7 @@ describe("About", () => {
     ).toBeInTheDocument();
     expect(screen.getByText(/built by Nijel Hunt/i)).toBeInTheDocument();
     expect(
-      screen.getByRole("heading", { name: /Five rules that decide what we refuse to say\./i }),
+      screen.getByRole("heading", { name: /Five rules that decide what a result may claim\./i }),
     ).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: /^Capture first\. Claim later\.$/i })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: /^Rights travel with the evidence$/i })).toBeInTheDocument();

--- a/client/tests/pages/FAQ.test.tsx
+++ b/client/tests/pages/FAQ.test.tsx
@@ -23,7 +23,7 @@ describe("FAQ", () => {
 
     expect(screen.getByText(/One service: a Task Evaluation Run/i)).toBeInTheDocument();
     expect(
-      screen.getByText(/manufacture a winner after the evidence has declined to produce one/i),
+      screen.getByText(/ordering a gap the design cannot separate is just reporting noise/i),
     ).toBeInTheDocument();
     // Withdrawn names may be described as withdrawn, but never offered.
     expect(

--- a/client/tests/pages/ForRobotTeams.test.tsx
+++ b/client/tests/pages/ForRobotTeams.test.tsx
@@ -16,11 +16,11 @@ describe("ForRobotTeams", () => {
     ).toBeGreaterThan(0);
 
     // A ranking is explicitly not the promise.
-    expect(screen.getByText(/A ranking is not the promise/i)).toBeInTheDocument();
+    expect(screen.getByText(/Bring candidates\. Get them screened, then ordered\./i)).toBeInTheDocument();
     // The buyer does not select the evidence backend.
     expect(screen.getByText(/Why you do not pick the backend/i)).toBeInTheDocument();
     // Abstention survives as a named outcome on the persona page too.
-    expect(screen.getByText(/^Not yet$/i)).toBeInTheDocument();
+    expect(screen.getByText(/^Inside the resolution$/i)).toBeInTheDocument();
 
     expect(screen.queryByText(/Policy Shortlist/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/\$3,000/)).not.toBeInTheDocument();

--- a/client/tests/pages/ForSiteOperators.test.tsx
+++ b/client/tests/pages/ForSiteOperators.test.tsx
@@ -26,7 +26,7 @@ describe("ForSiteOperators", () => {
     expect(screen.getByText(/^Restricted areas$/i)).toBeInTheDocument();
     expect(screen.getByText(/Safety stays yours/i)).toBeInTheDocument();
     // Abstention is still one of the named outcomes.
-    expect(screen.getByText(/^Not yet$/i)).toBeInTheDocument();
+    expect(screen.getByText(/^Inside the resolution$/i)).toBeInTheDocument();
 
     expect(screen.queryByText(/Robot Match/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/\$5,000/)).not.toBeInTheDocument();

--- a/client/tests/pages/Home.test.tsx
+++ b/client/tests/pages/Home.test.tsx
@@ -3,10 +3,13 @@ import { describe, expect, it } from "vitest";
 import Home from "@/pages/Home";
 
 describe("Home", () => {
-  it("renders one Task Evaluation Run lifecycle with abstention and one primary CTA", () => {
+  it("leads with screening then ranking, and keeps one primary CTA", () => {
     const { container } = render(<Home />);
     expect(
-      screen.getByRole("heading", { level: 1, name: /Answer it before you send a robot/i }),
+      screen.getByRole("heading", {
+        level: 1,
+        name: /Rank your candidates against a real site before you send one/i,
+      }),
     ).toBeInTheDocument();
     expect(
       screen.getAllByRole("link", { name: /Request a Task Evaluation Run/i }).length,
@@ -18,21 +21,32 @@ describe("Home", () => {
     expect(container).toHaveTextContent(/You bring one real job at one real site/i);
     expect(container).toHaveTextContent(/The capture becomes a testbed we version, pin, and maintain/i);
     expect(container).toHaveTextContent(/Each claim goes to the cheapest evidence that is strong enough/i);
-    expect(container).toHaveTextContent(/Supported, ruled out, or not yet/i);
 
     // A run grants neither of these, and the contract enforces it.
     expect(container).toHaveTextContent(/Deployment approval/i);
     expect(container).toHaveTextContent(/Safety certification/i);
 
-    // Abstention is still a first-class, named outcome.
-    expect(screen.getByText(/^Not yet$/i)).toBeInTheDocument();
-    expect(screen.getAllByText(/^Unresolved$/i).length).toBeGreaterThan(0);
+    // Screening comes before ranking, and it is the half that names a cause.
     expect(
-      screen.getByText(/A run is allowed to tell you it cannot tell you/i),
+      screen.getByRole("heading", { name: /Some candidates the building will not take/i }),
     ).toBeInTheDocument();
+    expect(screen.getAllByText(/^Ruled out$/i).length).toBeGreaterThan(0);
+    expect(container).toHaveTextContent(/None of these rows is a prediction/i);
+
+    // The ordering ships with its margin and its resolution floor, and a pair
+    // inside the floor is named as tied rather than ranked.
     expect(
-      screen.getByText(/is not reported as one/i),
+      screen.getByRole("heading", { name: /Then the survivors get ranked, with the margin/i }),
     ).toBeInTheDocument();
+    expect(screen.getAllByText(/^Separated$/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Tied at this rollout count/i).length).toBeGreaterThan(0);
+    expect(container).toHaveTextContent(/inside the 19\.8 pp floor/i);
+
+    // The real-world-ordering boundary stays stated, as a limit rather than a
+    // headline. This is the one claim the Pipeline contract will not carry.
+    expect(container).toHaveTextContent(
+      /We have not measured how our orderings track real-world orderings/i,
+    );
 
     // Withdrawn product names and fixed campaign prices stay gone.
     expect(screen.queryByText(/Policy Shortlist/i)).not.toBeInTheDocument();
@@ -44,11 +58,11 @@ describe("Home", () => {
   it("marks every figure that shows numbers as illustrative", () => {
     const { container } = render(<Home />);
     const figures = container.querySelectorAll("figure");
-    expect(figures.length).toBeGreaterThanOrEqual(3);
+    expect(figures.length).toBeGreaterThanOrEqual(4);
 
-    // The two figures that plot schematic values must carry the marker, and so
-    // must the run film, so none of the three can be read as live run data. The
+    // The three figures that plot schematic values must carry the marker, and so
+    // must the run film, so none of the four can be read as live run data. The
     // qualitative before/after comparison plots nothing and needs none.
-    expect(screen.getAllByText(/^Illustrative$/i).length).toBe(3);
+    expect(screen.getAllByText(/^Illustrative$/i).length).toBe(4);
   });
 });

--- a/client/tests/pages/Home.test.tsx
+++ b/client/tests/pages/Home.test.tsx
@@ -8,7 +8,7 @@ describe("Home", () => {
     expect(
       screen.getByRole("heading", {
         level: 1,
-        name: /Rank your candidates against a real site before you send one/i,
+        name: /Rank your candidates on the site you are bidding on, before the pilot/i,
       }),
     ).toBeInTheDocument();
     expect(

--- a/client/tests/pages/HowItWorks.test.tsx
+++ b/client/tests/pages/HowItWorks.test.tsx
@@ -6,7 +6,7 @@ describe("HowItWorks", () => {
   it("shows decision-oriented intake, routing owned by the pipeline, abstention, and the next experiment", () => {
     const { container } = render(<HowItWorks />);
     expect(
-      screen.getByRole("heading", { level: 1, name: /Seven moves, and one of them is allowed to say no/i }),
+      screen.getByRole("heading", { level: 1, name: /Seven moves from a real site-task to a ranked shortlist/i }),
     ).toBeInTheDocument();
 
     // The walkthrough is now the run film. Its acts carry the same beats the
@@ -14,13 +14,15 @@ describe("HowItWorks", () => {
     // with its edges, and the next cheapest test.
     expect(container).toHaveTextContent(/The actual call, the threshold it turns on/i);
     expect(container).toHaveTextContent(/The decision splits into claims/i);
-    expect(container).toHaveTextContent(/Supported, ruled out, or not yet/i);
+    expect(container).toHaveTextContent(/the smallest gap this run could separate/i);
     expect(container).toHaveTextContent(/Next test/i);
 
     // The customer does not choose the evidence backend, and the film says so.
     expect(container).toHaveTextContent(/You never pick the method — that is our job/i);
     expect(screen.getByRole("heading", { name: /The pipeline owns the verdict/i })).toBeInTheDocument();
-    expect(screen.getByText(/including the decision to abstain/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/The ordering, its margin, and anything the evidence could not separate/i),
+    ).toBeInTheDocument();
 
     // Unknown states fail closed rather than defaulting to a pass.
     expect(screen.getAllByText(/Unknown states fail closed/i).length).toBeGreaterThan(0);

--- a/e2e/capture-task-review.spec.ts
+++ b/e2e/capture-task-review.spec.ts
@@ -1,6 +1,13 @@
 import { expect, test } from "@playwright/test";
 
+import { seedCookieConsent } from "./helpers/cookie-consent";
+
 const sha = (character: string) => `sha256:${character.repeat(64)}`;
+
+// Same reason as task-evaluation-run.spec.ts: this review flow runs past
+// CookieConsent's 1500ms reveal timer, and the fixed bottom banner then
+// intercepts clicks on the controls underneath it.
+test.beforeEach(seedCookieConsent);
 
 test("customer reviews Pipeline-authored task intent without a false approval", async ({ page }, testInfo) => {
   const consoleProblems: string[] = [];

--- a/e2e/docs-blog.spec.ts
+++ b/e2e/docs-blog.spec.ts
@@ -17,7 +17,7 @@ test("blog alias redirects to home", async ({ page }) => {
   await expect(page).toHaveURL(/\/$/);
   await expect(
     page.getByRole("heading", {
-      name: /Rank your candidates against a real site before you send one\./i,
+      name: /Rank your candidates on the site you are bidding on, before the pilot\./i,
     }),
   ).toBeVisible();
 });

--- a/e2e/docs-blog.spec.ts
+++ b/e2e/docs-blog.spec.ts
@@ -17,7 +17,7 @@ test("blog alias redirects to home", async ({ page }) => {
   await expect(page).toHaveURL(/\/$/);
   await expect(
     page.getByRole("heading", {
-      name: /Answer it before you send a robot\./i,
+      name: /Rank your candidates against a real site before you send one\./i,
     }),
   ).toBeVisible();
 });

--- a/e2e/exact-site-hosted-review.spec.ts
+++ b/e2e/exact-site-hosted-review.spec.ts
@@ -8,7 +8,7 @@ test("exact-site hosted review route redirects to home", async ({ page }) => {
   await expect(page).toHaveURL(/\/$/);
   await expect(
     page.getByRole("heading", {
-      name: /Answer it before you send a robot\./i,
+      name: /Rank your candidates against a real site before you send one\./i,
     }),
   ).toBeVisible();
 });

--- a/e2e/exact-site-hosted-review.spec.ts
+++ b/e2e/exact-site-hosted-review.spec.ts
@@ -8,7 +8,7 @@ test("exact-site hosted review route redirects to home", async ({ page }) => {
   await expect(page).toHaveURL(/\/$/);
   await expect(
     page.getByRole("heading", {
-      name: /Rank your candidates against a real site before you send one\./i,
+      name: /Rank your candidates on the site you are bidding on, before the pilot\./i,
     }),
   ).toBeVisible();
 });

--- a/e2e/helpers/cookie-consent.ts
+++ b/e2e/helpers/cookie-consent.ts
@@ -1,0 +1,45 @@
+import type { Page } from "@playwright/test";
+
+/**
+ * Key and payload shape are mirrored from `client/src/components/CookieConsent.tsx`.
+ * The component only reads the key's presence to decide whether to arm its
+ * reveal timer, but the value is stored and re-parsed by `getCookieConsent`, so
+ * it has to be a well-formed record rather than a sentinel string.
+ */
+const COOKIE_CONSENT_KEY = "blueprint_cookie_consent";
+
+/**
+ * Put the page in the state a returning browser is already in: consent recorded,
+ * banner never armed.
+ *
+ * `CookieConsent` shows itself 1500ms after mount when no consent is stored, and
+ * it renders `fixed inset-x-0 bottom-0 z-50`. Any spec whose interactions run
+ * past that timer can have the banner drop on top of a control and intercept
+ * pointer events — which makes the spec's result a function of how fast the
+ * runner is, not of the behaviour under test.
+ *
+ * `addInitScript` runs before the app's scripts on every navigation in the
+ * page's lifetime, so this must be installed before the first `goto`.
+ *
+ * Use this only for specs that are not about the banner itself. It is
+ * deliberately not global: the brand-polish sweep still renders and screenshots
+ * the banner, and consent behaviour needs to stay observable somewhere.
+ */
+export async function seedCookieConsent({ page }: { page: Page }): Promise<void> {
+  await page.addInitScript(
+    ([key, value]) => {
+      window.localStorage.setItem(key, value);
+    },
+    [
+      COOKIE_CONSENT_KEY,
+      JSON.stringify({
+        analytics: false,
+        marketing: false,
+        necessary: true,
+        // Fixed rather than Date.now() so a rerun of the same spec produces the
+        // same stored payload.
+        timestamp: "2026-01-01T00:00:00.000Z",
+      }),
+    ] as const,
+  );
+}

--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -5,7 +5,7 @@ test('homepage leads with the single Task Evaluation Run story', async ({ page }
 
   await expect(
     page.getByRole('heading', {
-      name: /Rank your candidates against a real site before you send one\./i,
+      name: /Rank your candidates on the site you are bidding on, before the pilot\./i,
     }),
   ).toBeVisible();
   const nav = page.getByRole('banner').getByRole('navigation');

--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -5,7 +5,7 @@ test('homepage leads with the single Task Evaluation Run story', async ({ page }
 
   await expect(
     page.getByRole('heading', {
-      name: /Answer it before you send a robot\./i,
+      name: /Rank your candidates against a real site before you send one\./i,
     }),
   ).toBeVisible();
   const nav = page.getByRole('banner').getByRole('navigation');
@@ -33,17 +33,19 @@ test('homepage leads with the single Task Evaluation Run story', async ({ page }
     page.getByText(/The capture becomes a testbed we version, pin, and maintain/i).first(),
   ).toBeVisible();
   await expect(
-    page.getByText(/Supported, ruled out, or not yet/i).first(),
+    page.getByText(/the smallest gap this run could separate/i).first(),
   ).toBeVisible();
 
   // The two things a run never grants. Contract-enforced, so it is stated.
   await expect(page.getByText(/Deployment approval/i).first()).toBeVisible();
   await expect(page.getByText(/Safety certification/i).first()).toBeVisible();
 
-  // Declining to decide is stated on the page, not implied.
-  await expect(page.getByText(/A run is allowed to tell you it cannot tell you/i)).toBeVisible();
-  await expect(page.getByText(/^Not yet$/i).first()).toBeVisible();
-  await expect(page.getByText(/is not reported as one/i)).toBeVisible();
+  // Screening runs first and is the half that names a cause; the ordering
+  // follows, carrying the resolution that makes it readable.
+  await expect(page.getByText(/Some candidates the building will not take/i)).toBeVisible();
+  await expect(page.getByText(/^Ruled out$/i).first()).toBeVisible();
+  await expect(page.getByText(/Then the survivors get ranked, with the margin/i)).toBeVisible();
+  await expect(page.getByText(/Tied at this rollout count/i).first()).toBeVisible();
 
   // Figures carrying schematic values are marked as illustrative.
   await expect(page.getByText(/^Illustrative$/i).first()).toBeVisible();

--- a/e2e/robot-team-eval.spec.ts
+++ b/e2e/robot-team-eval.spec.ts
@@ -13,9 +13,10 @@ test("legacy robot-team evaluation URL reaches the current product", async ({ pa
 
 test("robot-team and site-operator pages describe one service and intake", async ({ page }) => {
   await page.goto("/for-robot-teams");
-  // Declining to decide is still presented as an outcome, not omitted.
-  await expect(page.getByText(/A ranking is not the promise/i).first()).toBeVisible();
-  await expect(page.getByText(/^Not yet$/i).first()).toBeVisible();
+  // Screening precedes the ordering, and a gap the design cannot separate is
+  // still presented as an outcome rather than omitted.
+  await expect(page.getByText(/Bring candidates\. Get them screened, then ordered\./i).first()).toBeVisible();
+  await expect(page.getByText(/^Inside the resolution$/i).first()).toBeVisible();
   await expect(page.getByText(/Policy Shortlist/i)).toHaveCount(0);
 
   await page.goto("/for-site-operators");

--- a/e2e/task-evaluation-run.spec.ts
+++ b/e2e/task-evaluation-run.spec.ts
@@ -1,8 +1,17 @@
 import { expect, test, type Page } from "@playwright/test";
 
 import { validDecisionEnvelope } from "../server/tests/helpers/decision-evidence-fixtures";
+import { seedCookieConsent } from "./helpers/cookie-consent";
 
 const digest = `sha256:${"a".repeat(64)}`;
+
+// The intake form is long enough that filling it can outlast CookieConsent's
+// 1500ms reveal timer. When it does, the fixed bottom banner lands on top of
+// the submit button and intercepts the click, so this spec passes or fails on
+// how quickly the runner types. Seeding consent puts the page in the state a
+// returning browser is already in and removes the race without suppressing the
+// banner's own behaviour, which brand-polish still exercises.
+test.beforeEach(seedCookieConsent);
 
 async function fillIntake(page: Page, decisionQuestion: string) {
   await page.getByLabel("Testbed ID").fill("testbed-001");

--- a/scripts/qa/brand-polish.ts
+++ b/scripts/qa/brand-polish.ts
@@ -152,7 +152,7 @@ export const publicQaRoutes: PublicQaRoute[] = [
     label: "Home",
     path: "/",
     canonicalPath: "/",
-    expectedHeading: "Rank your candidates against a real site before you send one.",
+    expectedHeading: "Rank your candidates on the site you are bidding on, before the pilot.",
     requiredCtas: [
       { label: "Request a Task Evaluation Run", hrefStartsWith: "/contact" },
       { label: "How it works", hrefStartsWith: "/how-it-works" },
@@ -162,7 +162,7 @@ export const publicQaRoutes: PublicQaRoute[] = [
     label: "Product (legacy, redirects to Home)",
     path: "/product",
     canonicalPath: "/",
-    expectedHeading: "Rank your candidates against a real site before you send one.",
+    expectedHeading: "Rank your candidates on the site you are bidding on, before the pilot.",
     requiredCtas: [
       { label: "Request a Task Evaluation Run", hrefStartsWith: "/contact" },
       { label: "How it works", hrefStartsWith: "/how-it-works" },
@@ -257,7 +257,7 @@ export const publicQaRoutes: PublicQaRoute[] = [
     label: "Updates (legacy, redirects to Home)",
     path: "/updates",
     canonicalPath: "/",
-    expectedHeading: "Rank your candidates against a real site before you send one.",
+    expectedHeading: "Rank your candidates on the site you are bidding on, before the pilot.",
     requiredCtas: [
       { label: "Request a Task Evaluation Run", hrefStartsWith: "/contact" },
       { label: "How it works", hrefStartsWith: "/how-it-works" },

--- a/scripts/qa/brand-polish.ts
+++ b/scripts/qa/brand-polish.ts
@@ -152,7 +152,7 @@ export const publicQaRoutes: PublicQaRoute[] = [
     label: "Home",
     path: "/",
     canonicalPath: "/",
-    expectedHeading: "Answer it before you send a robot.",
+    expectedHeading: "Rank your candidates against a real site before you send one.",
     requiredCtas: [
       { label: "Request a Task Evaluation Run", hrefStartsWith: "/contact" },
       { label: "How it works", hrefStartsWith: "/how-it-works" },
@@ -162,7 +162,7 @@ export const publicQaRoutes: PublicQaRoute[] = [
     label: "Product (legacy, redirects to Home)",
     path: "/product",
     canonicalPath: "/",
-    expectedHeading: "Answer it before you send a robot.",
+    expectedHeading: "Rank your candidates against a real site before you send one.",
     requiredCtas: [
       { label: "Request a Task Evaluation Run", hrefStartsWith: "/contact" },
       { label: "How it works", hrefStartsWith: "/how-it-works" },
@@ -257,7 +257,7 @@ export const publicQaRoutes: PublicQaRoute[] = [
     label: "Updates (legacy, redirects to Home)",
     path: "/updates",
     canonicalPath: "/",
-    expectedHeading: "Answer it before you send a robot.",
+    expectedHeading: "Rank your candidates against a real site before you send one.",
     requiredCtas: [
       { label: "Request a Task Evaluation Run", hrefStartsWith: "/contact" },
       { label: "How it works", hrefStartsWith: "/how-it-works" },


### PR DESCRIPTION
## What changed

The site led with what a run declines to say. The hero, Home 04 ("The honest part — A run is allowed to tell you it cannot tell you"), Home 05 ("Five ways a run can end. Four of them are not a winner"), and the `/how-it-works` H1 all put refusal in the first line. That buried what Blueprint sells and framed a measurement property as a moral stance.

Two claim families now carry the public story, in the order they actually run.

**Screening (promoted to the front).** Reach, clearance, footprint, and sightlines are arithmetic over a measured place and a published robot envelope — no policy, no rollout, no transfer assumption. They are the only public claims that can name a cause *and* a magnitude, and they were previously buried inside the evidence ladder. New `ClearanceMarginChart` puts them first, on a signed axis in metres.

**Ranking (the centrepiece).** New `RankingMarginChart` reports the ordering with the gap between adjacent candidates, the interval on that gap, and the design's resolution floor.

Abstention is **not removed anywhere** and is unchanged as a contract value. It stops being a section header and becomes a number: "these two are 4 points apart and this design separates 20" says the same thing as a spec rather than a stance.

## Why the figures compute rather than assert

Both figures derive their verdicts instead of accepting authored ones, so copy cannot drift from the numbers:

- `screeningVerdict()` mirrors the Pipeline's analytic reachability adapter — clears only when the whole calibration interval is above zero, ruled out only when it is entirely below, otherwise reported as *under capture precision* rather than rounded either way.
- `gapInterval()` computes each gap's 95% interval from the rates and rollout count. A pair is called separated only when that interval stays clear of zero. At 100 rollouts per candidate the pooled two-proportion design resolves ~19.8 points, so the 24-point gap separates and the 4-point gap is reported as tied at that count.

## Claim boundaries

The real-world-ordering boundary moved from nowhere to the limits section, stated plainly: we have not measured how our orderings track real-world orderings, and we do not inherit external rank-fidelity figures. That is what `decision_grade_ranking`'s `claim_boundary` already asserts (`simulator_ranking_is_not_real_world_ordering`, `paper_metrics_are_never_inherited`, `correlation_status: correlation_not_measured`).

Every figure with numbers keeps its `Illustrative` marker; the Home assertion moved from 3 to 4.

## Persona emphasis

"Two ways in. Same run. Different starting point." presented both personas as co-equal front doors. Locked doctrine (`PLATFORM_CONTEXT` shared block) requires both to use the same service, workflow, and call to action, so this is an emphasis change, not a product split. `VISION`'s ladder settles the emphasis — rung 1 is the wedge sold to robot teams, rung 2 is where site operators start requiring runs. Section 07 now reads "Robot teams buy the run. Site operators set its terms," with one intake and one CTA preserved.

## The hero, and the open question it partly answers

The H1 is now **"Rank your candidates on the site you are bidding on, before the pilot."**

An earlier revision of this branch read "against a real site before you send one," leaning on an access gap that mostly is not there. In 2026 the site survey is a vendor pre-sales activity — the operator sends one brief to shortlisted vendors and each walks the floor for free before quoting. By the time a robot team cares about a building, it has usually been let in. The real gap is that the walkthrough produces no measurement: eyeball the floor, write the proposal, discover over a 90–180 day pilot whether the policy works.

That also narrows, without fully closing, the claim-boundary question. The Pipeline emits `policy_ranking_thesis_verdict: "thesis_not_supported"` in every evidence plan, and `VISION`'s locked proof boundary says a run "may still resolve geometry, perception, collision, or other qualified claims **and abstain on ranking**." "Before the pilot" is a promise a screening-only run still keeps, and screening leads the page — but the H1's verb is still *rank*. Worth a deliberate call rather than inheriting it from this PR.

## Test-lane fix (not caused by this branch)

The e2e job's second lane failed on `task-evaluation-run.spec.ts`. `CookieConsent` arms a 1500ms timer when no consent is stored and renders `fixed inset-x-0 bottom-0 z-50`; the intake spec fills seventeen fields before clicking submit, so past 1500ms the banner intercepts the click and the result depends on runner speed.

Confirmed pre-existing — the same three tests fail identically on `origin/main` (5a9db17) with none of these commits present — and genuinely intermittent, having passed in CI on `1c37946` and failed on `b7e7dd2`. Fixed by seeding the consent key via `addInitScript` before the first navigation, scoped to the two affected specs so `brand-polish` still renders and screenshots the banner.

Separately worth noting for a future PR: a real user filling that form slowly meets the same banner over the same submit button. The spec was reporting something true about the UI.

## Verification

Run locally against `9bb3ab3`, all lanes:

- `npm run check` — clean
- `npm run build` — clean
- `npx vitest run` — **1792 passed, 0 failed** (763 suites), including `build-output` prerender assertions against a fresh build
- `npx playwright test` — **28 passed**
- `scripts/qa/run-task-evaluation-run-e2e.ts` — the two previously failing `task-evaluation-run` tests now pass. `capture-task-review` fails in the sandbox on `ERR_CONNECTION_RESET` from blocked egress; it passed in the CI run that surfaced this failure, so it is environment-local and untouched here.
- `npm run doctrine:verify` — all three locked blocks green; no shared-doctrine block touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LxvsoKK6vAXq2KmgUEMMqC