### PR TITLE
Bind launch callbacks to the canonical Pipeline secret

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -221,7 +221,9 @@ Agent-side creative MCP note:
   - `BLUEPRINT_TASK_EVALUATION_LAUNCH_FORWARD_WORKER_ENABLED=true` on the Render worker so a crash between the durable Firestore write and signed Pipeline POST is recovered
   - `TASK_EVALUATION_LAUNCH_FORWARD_MAX_ATTEMPTS=20` bounds intake-transport retries; these are idempotent queue deliveries and never authorize a paid GPU retry
   - `TASK_EVALUATION_LAUNCH_PROFILES_JSON` set to the exact descriptor catalog emitted by Pipeline's `publish_task_evaluation_launch_profiles.py`, or leave it empty so the server fetches and validates Pipeline's public `/api/live-pipeline/task-evaluation-launch-profiles` descriptor catalog; `TASK_EVALUATION_LAUNCH_PROFILES_URL` is an optional explicit catalog endpoint override
-  - `PIPELINE_SYNC_TOKEN` matching the Pipeline receipt publisher
+  - launch receipts and supervision callbacks use the same canonical
+    `ROBOT_EVAL_JOB_REQUEST_FORWARD_TOKEN`; no separate launch callback secret
+    is accepted
   - authenticated admin/ops control surface: `/ops/task-evaluation-launches`
 - `BLUEPRINT_REQUEST_REVIEW_TOKEN_SECRET`
 - Live robot-eval forwarding required for request acceptance:

--- a/render.required.env.example
+++ b/render.required.env.example
@@ -93,6 +93,8 @@ CHECKOUT_ALLOWED_ORIGINS=https://www.tryblueprint.io,https://tryblueprint.io
 PIPELINE_SYNC_TOKEN=
 # Optional endpoint override. The Task Evaluation launch bridge always reuses
 # ROBOT_EVAL_JOB_REQUEST_FORWARD_TOKEN and the fixed blueprint-webapp client ID.
+# Pipeline launch-receipt and supervision callbacks verify against that same
+# canonical secret; PIPELINE_SYNC_TOKEN continues to govern unrelated sync APIs.
 # TASK_EVALUATION_RUN_FORWARD_* remains for the separate prepare/authorize/run
 # control endpoints and is never launch authority.
 TASK_EVALUATION_LAUNCH_URL=

--- a/server/routes/internal-task-evaluation-launches.ts
+++ b/server/routes/internal-task-evaluation-launches.ts
@@ -11,7 +11,9 @@ const router = Router();
 const rateLimiter = createPipelineSyncRateLimiter();
 
 function requirePipelineSignature(req: Request, res: Response, next: () => void) {
-  const result = verifyPipelineSyncRequest(req);
+  const result = verifyPipelineSyncRequest(req, {
+    expectedSecret: process.env.ROBOT_EVAL_JOB_REQUEST_FORWARD_TOKEN,
+  });
   if (!result.ok) return res.status(result.status).json({
     error: result.message,
     code: result.code,

--- a/server/tests/pipeline-sync-security.test.ts
+++ b/server/tests/pipeline-sync-security.test.ts
@@ -58,6 +58,30 @@ describe("pipeline sync security", () => {
     ).toMatchObject({ ok: true });
   });
 
+  it("can bind a scoped callback to an explicit canonical secret", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-10T18:00:00.000Z"));
+    process.env.PIPELINE_SYNC_TOKEN = "unrelated-sync-secret";
+    const body = { schema_version: "task_evaluation_launch_receipt.v1" };
+    const timestamp = "2026-08-10T18:00:00.000Z";
+    const signature = buildPipelineSyncSignature({
+      secret: "canonical-launch-secret",
+      timestamp,
+      body: JSON.stringify(body),
+    });
+    const request = requestWithHeaders({ body, timestamp, signature });
+
+    expect(verifyPipelineSyncRequest(request)).toMatchObject({
+      ok: false,
+      code: "invalid_pipeline_sync_signature",
+    });
+    expect(
+      verifyPipelineSyncRequest(request, {
+        expectedSecret: "canonical-launch-secret",
+      }),
+    ).toMatchObject({ ok: true });
+  });
+
   it("builds nonce-bound signatures for Pipeline intake forwarding", () => {
     const body = JSON.stringify({ schema_version: "v1", job_id: "job-1" });
     const signature = buildPipelineSyncSignature({

--- a/server/utils/pipelineSyncSecurity.ts
+++ b/server/utils/pipelineSyncSecurity.ts
@@ -43,8 +43,15 @@ export function buildPipelineSyncSignature(args: {
     .digest("hex");
 }
 
-export function verifyPipelineSyncRequest(req: Request): PipelineSyncAuthResult {
-  const expected = String(process.env.PIPELINE_SYNC_TOKEN || "").trim();
+export function verifyPipelineSyncRequest(
+  req: Request,
+  options: { expectedSecret?: string } = {},
+): PipelineSyncAuthResult {
+  const expected = String(
+    options.expectedSecret === undefined
+      ? process.env.PIPELINE_SYNC_TOKEN || ""
+      : options.expectedSecret,
+  ).trim();
   if (!expected) {
     return {
       ok: false,


### PR DESCRIPTION
## Outcome

Closes the terminal-receipt deployment blocker found by a live non-mutating authentication probe: production has no separate PIPELINE_SYNC_TOKEN configured.

Only the Task Evaluation launch receipt and optional supervisor callback routes now verify against the existing canonical ROBOT_EVAL_JOB_REQUEST_FORWARD_TOKEN. Unrelated Pipeline sync routes continue to require their existing PIPELINE_SYNC_TOKEN policy. The Pipeline host can therefore sign both directions of this one launch contract with the already matched canonical bridge secret, without adding or guessing another production secret.

## Verification

- focused launch, admin route, and sync-security tests: 14 passed
- TypeScript check: passed
- production dependency audit: 0 vulnerabilities
- required graphify refresh was attempted; the isolated worktree lacks graphifyy and no tracked graph output changed

No provider, Firestore, or deployment mutation was performed by these checks.