### PR TITLE
Discover immutable Task Evaluation profiles from Pipeline

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -215,13 +215,13 @@ Agent-side creative MCP note:
 ### Internal Marketplace + Pipeline
 - `PIPELINE_SYNC_TOKEN`
 - Production Task Evaluation launch bridge:
-  - `TASK_EVALUATION_LAUNCH_URL=https://<pipeline-host>/api/live-pipeline/task-evaluation-launches`
-  - `TASK_EVALUATION_RUN_FORWARD_TOKEN` matching the Pipeline intake HMAC client secret
+  - `TASK_EVALUATION_LAUNCH_URL=https://<pipeline-host>/api/live-pipeline/task-evaluation-launches`; optional when `ROBOT_EVAL_JOB_REQUEST_FORWARD_URL` is the canonical Pipeline `/job-requests` endpoint
+  - `TASK_EVALUATION_RUN_FORWARD_TOKEN` matching the Pipeline intake HMAC client secret; optional when the canonical `ROBOT_EVAL_JOB_REQUEST_FORWARD_TOKEN` is already configured
   - `TASK_EVALUATION_RUN_FORWARD_CLIENT_ID=blueprint-webapp`
   - `TASK_EVALUATION_LAUNCH_FORWARD_REQUIRED=true`
   - `BLUEPRINT_TASK_EVALUATION_LAUNCH_FORWARD_WORKER_ENABLED=true` on the Render worker so a crash between the durable Firestore write and signed Pipeline POST is recovered
   - `TASK_EVALUATION_LAUNCH_FORWARD_MAX_ATTEMPTS=20` bounds intake-transport retries; these are idempotent queue deliveries and never authorize a paid GPU retry
-  - `TASK_EVALUATION_LAUNCH_PROFILES_JSON` set to the exact descriptor catalog emitted by Pipeline's `publish_task_evaluation_launch_profiles.py`
+  - `TASK_EVALUATION_LAUNCH_PROFILES_JSON` set to the exact descriptor catalog emitted by Pipeline's `publish_task_evaluation_launch_profiles.py`, or leave it empty so the server fetches and validates Pipeline's public `/api/live-pipeline/task-evaluation-launch-profiles` descriptor catalog; `TASK_EVALUATION_LAUNCH_PROFILES_URL` is an optional explicit catalog endpoint override
   - `PIPELINE_SYNC_TOKEN` matching the Pipeline receipt publisher
   - authenticated admin/ops control surface: `/ops/task-evaluation-launches`
 - `BLUEPRINT_REQUEST_REVIEW_TOKEN_SECRET`

--- a/render.required.env.example
+++ b/render.required.env.example
@@ -91,13 +91,18 @@ CHECKOUT_ALLOWED_ORIGINS=https://www.tryblueprint.io,https://tryblueprint.io
 ########################################
 
 PIPELINE_SYNC_TOKEN=
+# Optional overrides. When unset, the Task Evaluation bridge derives its endpoint
+# from ROBOT_EVAL_JOB_REQUEST_FORWARD_URL and reuses that canonical HMAC token.
 TASK_EVALUATION_LAUNCH_URL=
 TASK_EVALUATION_RUN_FORWARD_TOKEN=
 TASK_EVALUATION_RUN_FORWARD_CLIENT_ID=blueprint-webapp
 TASK_EVALUATION_LAUNCH_FORWARD_REQUIRED=true
 BLUEPRINT_TASK_EVALUATION_LAUNCH_FORWARD_WORKER_ENABLED=true
 TASK_EVALUATION_LAUNCH_FORWARD_MAX_ATTEMPTS=20
+# Optional immutable inline override. When empty, the server reads the validated
+# public descriptor catalog from the canonical Pipeline endpoint.
 TASK_EVALUATION_LAUNCH_PROFILES_JSON=[]
+TASK_EVALUATION_LAUNCH_PROFILES_URL=
 
 ########################################
 # Autonomous alpha lane enables

