### PR TITLE
Require the canonical Pipeline launch secret

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -216,8 +216,7 @@ Agent-side creative MCP note:
 - `PIPELINE_SYNC_TOKEN`
 - Production Task Evaluation launch bridge:
   - `TASK_EVALUATION_LAUNCH_URL=https://<pipeline-host>/api/live-pipeline/task-evaluation-launches`; optional when `ROBOT_EVAL_JOB_REQUEST_FORWARD_URL` is the canonical Pipeline `/job-requests` endpoint
-  - `TASK_EVALUATION_RUN_FORWARD_TOKEN` matching the Pipeline intake HMAC client secret; optional when the canonical `ROBOT_EVAL_JOB_REQUEST_FORWARD_TOKEN` is already configured
-  - `TASK_EVALUATION_RUN_FORWARD_CLIENT_ID=blueprint-webapp`
+  - the launch bridge always reuses `ROBOT_EVAL_JOB_REQUEST_FORWARD_TOKEN` and the fixed `blueprint-webapp` client identity; task-specific token overrides are not accepted
   - `TASK_EVALUATION_LAUNCH_FORWARD_REQUIRED=true`
   - `BLUEPRINT_TASK_EVALUATION_LAUNCH_FORWARD_WORKER_ENABLED=true` on the Render worker so a crash between the durable Firestore write and signed Pipeline POST is recovered
   - `TASK_EVALUATION_LAUNCH_FORWARD_MAX_ATTEMPTS=20` bounds intake-transport retries; these are idempotent queue deliveries and never authorize a paid GPU retry

--- a/render.required.env.example
+++ b/render.required.env.example
@@ -91,8 +91,10 @@ CHECKOUT_ALLOWED_ORIGINS=https://www.tryblueprint.io,https://tryblueprint.io
 ########################################
 
 PIPELINE_SYNC_TOKEN=
-# Optional overrides. When unset, the Task Evaluation bridge derives its endpoint
-# from ROBOT_EVAL_JOB_REQUEST_FORWARD_URL and reuses that canonical HMAC token.
+# Optional endpoint override. The Task Evaluation launch bridge always reuses
+# ROBOT_EVAL_JOB_REQUEST_FORWARD_TOKEN and the fixed blueprint-webapp client ID.
+# TASK_EVALUATION_RUN_FORWARD_* remains for the separate prepare/authorize/run
+# control endpoints and is never launch authority.
 TASK_EVALUATION_LAUNCH_URL=
 TASK_EVALUATION_RUN_FORWARD_TOKEN=
 TASK_EVALUATION_RUN_FORWARD_CLIENT_ID=blueprint-webapp

--- a/server/tests/admin-task-evaluation-launches.test.ts
+++ b/server/tests/admin-task-evaluation-launches.test.ts
@@ -138,7 +138,7 @@ beforeEach(() => {
   state.records.clear();
   process.env.TASK_EVALUATION_LAUNCH_PROFILES_JSON = JSON.stringify([profile()]);
   process.env.TASK_EVALUATION_LAUNCH_URL = "https://pipeline.example/launches";
-  process.env.TASK_EVALUATION_RUN_FORWARD_TOKEN = "forward-secret";
+  process.env.ROBOT_EVAL_JOB_REQUEST_FORWARD_TOKEN = "forward-secret";
   vi.stubGlobal("fetch", vi.fn(async (url: string, init?: RequestInit) => {
     if (url.startsWith("http://127.0.0.1:")) {
       return realFetch(url, init);
@@ -164,7 +164,7 @@ afterEach(() => {
   vi.unstubAllGlobals();
   delete process.env.TASK_EVALUATION_LAUNCH_PROFILES_JSON;
   delete process.env.TASK_EVALUATION_LAUNCH_URL;
-  delete process.env.TASK_EVALUATION_RUN_FORWARD_TOKEN;
+  delete process.env.ROBOT_EVAL_JOB_REQUEST_FORWARD_TOKEN;
 });
 
 describe("admin Task Evaluation launch route", () => {

--- a/server/tests/task-evaluation-launch-contract.test.ts
+++ b/server/tests/task-evaluation-launch-contract.test.ts
@@ -142,6 +142,7 @@ describe("Task Evaluation production launch contract", () => {
     process.env.ROBOT_EVAL_JOB_REQUEST_FORWARD_URL =
       "https://paperclip.tryblueprint.io/api/live-pipeline/job-requests";
     process.env.ROBOT_EVAL_JOB_REQUEST_FORWARD_TOKEN = "canonical-forward-secret";
+    process.env.TASK_EVALUATION_RUN_FORWARD_TOKEN = "deprecated-noncanonical-secret";
     const request = buildTaskEvaluationLaunchRequest({
       input: input(), profile: profile(), actorId: "founder-001", actorRole: "admin",
       authorizedAt: "2026-08-10T12:00:00.000Z",

--- a/server/utils/taskEvaluationLaunchContract.ts
+++ b/server/utils/taskEvaluationLaunchContract.ts
@@ -291,7 +291,6 @@ export async function forwardTaskEvaluationLaunch(params: {
   };
   const token = String(
     params.token
-      || process.env.TASK_EVALUATION_RUN_FORWARD_TOKEN
       || process.env.ROBOT_EVAL_JOB_REQUEST_FORWARD_TOKEN
       || "",
   ).trim();
@@ -300,7 +299,7 @@ export async function forwardTaskEvaluationLaunch(params: {
     endpoint_configured: true, blocker: "task_evaluation_launch_forward_token_missing",
   };
   const clientId = String(
-    params.clientId || process.env.TASK_EVALUATION_RUN_FORWARD_CLIENT_ID || "blueprint-webapp",
+    params.clientId || "blueprint-webapp",
   ).trim();
   const body = JSON.stringify(params.request);
   const timestamp = new Date().toISOString();


### PR DESCRIPTION
## Outcome

Removes the final secret-selection ambiguity from the production Task Evaluation launch path.

The launch forwarder now always uses ROBOT_EVAL_JOB_REQUEST_FORWARD_TOKEN and the fixed blueprint-webapp HMAC client identity. A stale or accidentally configured TASK_EVALUATION_RUN_FORWARD_TOKEN can no longer redirect launch signing authority. The latter remains limited to the separate prepare/authorize/run control endpoints.

## Verification

- focused launch contract and admin route tests: 8 passed
- TypeScript check: passed
- production dependency audit: 0 vulnerabilities
- required graphify refresh was attempted but the isolated worktree lacks the graphifyy Python package; the command made no tracked changes

No external mutation or deployment was performed by these checks.