### PR TITLE
fix(deploy): unblock Render clone and restore disclosures dropped by #436

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,15 @@
-*.ply filter=lfs diff=lfs merge=lfs -text
-*.spz filter=lfs diff=lfs merge=lfs -text
+# Gaussian-splat / point-cloud previews are treated as binary, but they are
+# deliberately NOT routed through Git LFS.
+#
+# Why: Render clones this repo on every deploy. When a checked-out file is an
+# LFS pointer, git runs the `git-lfs filter-process` smudge filter during that
+# clone. Once the GitHub account's LFS budget is exhausted, the smudge fails,
+# the clone fails, and the deploy dies before the build ever starts — which is
+# exactly what took down the 2026-08-06 deploy of d6bddb4. An LFS-tracked
+# binary is therefore a hard, account-wide deploy dependency, not just a
+# storage choice.
+#
+# Large preview binaries belong on a CDN / Firebase Storage and should be
+# referenced by URL, so shipping the site never depends on LFS quota.
+*.ply binary
+*.spz binary

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,17 @@ on:
         description: "Exact git SHA to deploy on Render (operator-initiated redeploy/rollforward)."
         required: true
         type: string
+      clear_cache:
+        description: >-
+          Clear Render's build cache before deploying. Needed when a failed
+          clone left a partially-populated /opt/render/project/src behind:
+          Render then retries into a non-empty directory and every attempt
+          fails with "destination path already exists" regardless of what the
+          commit contains. Off by default because clearing the cache makes the
+          build materially slower.
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: render-deploy-main
@@ -85,6 +96,7 @@ jobs:
           RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
           RENDER_SERVICE_ID: ${{ vars.RENDER_SERVICE_ID }}
           DEPLOY_REF: ${{ steps.ref.outputs.deploy_ref }}
+          CLEAR_CACHE: ${{ github.event.inputs.clear_cache }}
         run: |
           set -euo pipefail
           if [ -z "${RENDER_API_KEY:-}" ]; then
@@ -98,7 +110,15 @@ jobs:
               exit 1
               ;;
           esac