--- a/server/routes/admin-task-evaluation-launches.ts
+++ b/server/routes/admin-task-evaluation-launches.ts
@@ -6,7 +6,7 @@ import { resolveAccessContext } from "../utils/access-control";
 import {
   buildTaskEvaluationLaunchRequest,
   forwardTaskEvaluationLaunch,
-  loadPublishedLaunchProfiles,
+  resolvePublishedLaunchProfiles,
   taskEvaluationLaunchInputSchema,
 } from "../utils/taskEvaluationLaunchContract";
 
@@ -15,11 +15,11 @@ const COLLECTION = "taskEvaluationLaunches";
 
 router.use(requireAdminRole);
 
-router.get("/profiles", (_req, res) => {
+router.get("/profiles", async (_req, res) => {
   res.set("Cache-Control", "no-store");
   return res.json({
     schema_version: "task_evaluation_launch_profile_catalog.v1",
-    profiles: loadPublishedLaunchProfiles(),
+    profiles: await resolvePublishedLaunchProfiles(),
   });
 });
 
@@ -34,7 +34,7 @@ router.post("/", async (req, res) => {
     error: "Spend authority has expired",
     code: "task_evaluation_launch_spend_authority_expired",
   });
-  const profile = loadPublishedLaunchProfiles().find((candidate) =>
+  const profile = (await resolvePublishedLaunchProfiles()).find((candidate) =>
     candidate.profile_id === parsed.data.profile_id
     && candidate.profile_digest === parsed.data.profile_digest,
   );

--- a/server/tests/task-evaluation-launch-contract.test.ts
+++ b/server/tests/task-evaluation-launch-contract.test.ts
@@ -9,6 +9,9 @@ import {
   forwardTaskEvaluationLaunch,
   loadPublishedLaunchProfiles,
   parseTaskEvaluationLaunchReceipt,
+  resolvePublishedLaunchProfiles,
+  resolveTaskEvaluationLaunchUrl,
+  resolveTaskEvaluationProfileCatalogUrl,
   taskEvaluationLaunchInputSchema,
 } from "../utils/taskEvaluationLaunchContract";
 
@@ -67,7 +70,13 @@ function input() {
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
   delete process.env.TASK_EVALUATION_LAUNCH_PROFILES_JSON;
+  delete process.env.TASK_EVALUATION_LAUNCH_PROFILES_URL;
+  delete process.env.TASK_EVALUATION_LAUNCH_URL;
+  delete process.env.TASK_EVALUATION_RUN_FORWARD_TOKEN;
+  delete process.env.ROBOT_EVAL_JOB_REQUEST_FORWARD_URL;
+  delete process.env.ROBOT_EVAL_JOB_REQUEST_FORWARD_TOKEN;
 });
 
 describe("Task Evaluation production launch contract", () => {
@@ -126,6 +135,69 @@ describe("Task Evaluation production launch contract", () => {
     });
 
     expect(result).toMatchObject({ status: "forwarded", performed: true, http_status: 202 });
+  });
+
+  it("reuses the canonical robot-eval Pipeline bridge for Task Evaluation intake", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    process.env.ROBOT_EVAL_JOB_REQUEST_FORWARD_URL =
+      "https://paperclip.tryblueprint.io/api/live-pipeline/job-requests";
+    process.env.ROBOT_EVAL_JOB_REQUEST_FORWARD_TOKEN = "canonical-forward-secret";
+    const request = buildTaskEvaluationLaunchRequest({
+      input: input(), profile: profile(), actorId: "founder-001", actorRole: "admin",
+      authorizedAt: "2026-08-10T12:00:00.000Z",
+    });
+    vi.stubGlobal("fetch", vi.fn(async (url: string, init: RequestInit) => {
+      expect(url).toBe(
+        "https://paperclip.tryblueprint.io/api/live-pipeline/task-evaluation-launches",
+      );
+      const headers = init.headers as Record<string, string>;
+      const expected = createHmac("sha256", "canonical-forward-secret")
+        .update(
+          `${headers["x-blueprint-pipeline-timestamp"]}.blueprint-webapp.${headers["x-blueprint-pipeline-nonce"]}.${init.body}`,
+        )
+        .digest("hex");
+      expect(headers["x-blueprint-pipeline-signature"]).toBe(`sha256=${expected}`);
+      return new Response(JSON.stringify({
+        schema_version: "task_evaluation_launch_intake_receipt.v1",
+        status: "accepted",
+        provider_mutation_performed_inside_http_request: false,
+        queue: {
+          schema_version: "task_evaluation_launch_queue_receipt.v1",
+          status: "queued",
+          launch_id: request.launch_id,
+          run_id: request.run_id,
+          request_digest: request.request_digest,
+          provider_mutation_performed: false,
+        },
+      }), { status: 202, headers: { "content-type": "application/json" } });
+    }));
+
+    expect(resolveTaskEvaluationLaunchUrl()).toBe(
+      "https://paperclip.tryblueprint.io/api/live-pipeline/task-evaluation-launches",
+    );
+    expect(await forwardTaskEvaluationLaunch({ request })).toMatchObject({
+      status: "forwarded", performed: true,
+    });
+  });
+
+  it("discovers and validates the immutable public catalog from Pipeline", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    process.env.ROBOT_EVAL_JOB_REQUEST_FORWARD_URL =
+      "https://paperclip.tryblueprint.io/api/live-pipeline/job-requests";
+    vi.stubGlobal("fetch", vi.fn(async (url: string) => {
+      expect(url).toBe(
+        "https://paperclip.tryblueprint.io/api/live-pipeline/task-evaluation-launch-profiles",
+      );
+      return new Response(JSON.stringify({
+        schema_version: "task_evaluation_launch_profile_catalog.v1",
+        profiles: [profile()],
+      }), { status: 200, headers: { "content-type": "application/json" } });
+    }));
+
+    expect(resolveTaskEvaluationProfileCatalogUrl()).toBe(
+      "https://paperclip.tryblueprint.io/api/live-pipeline/task-evaluation-launch-profiles",
+    );
+    expect(await resolvePublishedLaunchProfiles()).toEqual([profile()]);
   });
 
   it("rejects a terminal receipt whose digest was altered", () => {

--- a/server/utils/taskEvaluationLaunchContract.ts
+++ b/server/utils/taskEvaluationLaunchContract.ts
@@ -134,6 +134,18 @@ export function parseTaskEvaluationLaunchSupervision(value: unknown) {
 
 export type PublishedLaunchProfile = z.infer<typeof publishedLaunchProfileSchema>;
 
+function parsePublishedLaunchProfiles(value: unknown): PublishedLaunchProfile[] {
+  const result = z.array(publishedLaunchProfileSchema).safeParse(value);
+  if (!result.success) return [];
+  const seen = new Set<string>();
+  return result.data.filter((profile) => {
+    const key = `${profile.profile_id}:${profile.profile_digest}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
 export function loadPublishedLaunchProfiles(
   raw = process.env.TASK_EVALUATION_LAUNCH_PROFILES_JSON,
 ): PublishedLaunchProfile[] {
@@ -143,15 +155,73 @@ export function loadPublishedLaunchProfiles(
   } catch {
     return [];
   }
-  const result = z.array(publishedLaunchProfileSchema).safeParse(parsed);
-  if (!result.success) return [];
-  const seen = new Set<string>();
-  return result.data.filter((profile) => {
-    const key = `${profile.profile_id}:${profile.profile_digest}`;
-    if (seen.has(key)) return false;
-    seen.add(key);
-    return true;
-  });
+  return parsePublishedLaunchProfiles(parsed);
+}
+
+function derivePipelineEndpoint(pathname: string): string {
+  const configured = String(process.env.ROBOT_EVAL_JOB_REQUEST_FORWARD_URL || "").trim();
+  if (!configured) return "";
+  try {
+    const url = new URL(configured);
+    if (url.protocol !== "https:" && process.env.NODE_ENV === "production") return "";
+    if (!url.pathname.endsWith("/api/live-pipeline/job-requests")) return "";
+    url.pathname = pathname;
+    url.search = "";
+    url.hash = "";
+    return url.toString();
+  } catch {
+    return "";
+  }
+}
+
+export function resolveTaskEvaluationLaunchUrl(): string {
+  return String(
+    process.env.TASK_EVALUATION_LAUNCH_URL
+      || derivePipelineEndpoint("/api/live-pipeline/task-evaluation-launches"),
+  ).trim();
+}
+
+export function resolveTaskEvaluationProfileCatalogUrl(): string {
+  const configured = String(process.env.TASK_EVALUATION_LAUNCH_PROFILES_URL || "").trim();
+  if (configured) return configured;
+  const launchUrl = resolveTaskEvaluationLaunchUrl();
+  if (!launchUrl) return "";
+  try {
+    const url = new URL(launchUrl);
+    url.pathname = "/api/live-pipeline/task-evaluation-launch-profiles";
+    url.search = "";
+    url.hash = "";
+    return url.toString();
+  } catch {
+    return "";
+  }
+}
+
+export async function resolvePublishedLaunchProfiles(): Promise<PublishedLaunchProfile[]> {
+  const configured = loadPublishedLaunchProfiles();
+  if (configured.length > 0) return configured;
+  const endpoint = resolveTaskEvaluationProfileCatalogUrl();
+  if (!endpoint) return [];
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10_000);
+  try {
+    const response = await fetch(endpoint, {
+      method: "GET",
+      headers: { accept: "application/json" },
+      signal: controller.signal,
+    });
+    if (!response.ok) return [];
+    const payload = await response.json().catch(() => null);
+    if (
+      !payload
+      || payload.schema_version !== "task_evaluation_launch_profile_catalog.v1"
+    ) return [];
+    return parsePublishedLaunchProfiles(payload.profiles);
+  } catch {
+    return [];
+  } finally {
+    clearTimeout(timeout);
+  }
 }
 
 export function buildTaskEvaluationLaunchRequest(params: {
@@ -211,7 +281,7 @@ export async function forwardTaskEvaluationLaunch(params: {
   clientId?: string;
 }): Promise<LaunchForwardResult> {
   const endpoint = String(
-    params.endpointUrl || process.env.TASK_EVALUATION_LAUNCH_URL || "",
+    params.endpointUrl || resolveTaskEvaluationLaunchUrl(),
   ).trim();
   const required = process.env.NODE_ENV === "production"
     || String(process.env.TASK_EVALUATION_LAUNCH_FORWARD_REQUIRED || "").toLowerCase() === "true";
@@ -220,7 +290,10 @@ export async function forwardTaskEvaluationLaunch(params: {
     endpoint_configured: false, blocker: "task_evaluation_launch_url_missing",
   };
   const token = String(
-    params.token || process.env.TASK_EVALUATION_RUN_FORWARD_TOKEN || "",
+    params.token
+      || process.env.TASK_EVALUATION_RUN_FORWARD_TOKEN
+      || process.env.ROBOT_EVAL_JOB_REQUEST_FORWARD_TOKEN
+      || "",
   ).trim();
   if (!token) return {
     status: "blocked", performed: false, required,


### PR DESCRIPTION
## Outcome

Closes the remaining production configuration drift between the deployed WebApp Task Evaluation control room and the Pipeline-owned immutable profile registry.

- derives the Task Evaluation launch URL from the already canonical robot-eval Pipeline endpoint when no narrower override exists
- reuses the existing Pipeline HMAC secret rather than requiring a second manually synchronized secret
- fetches the non-secret public profile descriptor catalog from Pipeline when no immutable inline catalog override is configured
- validates every fetched descriptor with the same strict schema before it can enter an authorization record
- fails closed to an empty catalog on transport, schema, or endpoint failure

This remains ADP-009D development-only infrastructure. It does not enable GPU execution or change claim ceilings.

## Verification

- `npx vitest run server/tests/task-evaluation-launch-contract.test.ts server/tests/admin-task-evaluation-launches.test.ts` — 8 passed; covers endpoint/token reuse, HMAC binding, catalog validation, durable authority, and exact-profile forwarding
- `npm run check` — passed; full TypeScript contract
- `npm audit --omit=dev` — 0 vulnerabilities
- `git diff --check` — passed
- `bash scripts/graphify/run-webapp-architecture-pilot.sh --no-viz` — corpus staging succeeded, graph publication unavailable because the local `graphifyy` Python package is not installed; no graph outputs changed

No provider mutation, Firestore write, production request, secret rotation, or deploy was performed by these checks.