-          payload=$(printf '{"commitId":"%s","clearCache":"do_not_clear"}' "${DEPLOY_REF}")
+          # Only an explicit workflow_dispatch opt-in clears the cache; the
+          # automatic post-CI path keeps the fast default.
+          if [ "${CLEAR_CACHE:-false}" = "true" ]; then
+            clear_cache_value="clear"
+          else
+            clear_cache_value="do_not_clear"
+          fi
+          echo "Render build cache: ${clear_cache_value}"
+          payload=$(printf '{"commitId":"%s","clearCache":"%s"}' "${DEPLOY_REF}" "${clear_cache_value}")
           response_code=$(curl -s -o /tmp/render-deploy-response.txt -w "%{http_code}" \
             --request POST \
             --header "Authorization: Bearer ${RENDER_API_KEY}" \

--- a/client/public/world-model-previews/interiorgs-0043-839876-3dgs-compressed.ply
+++ b/client/public/world-model-previews/interiorgs-0043-839876-3dgs-compressed.ply
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:479fa36a5e7eadd1c0fac95608bc0d8da35938ac0c20bac6056295ffbb588229
-size 76181685

--- a/client/public/world-model-previews/project-vintage-classroom-with-chalkboard.spz
+++ b/client/public/world-model-previews/project-vintage-classroom-with-chalkboard.spz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:34fefb16dffe515a507de6d69cebcb0a3974b0ff3c6b615778b4525ab27e643b
-size 15752292

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -6,11 +6,39 @@ import {
 } from "@heroicons/react/24/outline";
 
 import { SEO } from "@/components/SEO";
+import { ProofBoundary } from "@/components/blueprint";
+import {
+  ClearanceMarginChart,
+  DecisionShiftCompare,
+  EvidenceLadderChart,
+  RankingMarginChart,
+  StatRow,
+} from "@/components/site/figures";
 import {
   KineticBenchmark,
   ResultDecisionPanel,
 } from "@/components/site/KineticBenchmark";
 import { Reveal } from "@/components/site/motion";
+import {
+  Band,
+  Inner,
+  NoteCards,
+  SectionHeader,
+} from "@/components/site/publicSections";
+import { RunFilm } from "@/components/site/runFilm";
+import {
+  homeClaimMetricLabel,
+  homeDecisionCost,
+  homeEvidenceRungs,
+  homeLimits,
+  homeRankingCandidates,
+  homeRankingOodAxes,
+  homeRankingResolutionFloorPp,
+  homeRankingRolloutsPerCandidate,
+  homeRankingTestbedVersion,
+  homeScreeningMargins,
+  homeStats,
+} from "@/data/publicSiteCopy";
 import { webPageJsonLd } from "@/lib/seoStructuredData";
 
 const runHref =
@@ -166,6 +194,156 @@ export default function Home() {
           </Reveal>
         </div>
       </section>
+
+      {/*
+        The evidence half of the page. The kinetic panels above sell the shape of
+        a run; everything below is what the run is allowed to claim, and it is
+        deliberately in the same type size as the promises. Each block re-mounts
+        the component that owns the claim, so the disclosure and the figure it
+        qualifies can never drift apart in copy edits.
+      */}
+      <Band tone="ink">
+        <Inner className="py-16 lg:py-20">
+          <SectionHeader
+            index="01"
+            eyebrow="What you are buying"
+            title="One service. Priced per decision."
+            lede="Blueprint sells one thing: a Task Evaluation Run. Robot teams and site operators get their own explanation of it, then use the same intake, the same workflow, and the same result."
+            onInk
+          />
+          <div className="mt-12 overflow-hidden rounded-lg border border-white/10 bg-[#ded7c8]">
+            <StatRow tiles={homeStats} onInk />
+          </div>
+        </Inner>
+      </Band>
+
+      <Band tone="canvas">
+        <Inner className="py-20 lg:py-28">
+          <SectionHeader
+            index="02"
+            eyebrow="What changes"
+            title="A robot on site is a very expensive way to ask a question."
+            lede="A run does not replace the visit. It makes the visit a test of something you have already narrowed down."
+          />
+          <Reveal className="mt-14">
+            <DecisionShiftCompare rows={homeDecisionCost} />
+          </Reveal>
+        </Inner>
+      </Band>
+
+      {/* The seven acts, plus the two stamps a run is contractually barred from granting. */}
+      <Band tone="paper" rule>
+        <Inner className="py-20 lg:py-28">
+          <SectionHeader
+            index="03"
+            eyebrow="How a run moves"
+            title="Seven moves from a real task to an answer."
+            lede="Nothing here asks you to design an evaluation. You bring the job and the decision; the substrate and the method are ours to get right."
+          />
+          <RunFilm variant="compact" className="mt-16" />
+        </Inner>
+      </Band>
+
+      {/* Screening — the only pass that can name a cause rather than an order. */}
+      <Band tone="canvas">
+        <Inner className="py-20 lg:py-28">
+          <SectionHeader
+            index="04"
+            eyebrow="Ruled out first"
+            title="Some candidates the building will not take."
+            lede="Reach, clearance, footprint, sightlines. These come off the capture as distances, not as predictions — which makes this the one part of a run that can tell you what stopped a candidate and by how much. It is also the cheapest, so it runs before anything else."
+          />
+          <Reveal className="mt-14">
+            <ClearanceMarginChart rows={homeScreeningMargins} />
+          </Reveal>
+          <div className="mt-8 grid gap-5 lg:grid-cols-2">
+            <Reveal>
+              <ProofBoundary level="info" title="Read the figure this way">
+                The dock door misses by 18 cm against a 2 cm tolerance — the
+                whole interval sits below zero, so that candidate is out on
+                measurement. The rack upright is 4 cm short against a 5 cm
+                tolerance, so this capture cannot call it either way, and the run
+                says which one it is rather than picking.
+              </ProofBoundary>
+            </Reveal>
+            <Reveal delay={0.08}>
+              <ProofBoundary level="warn" title="What screening does not tell you">
+                That a candidate fits is not that a candidate works. Screening
+                clears the floor for the comparison; it says nothing about
+                whether the policy is any good. That is the next section, and it
+                is a weaker kind of claim.
+              </ProofBoundary>
+            </Reveal>
+          </div>
+        </Inner>
+      </Band>
+
+      {/* The ordering, shipped with its margin and its resolution floor. */}
+      <Band tone="paper" rule>
+        <Inner className="py-20 lg:py-28">
+          <SectionHeader
+            index="05"
+            eyebrow="The ordering"
+            title="Then the survivors get ranked, with the margin."
+            lede="One task, one pinned testbed version, the same conditions for every candidate. You get the order, the gap between each pair, the interval on that gap, and the smallest gap the design can separate at all."
+          />
+          <Reveal className="mt-14">
+            <RankingMarginChart
+              candidates={homeRankingCandidates}
+              rolloutsPerCandidate={homeRankingRolloutsPerCandidate}
+              resolutionFloorPp={homeRankingResolutionFloorPp}
+              testbedVersion={homeRankingTestbedVersion}
+              oodAxes={homeRankingOodAxes}
+              metricLabel={homeClaimMetricLabel}
+            />
+          </Reveal>
+          <div className="mt-8 grid gap-5 lg:grid-cols-2">
+            <Reveal>
+              <ProofBoundary level="info" title="Read the figure this way">
+                A leads C by 24 points and the interval on that gap stays clear
+                of zero, so it is a real lead. C leads D by 4 points, inside the
+                floor this design can resolve, so they are reported as tied at
+                this rollout count instead of ordered.
+              </ProofBoundary>
+            </Reveal>
+            <Reveal delay={0.08}>
+              <ProofBoundary level="warn" title="Where the ordering stops">
+                This is an ordering on this testbed, under these conditions. We
+                have not measured how our orderings track real-world orderings,
+                and we do not inherit anyone else's correlation figures as if
+                they were ours.
+              </ProofBoundary>
+            </Reveal>
+          </div>
+        </Inner>
+      </Band>
+
+      <Band tone="canvas">
+        <Inner className="py-20 lg:py-28">
+          <SectionHeader
+            index="06"
+            eyebrow="How we spend your budget"
+            title="The cheapest evidence that is actually good enough."
+            lede="You will not be asked to choose a simulator, a world model, or a provider. That choice depends on what each claim needs, which is exactly the part you are paying us to know. Cheaper is about cost, not about proving less — real capture stays the reference, and derived methods stay support."
+          />
+          <Reveal className="mt-14">
+            <EvidenceLadderChart rungs={homeEvidenceRungs} />
+          </Reveal>
+        </Inner>
+      </Band>
+
+      <Band tone="ink">
+        <Inner className="py-20 lg:py-28">
+          <SectionHeader
+            index="07"
+            eyebrow="Where we stop"
+            title="The limits, in the same size type as the promises."
+            lede="If these are going to be a problem for your decision, it is cheaper for both of us to know now."
+            onInk
+          />
+          <NoteCards items={homeLimits} onInk className="mt-14" />
+        </Inner>
+      </Band>
 
       <section className="relative isolate overflow-hidden bg-kinetic-blue text-white">
         <img

--- a/client/tests/pages/About.test.tsx
+++ b/client/tests/pages/About.test.tsx
@@ -27,7 +27,7 @@ describe("About", () => {
     siteLinks.forEach((link) => {
       expect(link).toHaveAttribute("href", "/sites");
     });
-    const contactLinks = screen.getAllByRole("link", { name: /Request a Task Evaluation Run/i });
+    const contactLinks = screen.getAllByRole("link", { name: /Scope a benchmark/i });
     expect(contactLinks.length).toBeGreaterThanOrEqual(1);
     contactLinks.forEach((link) => {
       expect(link.getAttribute("href")).toMatch(/^\/contact\/robot-team/);

--- a/client/tests/pages/ForRobotTeams.test.tsx
+++ b/client/tests/pages/ForRobotTeams.test.tsx
@@ -8,11 +8,11 @@ describe("ForRobotTeams", () => {
     expect(
       screen.getByRole("heading", {
         level: 1,
-        name: /Spend field time on the candidate that earned it/i,
+        name: /Know which checkpoint deserves the pilot/i,
       }),
     ).toBeInTheDocument();
     expect(
-      screen.getAllByRole("link", { name: /Request a Task Evaluation Run/i }).length,
+      screen.getAllByRole("link", { name: /Scope a benchmark/i }).length,
     ).toBeGreaterThan(0);
 
     // A ranking is explicitly not the promise.

--- a/client/tests/pages/ForSiteOperators.test.tsx
+++ b/client/tests/pages/ForSiteOperators.test.tsx
@@ -12,7 +12,7 @@ describe("ForSiteOperators", () => {
       }),
     ).toBeInTheDocument();
     expect(
-      screen.getAllByRole("link", { name: /Request a Task Evaluation Run/i }).length,
+      screen.getAllByRole("link", { name: /Scope a site benchmark/i }).length,
     ).toBeGreaterThan(0);
 
     // Same service as the robot-team persona, entered from the other side.

--- a/client/tests/pages/Home.test.tsx
+++ b/client/tests/pages/Home.test.tsx
@@ -5,14 +5,17 @@ import Home from "@/pages/Home";
 describe("Home", () => {
   it("leads with screening then ranking, and keeps one primary CTA", () => {
     const { container } = render(<Home />);
+    // The kinetic rebuild replaced the hero headline and the primary CTA label.
+    // Those are presentation; everything asserted below this point is what the
+    // page is allowed to claim, and that did not change with the redesign.
     expect(
       screen.getByRole("heading", {
         level: 1,
-        name: /Rank your candidates on the site you are bidding on, before the pilot/i,
+        name: /Turn one site walkthrough into a robot benchmark by tomorrow/i,
       }),
     ).toBeInTheDocument();
     expect(
-      screen.getAllByRole("link", { name: /Request a Task Evaluation Run/i }).length,
+      screen.getAllByRole("link", { name: /Plan your first benchmark/i }).length,
     ).toBeGreaterThan(0);
 
     // The lifecycle still reads task -> maintained testbed -> routed evidence ->
@@ -61,8 +64,14 @@ describe("Home", () => {
     expect(figures.length).toBeGreaterThanOrEqual(4);
 
     // The three figures that plot schematic values must carry the marker, and so
-    // must the run film, so none of the four can be read as live run data. The
+    // must the run film, so none of those four can be read as live run data. The
     // qualitative before/after comparison plots nothing and needs none.
-    expect(screen.getAllByText(/^Illustrative$/i).length).toBe(4);
+    //
+    // The fifth is the kinetic evidence-envelope image, which the redesign added
+    // with its own marker. It is counted here rather than exempted: the marker
+    // is what stops a rendered scene being read as a captured result, so the
+    // assertion tracks every element claiming illustrative status, and a drop
+    // back to four would mean one of them lost its marker.
+    expect(screen.getAllByText(/^Illustrative$/i).length).toBe(5);
   });
 });

--- a/client/tests/pages/HowItWorks.test.tsx
+++ b/client/tests/pages/HowItWorks.test.tsx
@@ -6,7 +6,7 @@ describe("HowItWorks", () => {
   it("shows decision-oriented intake, routing owned by the pipeline, abstention, and the next experiment", () => {
     const { container } = render(<HowItWorks />);
     expect(
-      screen.getByRole("heading", { level: 1, name: /Seven moves from a real site-task to a ranked shortlist/i }),
+      screen.getByRole("heading", { level: 1, name: /Walk the site\. We build the benchmark\. You get the decision\./i }),
     ).toBeInTheDocument();
 
     // The walkthrough is now the run film. Its acts carry the same beats the
@@ -32,7 +32,7 @@ describe("HowItWorks", () => {
     expect(container).toHaveTextContent(/Safety certification/i);
 
     expect(
-      screen.getAllByRole("link", { name: /Request a Task Evaluation Run/i })[0],
+      screen.getAllByRole("link", { name: /Scope a benchmark/i })[0],
     ).toHaveAttribute("href", expect.stringContaining("/contact/robot-team"));
     expect(screen.queryByText(/Policy Improvement Run/i)).not.toBeInTheDocument();
   });

--- a/client/tests/pages/Pricing.test.tsx
+++ b/client/tests/pages/Pricing.test.tsx
@@ -8,13 +8,16 @@ describe("Pricing", () => {
     expect(
       screen.getByRole("heading", {
         level: 1,
-        name: /You pay for the decision, not a package/i,
+        name: /Buy one decision before you buy the field time/i,
       }),
     ).toBeInTheDocument();
     expect(screen.getByText(/^Task Evaluation Run$/i)).toBeInTheDocument();
-    expect(screen.getByText(/^Scoped quote$/i)).toBeInTheDocument();
+    // Scoped to the heading: the same string also appears as a hero chip.
     expect(
-      screen.getAllByRole("link", { name: /Request a Task Evaluation Run/i }).length,
+      screen.getByRole("heading", { name: /^From \$2,500$/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getAllByRole("link", { name: /Scope a benchmark/i }).length,
     ).toBeGreaterThan(0);
 
     // Price is set server-side; a client-supplied number is not authoritative.
@@ -24,7 +27,9 @@ describe("Pricing", () => {
     ).toBeInTheDocument();
     // A quote buys work, not a favourable verdict.
     expect(screen.getByText(/No guaranteed outcome/i)).toBeInTheDocument();
-    expect(screen.getByText(/none of them is a tier/i)).toBeInTheDocument();
+    // The "not a packaged tier" promise survives the rebuild, restated as the
+    // absence of a subscription rather than the absence of tiers.
+    expect(screen.getByText(/No subscription required/i)).toBeInTheDocument();
 
     expect(screen.queryByText(/\$3,000/)).not.toBeInTheDocument();
     expect(screen.queryByText(/\$5,000/)).not.toBeInTheDocument();

--- a/client/tests/pages/Proof.test.tsx
+++ b/client/tests/pages/Proof.test.tsx
@@ -34,7 +34,7 @@ describe("Proof page", () => {
       screen.getByText(/Estimates are not physical guarantees, safety approval remains external/i),
     ).toBeInTheDocument();
     expect(
-      screen.getAllByRole("link", { name: /^Request a Task Evaluation Run$/i })[0],
+      screen.getAllByRole("link", { name: /^Scope a benchmark$/i })[0],
     ).toHaveAttribute("href", expect.stringContaining("/contact/robot-team"));
   });
 });

--- a/docs/runbooks/ci-gated-deploy-2026-07-16.md
+++ b/docs/runbooks/ci-gated-deploy-2026-07-16.md
@@ -74,6 +74,42 @@ an empty directory` no matter how healthy the commit is. Clearing the cache is
 the only way out; leave it off otherwise, since it makes the build materially
 slower.
 
+## Correction (2026-08-07): deploy ownership is not currently singular
+
+The "RESOLVED 2026-07-21" banner above and `render.yaml`'s `autoDeploy: false`
+both assert that this workflow is the only path to production. As of
+2026-08-07 that is **not** what the evidence shows, and the banner is retained
+above only as the record of what was true on 2026-07-21.
+
+What was observed:
+
+- `d6bddb4` (merge of #436) landed on `main` on 2026-08-06 and **no `CI`
+  workflow run exists for it**. The newest `CI` run on `main` is `e3e7181`
+  from 2026-08-04.
+- Render nevertheless attempted a deploy of `d6bddb4` on 2026-08-06 at
+  16:24 CDT. With no green CI run for that SHA, `deploy.yml` cannot have
+  fired it — its `workflow_run` trigger requires a completed successful `CI`
+  run on `main`.
+
+The remaining explanation is that Render-native auto-deploy is still enabled
+on the service. `render.yaml`'s `autoDeploy: false` governs Blueprint-synced
+services only, so the dashboard setting can drift from the file without
+anything failing loudly.
+
+Two consequences worth stating plainly:
+
+- Production can currently ship a commit that CI never verified. That is how
+  `d6bddb4` reached Render carrying 9 failing tests.
+- Conversely, while `main` is red the CI-gated path cannot deploy at all, so
+  native auto-deploy is the only thing still shipping.
+
+Not changed here, deliberately: turning auto-deploy off while `main` is red
+would leave no working deploy path. Re-confirm the service's `autoDeploy`
+setting through the Render API once `main` is green again, and re-assert
+single ownership then. The open question of *why* no `CI` run was created for
+that push (Actions usage limits, disabled workflows, or a branch-protection
+gap) is still unresolved and is the reason a red merge shipped unnoticed.
+
 ## Failure mode: Git LFS breaks the deploy clone (2026-08-06)
 
 The 2026-08-06 deploy of `d6bddb4` (merge of #436, the kinetic site redesign)

--- a/docs/runbooks/ci-gated-deploy-2026-07-16.md
+++ b/docs/runbooks/ci-gated-deploy-2026-07-16.md
@@ -66,6 +66,42 @@ ownership semantics.
 `Actions → Deploy (Render, CI-gated) → Run workflow` with the exact SHA to
 deploy. Use only SHAs that have a green CI run.
 
+Set the `clear_cache` input to `true` when a previous deploy failed *during
+clone or checkout* rather than during build. A failed clone can leave a
+partially-populated `/opt/render/project/src` in the build cache, after which
+Render's retries all fail with `destination path ... already exists and is not
+an empty directory` no matter how healthy the commit is. Clearing the cache is
+the only way out; leave it off otherwise, since it makes the build materially
+slower.
+
+## Failure mode: Git LFS breaks the deploy clone (2026-08-06)
+
+The 2026-08-06 deploy of `d6bddb4` (merge of #436, the kinetic site redesign)
+failed before the build started, leaving production on the older `e3e7181`.
+
+Cause: `client/public/world-model-previews/` held two Git LFS-tracked binaries
+(a 76 MB `.ply` and a 16 MB `.spz`). Render clones the repo on every deploy, and
+a checked-in LFS pointer makes that clone run the `git-lfs filter-process`
+smudge filter. The GitHub account's LFS budget was exhausted, so the smudge
+returned `This repository exceeded its LFS budget`, the clone aborted, and the
+retries then hit the stale-directory error above.
+
+The important property: **an LFS-tracked binary is an account-wide deploy
+dependency, not just a storage choice.** Blowing the LFS quota takes production
+deploys down even when every commit is green.
+
+Resolution and current guard rails:
+
+- Both binaries were removed; nothing in the app referenced them (the only
+  mention in the repo was a docs line recommending they move to a CDN).
+- `.gitattributes` no longer routes `*.ply` / `*.spz` through LFS.
+- `npm run audit:assets` (a CI `check`-job step) now fails on any checked-in
+  LFS pointer file, so this cannot silently return.
+
+Large preview binaries belong on a CDN / Firebase Storage, referenced by URL.
+The LFS objects themselves still exist in GitHub's LFS store and in git history,
+so they remain recoverable if the budget is raised.
+
 ## Rollback
 
 Rollback is revert-commit based — never rewrite history:

--- a/e2e/docs-blog.spec.ts
+++ b/e2e/docs-blog.spec.ts
@@ -17,7 +17,7 @@ test("blog alias redirects to home", async ({ page }) => {
   await expect(page).toHaveURL(/\/$/);
   await expect(
     page.getByRole("heading", {
-      name: /Rank your candidates on the site you are bidding on, before the pilot\./i,
+      name: /Turn one site walkthrough into a robot benchmark by tomorrow\./i,
     }),
   ).toBeVisible();
 });

--- a/e2e/exact-site-hosted-review.spec.ts
+++ b/e2e/exact-site-hosted-review.spec.ts
@@ -8,7 +8,7 @@ test("exact-site hosted review route redirects to home", async ({ page }) => {
   await expect(page).toHaveURL(/\/$/);
   await expect(
     page.getByRole("heading", {
-      name: /Rank your candidates on the site you are bidding on, before the pilot\./i,
+      name: /Turn one site walkthrough into a robot benchmark by tomorrow\./i,
     }),
   ).toBeVisible();
 });

--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -3,13 +3,16 @@ import { test, expect } from '@playwright/test';
 test('homepage leads with the single Task Evaluation Run story', async ({ page }) => {
   await page.goto('/');
 
+  // The kinetic rebuild renamed the hero headline, the primary CTA, and the
+  // robot-team nav entry. Those are presentation. Every assertion below about
+  // what the page may claim is unchanged, and still holds.
   await expect(
     page.getByRole('heading', {
-      name: /Rank your candidates on the site you are bidding on, before the pilot\./i,
+      name: /Turn one site walkthrough into a robot benchmark by tomorrow\./i,
     }),
   ).toBeVisible();
   const nav = page.getByRole('banner').getByRole('navigation');
-  await expect(nav.getByRole('link', { name: /^For Robot Teams$/i })).toBeVisible();
+  await expect(nav.getByRole('link', { name: /^Product$/i })).toBeVisible();
   // Site operators are demoted out of the primary header nav to the footer.
   await expect(nav.getByRole('link', { name: /^For Site Operators$/i })).toHaveCount(0);
   await expect(nav.getByRole('link', { name: /^How it works$/i })).toBeVisible();
@@ -17,7 +20,11 @@ test('homepage leads with the single Task Evaluation Run story', async ({ page }
   await expect(
     page.getByRole('contentinfo').getByRole('link', { name: /^For Site Operators$/i }),
   ).toBeVisible();
-  await expect(page.getByRole('link', { name: /^Request a Task Evaluation Run$/i }).first()).toBeVisible();
+  await expect(page.getByRole('link', { name: /^Plan your first benchmark$/i }).first()).toBeVisible();
+  // The run intake stays reachable under its full name from the footer.
+  await expect(
+    page.getByRole('contentinfo').getByRole('link', { name: /^Request a Task Evaluation Run$/i }),
+  ).toBeVisible();
 
   // One service, and the lifecycle behind it.
   await expect(

--- a/e2e/pricing.spec.ts
+++ b/e2e/pricing.spec.ts
@@ -7,11 +7,11 @@ test("pricing page presents one scoped Task Evaluation Run", async ({
 
   await expect(
     page.getByRole("heading", {
-      name: "You pay for the decision, not a package.",
+      name: "Buy one decision before you buy the field time.",
     }),
   ).toBeVisible();
   await expect(
-    page.getByRole("heading", { name: "Scoped quote", exact: true }),
+    page.getByRole("heading", { name: "From $2,500", exact: true }),
   ).toBeVisible();
   await expect(
     page.getByRole("heading", { name: "One scoped run, and everything needed to read it.", exact: true }),
@@ -21,7 +21,7 @@ test("pricing page presents one scoped Task Evaluation Run", async ({
   await expect(page.getByText(/No guaranteed outcome/i)).toBeVisible();
   // The single engagement CTA lands on the shared robot-team-first intake.
   await expect(
-    page.getByRole("link", { name: /Request a Task Evaluation Run/i }).first(),
+    page.locator("main").getByRole("link", { name: /Scope a benchmark/i }).first(),
   ).toHaveAttribute("href", /\/contact\/robot-team/);
   await expect(page.getByText(/Policy Shortlist/i)).toHaveCount(0);
   await expect(page.getByText(/Robot Match/i)).toHaveCount(0);

--- a/e2e/robot-team-eval.spec.ts
+++ b/e2e/robot-team-eval.spec.ts
@@ -4,10 +4,10 @@ test("legacy robot-team evaluation URL reaches the current product", async ({ pa
   await page.goto("/robot-team/eval");
   await expect(page).toHaveURL(/\/for-robot-teams/);
   await expect(
-    page.getByRole("heading", { name: "Spend field time on the candidate that earned it." }),
+    page.getByRole("heading", { name: "Know which checkpoint deserves the pilot." }),
   ).toBeVisible();
   await expect(
-    page.getByRole("link", { name: /Request a Task Evaluation Run/i }).first(),
+    page.locator("main").getByRole("link", { name: /Scope a benchmark/i }).first(),
   ).toHaveAttribute("href", /\/contact\/robot-team/);
 });
 
@@ -26,7 +26,7 @@ test("robot-team and site-operator pages describe one service and intake", async
     }),
   ).toBeVisible();
   await expect(
-    page.locator("main").getByRole("link", { name: /Request a Task Evaluation Run/i }).first(),
+    page.locator("main").getByRole("link", { name: /Scope a site benchmark/i }).first(),
   ).toHaveAttribute("href", /\/contact\/site-operator/);
   await expect(page.getByText(/Robot Match/i)).toHaveCount(0);
 });
@@ -35,7 +35,7 @@ test("persona pages are usable on mobile", async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 844 });
   await page.goto("/for-robot-teams");
   await expect(
-    page.getByRole("link", { name: /Request a Task Evaluation Run/i }).first(),
+    page.getByRole("link", { name: /Scope a benchmark/i }).first(),
   ).toBeVisible();
   const hasHorizontalOverflow = await page.evaluate(
     () => document.documentElement.scrollWidth > document.documentElement.clientWidth + 1,

--- a/scripts/audit-assets.ts
+++ b/scripts/audit-assets.ts
@@ -102,6 +102,41 @@ function collectOversizedFiles(): Array<{ path: string; size: number }> {
   return oversized;
 }
 
+// Git LFS pointer files are small text stubs that stand in for the real blob.
+// Render clones this repo on every deploy, and any pointer in the checkout
+// makes that clone invoke the git-lfs smudge filter — so once the account's
+// LFS budget is exhausted the clone fails and the deploy dies before the build
+// starts. A pointer committed here is therefore a production outage waiting on
+// a quota, which is what happened to the 2026-08-06 deploy of d6bddb4.
+const lfsPointerSignature = "version https://git-lfs.github.com/spec/v1";
+const maxLfsPointerSizeBytes = 1024;
+
+function collectLfsPointerFiles(): string[] {
+  const files = walkFiles(repoRoot);
+  const pointers: string[] = [];
+
+  for (const filePath of files) {
+    // Real LFS payloads are large; pointers are always a few hundred bytes.
+    // Bounding the read keeps this from slurping genuine binaries.
+    if (fs.statSync(filePath).size > maxLfsPointerSizeBytes) {
+      continue;
+    }
+
+    let head: string;
+    try {
+      head = fs.readFileSync(filePath, "utf8");
+    } catch {
+      continue;
+    }
+
+    if (head.startsWith(lfsPointerSignature)) {
+      pointers.push(toPosixPath(path.relative(repoRoot, filePath)));
+    }
+  }
+
+  return pointers;
+}
+
 function isPublicAssetReferenced(assetPath: string, corpus: string): boolean {
   const relFromPublic = toPosixPath(path.relative(publicRoot, assetPath));
   const publicUrl = `/${relFromPublic}`;
@@ -127,6 +162,15 @@ function main() {
     issues.push(
       `Root screenshot dump files found:\n${rootScreenshotDumps
         .map((entry) => `  - ${toPosixPath(path.relative(repoRoot, entry))}`)
+        .join("\n")}`,
+    );
+  }
+
+  const lfsPointerFiles = collectLfsPointerFiles();
+  if (lfsPointerFiles.length > 0) {
+    issues.push(
+      `Git LFS pointer files are checked in. Render's deploy clone smudges these, so an exhausted LFS budget takes production down. Host these on a CDN / Firebase Storage and reference them by URL instead:\n${lfsPointerFiles
+        .map((entry) => `  - ${entry}`)
         .join("\n")}`,
     );
   }

--- a/scripts/qa/brand-polish.ts
+++ b/scripts/qa/brand-polish.ts
@@ -152,7 +152,7 @@ export const publicQaRoutes: PublicQaRoute[] = [
     label: "Home",
     path: "/",
     canonicalPath: "/",
-    expectedHeading: "Rank your candidates on the site you are bidding on, before the pilot.",
+    expectedHeading: "Turn one site walkthrough into a robot benchmark by tomorrow.",
     requiredCtas: [
       { label: "Request a Task Evaluation Run", hrefStartsWith: "/contact" },
       { label: "How it works", hrefStartsWith: "/how-it-works" },
@@ -162,7 +162,7 @@ export const publicQaRoutes: PublicQaRoute[] = [
     label: "Product (legacy, redirects to Home)",
     path: "/product",
     canonicalPath: "/",
-    expectedHeading: "Rank your candidates on the site you are bidding on, before the pilot.",
+    expectedHeading: "Turn one site walkthrough into a robot benchmark by tomorrow.",
     requiredCtas: [
       { label: "Request a Task Evaluation Run", hrefStartsWith: "/contact" },
       { label: "How it works", hrefStartsWith: "/how-it-works" },
@@ -192,7 +192,7 @@ export const publicQaRoutes: PublicQaRoute[] = [
     label: "Pricing",
     path: "/pricing",
     canonicalPath: "/pricing",
-    expectedHeading: "You pay for the decision, not a package.",
+    expectedHeading: "Buy one decision before you buy the field time.",
     requiredCtas: [
       { label: "Request a Task Evaluation Run", hrefStartsWith: "/contact" },
     ],
@@ -257,7 +257,7 @@ export const publicQaRoutes: PublicQaRoute[] = [
     label: "Updates (legacy, redirects to Home)",
     path: "/updates",
     canonicalPath: "/",
-    expectedHeading: "Rank your candidates on the site you are bidding on, before the pilot.",
+    expectedHeading: "Turn one site walkthrough into a robot benchmark by tomorrow.",
     requiredCtas: [
       { label: "Request a Task Evaluation Run", hrefStartsWith: "/contact" },
       { label: "How it works", hrefStartsWith: "/how-it-works" },


### PR DESCRIPTION
Gets the #436 kinetic redesign actually shipping. Two independent blockers, one per commit.

## Problem 1 — the Render clone (commit `9aa2e3f`)

The 2026-08-06 deploy of `d6bddb4` (merge of #436) **failed before the build started**. Production is still serving `e3e7181` from Aug 4 — verified live:

```
$ curl https://tryblueprint.io/version.json
{"service":"blueprint-webapp","git_sha":"e3e71815...","built_at_iso":"2026-08-04T03:49:16.976Z"}
```

Two Git LFS binaries under `client/public/world-model-previews/` — a 76 MB `.ply` and a 16 MB `.spz` — made Render's clone run the `git-lfs` smudge filter. The account's LFS budget was exhausted:

```
batch response: This repository exceeded its LFS budget.
fatal: ...interiorgs-0043-839876-3dgs-compressed.ply: smudge filter lfs failed
```

That aborted the clone, and the retries then hit `destination path '/opt/render/project/src' already exists` because the failed attempt left a partial source dir in the build cache.

**An LFS-tracked binary is an account-wide deploy dependency, not a storage choice.** It fails in the clone, upstream of every CI gate this repo has.

- Removed both binaries. Nothing referenced them — the only mention in the repo was a docs line recommending they move to a CDN. They were already broken in production anyway: with the budget blown, a checkout yields 133-byte pointer stubs, not splats. The LFS objects remain in GitHub's store and in git history, so they're recoverable if the budget is raised.
- Stopped routing `*.ply` / `*.spz` through LFS in `.gitattributes`.
- `npm run audit:assets` now fails on any checked-in LFS pointer. It already runs in CI's `check` job. Worth noting the existing oversized-file check skips `client/public/` entirely — that's how a 76 MB asset got in.
- Added a `clear_cache` input to the deploy workflow; it hardcoded `do_not_clear`, and a poisoned cache has no other exit.

## Problem 2 — #436 merged red (commit `7321dfd`)

Fixing the clone isn't enough: **the deploy workflow only fires on a green CI run on `main`**, and `main` is red.

#436 replaced `Home.tsx` wholesale and updated three test files, but left `Home.test.tsx` and every e2e spec asserting the old page. It merged with **9 failing tests**, reproducible on `main` at `d6bddb4`. No CI run exists for that SHA, so nothing caught it.

The failures were not all stale copy. Several asserted disclosures the rebuild dropped:

| Disclosure | State after #436 |
|---|---|
| Figures plotting schematic values carry a visible "Illustrative" marker | **no `<figure>` rendered at all** — nothing separated a drawn example from a measured result |
| "None of these rows is a prediction" | gone |
| "We have not measured how our orderings track real-world orderings" | gone |
| No "Deployment approval" / "Safety certification" | gone — and `DecisionEnvelope` fails validation unless both are false, so these are contract-level guarantees |

None of the underlying components were deleted, only orphaned. So the substance is restored by **re-mounting** them rather than rewriting copy: the run film with its acts and stamps, the screening and ranking figures with their `ProofBoundary` readings, the evidence ladder, and the limits cards. The kinetic hero, artifact grid, result panel, and closing CTA are untouched — the rebuild's design survives intact above the evidence sections.

Test changes are confined to what #436 genuinely renamed: hero headlines, CTA labels (`Request a Task Evaluation Run` → `Scope a benchmark`), and the nav entry (`For Robot Teams` → `Product`). Every assertion about what a page may *claim* is unchanged. Two exceptions, stated rather than silently absorbed:

- **Illustrative-marker count 4 → 5.** The fifth is the kinetic evidence-envelope image, which ships its own marker. Counting it means a drop back to four now *fails* — the assertion tracks every element claiming illustrative status instead of exempting the new one.
- **Pricing's "none of them is a tier" → "No subscription required".** The no-packaged-tiers promise survives in the form the page now states it.

## Verification

| Check | Result |
|---|---|
| `npm run check` | pass |
| `npm run test:coverage` | **1785 passed / 353 files** |
| `npm run test:e2e` | **28 passed** (incl. the 5.3-min brand-polish sweep) |
| `npm run build` | pass |
| `npm run test:build-output` | pass (7/7) |
| `npm run audit:assets` | pass |
| `npm run claims:guard` | pass — no drift findings |
| `npm run doctrine:verify` | pass |
| `npm run smoke:launch:local` | pass |

The new LFS guard was negative-tested: a planted pointer at `client/public/__lfs-guard-probe.ply` correctly fails the audit; probe removed after.

## Also found: deploy ownership is not actually singular

`render.yaml` says `autoDeploy: false` and the runbook's banner says this workflow is the only path to production. The evidence disagrees: **`d6bddb4` has no CI run**, yet Render attempted a deploy of it — which `deploy.yml` cannot have triggered, since its `workflow_run` gate requires a successful CI run. Native auto-deploy appears to still be on, and `render.yaml` only governs Blueprint-synced services, so the dashboard can drift without failing loudly.

That means production can currently ship a commit CI never verified — which is exactly how `d6bddb4` reached Render with 9 failing tests.

Documented in the runbook, **not changed**: turning auto-deploy off while `main` is red would leave no working deploy path. Worth re-asserting single ownership once this merges and `main` is green.

Still open: *why* no CI run was created for that push (Actions usage limits, disabled workflows, or a branch-protection gap). That's the reason a red merge shipped unnoticed, and it's not something this PR can fix.

## After merge

The first deploy may still hit the leftover `/opt/render/project/src`. If it does: Render dashboard → **Clear build cache & deploy**, or Actions → **Deploy (Render, CI-gated) → Run workflow** with `clear_cache: true`.

The LFS budget is still exhausted at the account level. Nothing in the app depends on it now, but future `git lfs` use needs it raised.