### PR TITLE
Harden production task evaluation launch forwarding

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,8 @@
 name: Deploy (Render, CI-gated)
 
-# Single deploy owner for blueprint-webapp: render.yaml keeps Render-native
-# auto-deploy OFF, and this workflow is the only path to production.
+# Single deploy owner for Blueprint-WebApp and blueprint-webapp-worker:
+# render.yaml keeps Render-native auto-deploy OFF, and this workflow is the
+# only path to production for both exact-SHA identities.
 #
 # Guarantees:
 #   * Only an exact commit whose CI workflow concluded `success` on main can
@@ -15,7 +16,8 @@ name: Deploy (Render, CI-gated)
 #
 # One-time dashboard steps (documented in docs/runbooks/ci-gated-deploy-2026-07-16.md):
 #   1. Store a Render API key as the RENDER_API_KEY Actions secret.
-#   2. Store the service ID as the RENDER_SERVICE_ID Actions variable.
+#   2. Store the web and worker service IDs as the RENDER_SERVICE_ID and
+#      RENDER_WORKER_SERVICE_ID Actions variables.
 #   3. Confirm Auto-Deploy is off after this workflow is proven operational.
 
 on:
@@ -95,6 +97,7 @@ jobs:
         env:
           RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
           RENDER_SERVICE_ID: ${{ vars.RENDER_SERVICE_ID }}
+          RENDER_WORKER_SERVICE_ID: ${{ vars.RENDER_WORKER_SERVICE_ID }}
           DEPLOY_REF: ${{ steps.ref.outputs.deploy_ref }}
           CLEAR_CACHE: ${{ github.event.inputs.clear_cache }}
         run: |
@@ -103,13 +106,16 @@ jobs:
             echo "::error::RENDER_API_KEY secret is not set. Deploys fail closed. See docs/runbooks/ci-gated-deploy-2026-07-16.md."
             exit 1
           fi
-          case "${RENDER_SERVICE_ID:-}" in
-            srv-*) ;;
-            *)
-              echo "::error::RENDER_SERVICE_ID Actions variable is missing or invalid."
-              exit 1
-              ;;
-          esac
+          for service_var in RENDER_SERVICE_ID RENDER_WORKER_SERVICE_ID; do
+            service_id="${!service_var:-}"
+            case "${service_id}" in
+              srv-*) ;;
+              *)
+                echo "::error::${service_var} Actions variable is missing or invalid."
+                exit 1
+                ;;
+            esac
+          done
           # Only an explicit workflow_dispatch opt-in clears the cache; the
           # automatic post-CI path keeps the fast default.
           if [ "${CLEAR_CACHE:-false}" = "true" ]; then
@@ -119,37 +125,50 @@ jobs:
           fi
           echo "Render build cache: ${clear_cache_value}"
           payload=$(printf '{"commitId":"%s","clearCache":"%s"}' "${DEPLOY_REF}" "${clear_cache_value}")
-          response_code=$(curl -s -o /tmp/render-deploy-response.txt -w "%{http_code}" \
-            --request POST \
-            --header "Authorization: Bearer ${RENDER_API_KEY}" \
-            --header "Content-Type: application/json" \
-            --data "${payload}" \
-            "https://api.render.com/v1/services/${RENDER_SERVICE_ID}/deploys")
-          echo "Render deploy API responded ${response_code}"
-          if [ "${response_code}" -lt 200 ] || [ "${response_code}" -ge 300 ]; then
-            echo "::error::Render deploy API returned HTTP ${response_code}."
-            cat /tmp/render-deploy-response.txt || true
-            exit 1
-          fi
-          deploy_id=$(node -e '
-            const fs = require("node:fs");
-            const response = JSON.parse(fs.readFileSync("/tmp/render-deploy-response.txt", "utf8"));
-            if (typeof response.id !== "string" || !response.id.startsWith("dep-")) process.exit(1);
-            process.stdout.write(response.id);
-          ')
-          if [ -z "${deploy_id}" ]; then
-            echo "::error::Render accepted the request but did not return a deploy ID."
-            exit 1
-          fi
-          echo "deploy_id=${deploy_id}" >> "${GITHUB_OUTPUT}"
-          echo "Render accepted deploy ${deploy_id} for ${DEPLOY_REF}. API acceptance is NOT deployment success; the verify step below is the gate."
+          trigger_deploy() {
+            service_id="$1"
+            label="$2"
+            response_path="/tmp/render-${label}-deploy-response.json"
+            response_code=$(curl -s -o "${response_path}" -w "%{http_code}" \
+              --request POST \
+              --header "Authorization: Bearer ${RENDER_API_KEY}" \
+              --header "Content-Type: application/json" \
+              --data "${payload}" \
+              "https://api.render.com/v1/services/${service_id}/deploys")
+            echo "Render ${label} deploy API responded ${response_code}"
+            if [ "${response_code}" -lt 200 ] || [ "${response_code}" -ge 300 ]; then
+              echo "::error::Render ${label} deploy API returned HTTP ${response_code}."
+              cat "${response_path}" || true
+              exit 1
+            fi
+            TRIGGERED_DEPLOY_ID=$(node -e '
+              const fs = require("node:fs");
+              const response = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+              if (typeof response.id !== "string" || !response.id.startsWith("dep-")) process.exit(1);
+              process.stdout.write(response.id);
+            ' "${response_path}")
+            if [ -z "${TRIGGERED_DEPLOY_ID}" ]; then
+              echo "::error::Render accepted the ${label} request but did not return a deploy ID."
+              exit 1
+            fi
+            echo "Render accepted ${label} deploy ${TRIGGERED_DEPLOY_ID} for ${DEPLOY_REF}."
+          }
+          trigger_deploy "${RENDER_SERVICE_ID}" web
+          web_deploy_id="${TRIGGERED_DEPLOY_ID}"
+          trigger_deploy "${RENDER_WORKER_SERVICE_ID}" worker
+          worker_deploy_id="${TRIGGERED_DEPLOY_ID}"
+          echo "web_deploy_id=${web_deploy_id}" >> "${GITHUB_OUTPUT}"
+          echo "worker_deploy_id=${worker_deploy_id}" >> "${GITHUB_OUTPUT}"
+          echo "API acceptance is NOT deployment success; both exact-SHA deploy records are verified below."
 
       - name: Verify deployment completed at the exact SHA
         env:
           DEPLOY_REF: ${{ steps.ref.outputs.deploy_ref }}
-          RENDER_DEPLOY_ID: ${{ steps.render.outputs.deploy_id }}
+          RENDER_WEB_DEPLOY_ID: ${{ steps.render.outputs.web_deploy_id }}
+          RENDER_WORKER_DEPLOY_ID: ${{ steps.render.outputs.worker_deploy_id }}
           RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
           RENDER_SERVICE_ID: ${{ vars.RENDER_SERVICE_ID }}
+          RENDER_WORKER_SERVICE_ID: ${{ vars.RENDER_WORKER_SERVICE_ID }}
           BASE_URL: https://tryblueprint.io
         run: |
           set -euo pipefail
@@ -157,37 +176,58 @@ jobs:
           evidence=/tmp/deploy-evidence/deploy-verification.json
           started_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
-          # Poll Render's deploy record first so build/update failures surface
-          # directly rather than looking like a generic live-SHA timeout.
-          deploy_status=""
-          for attempt in $(seq 1 80); do
-            if ! response_code=$(curl -s -o /tmp/deploy-evidence/render-deploy.json -w "%{http_code}" \
-              --max-time 20 \
-              --header "Authorization: Bearer ${RENDER_API_KEY}" \
-              "https://api.render.com/v1/services/${RENDER_SERVICE_ID}/deploys/${RENDER_DEPLOY_ID}"); then
-              response_code=000
+          # Poll both Render deploy records so the web and independent worker
+          # must become live at the same exact commit before production is
+          # called deployed.
+          wait_for_deploy() {
+            label="$1"
+            service_id="$2"
+            deploy_id="$3"
+            response_path="/tmp/deploy-evidence/render-${label}-deploy.json"
+            DEPLOY_STATUS=""
+            DEPLOY_COMMIT=""
+            for attempt in $(seq 1 80); do
+              if ! response_code=$(curl -s -o "${response_path}" -w "%{http_code}" \
+                --max-time 20 \
+                --header "Authorization: Bearer ${RENDER_API_KEY}" \
+                "https://api.render.com/v1/services/${service_id}/deploys/${deploy_id}"); then
+                response_code=000
+              fi
+              if [ "${response_code}" = "200" ]; then
+                deploy_fields=$(node -e '
+                  const fs = require("node:fs");
+                  const response = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+                  const status = typeof response.status === "string" ? response.status : "";
+                  const commit = typeof response.commit?.id === "string" ? response.commit.id : "";
+                  process.stdout.write(`${status}\t${commit}`);
+                ' "${response_path}")
+                IFS=$'\t' read -r DEPLOY_STATUS DEPLOY_COMMIT <<< "${deploy_fields}"
+              fi
+              case "${DEPLOY_STATUS}" in
+                live) break ;;
+                build_failed|update_failed|canceled|deactivated)
+                  echo "::error::Render ${label} deploy ${deploy_id} ended with status ${DEPLOY_STATUS}."
+                  exit 1
+                  ;;
+              esac
+              echo "${label} attempt ${attempt}/80: status='${DEPLOY_STATUS:-unreachable}'. Waiting 15s."
+              sleep 15
+            done
+            if [ "${DEPLOY_STATUS}" != "live" ]; then
+              echo "::error::Render ${label} deploy ${deploy_id} did not become live after 20 minutes."
+              exit 1
             fi
-            if [ "${response_code}" = "200" ]; then
-              deploy_status=$(node -e '
-                const fs = require("node:fs");
-                const response = JSON.parse(fs.readFileSync("/tmp/deploy-evidence/render-deploy.json", "utf8"));
-                process.stdout.write(typeof response.status === "string" ? response.status : "");
-              ')
+            if [ "${DEPLOY_COMMIT}" != "${DEPLOY_REF}" ]; then
+              echo "::error::Render ${label} deploy is live at '${DEPLOY_COMMIT:-unknown}', expected ${DEPLOY_REF}."
+              exit 1
             fi
-            case "${deploy_status}" in
-              live) break ;;
-              build_failed|update_failed|canceled|deactivated)
-                echo "::error::Render deploy ${RENDER_DEPLOY_ID} ended with status ${deploy_status}."
-                exit 1
-                ;;
-            esac
-            echo "Attempt ${attempt}/80: Render deploy status='${deploy_status:-unreachable}'. Waiting 15s."
-            sleep 15
-          done
-          if [ "${deploy_status}" != "live" ]; then
-            echo "::error::Render deploy ${RENDER_DEPLOY_ID} did not become live after 20 minutes."
-            exit 1
-          fi
+          }
+          wait_for_deploy web "${RENDER_SERVICE_ID}" "${RENDER_WEB_DEPLOY_ID}"
+          web_deploy_status="${DEPLOY_STATUS}"
+          web_deploy_commit="${DEPLOY_COMMIT}"
+          wait_for_deploy worker "${RENDER_WORKER_SERVICE_ID}" "${RENDER_WORKER_DEPLOY_ID}"
+          worker_deploy_status="${DEPLOY_STATUS}"
+          worker_deploy_commit="${DEPLOY_COMMIT}"
 
           # Poll GET /version.json until the exact requested SHA is serving
           # traffic. Timeout: 20 minutes.
@@ -213,8 +253,8 @@ jobs:
           health_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 20 "${BASE_URL}/health")
           ready_code=$(curl -s -o /tmp/deploy-evidence/health-ready-body.json -w "%{http_code}" --max-time 20 "${BASE_URL}/health/ready")
           finished_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-          printf '{"render_deploy_id":"%s","render_deploy_status":"%s","deploy_ref":"%s","live_git_sha":"%s","health_status":%s,"health_ready_status":%s,"started_at":"%s","finished_at":"%s"}\n' \
-            "${RENDER_DEPLOY_ID}" "${deploy_status}" "${DEPLOY_REF}" "${deployed_sha}" "${health_code}" "${ready_code}" "${started_at}" "${finished_at}" > "${evidence}"
+          printf '{"web_render_deploy_id":"%s","web_render_deploy_status":"%s","web_render_commit":"%s","worker_render_deploy_id":"%s","worker_render_deploy_status":"%s","worker_render_commit":"%s","deploy_ref":"%s","live_git_sha":"%s","health_status":%s,"health_ready_status":%s,"started_at":"%s","finished_at":"%s"}\n' \
+            "${RENDER_WEB_DEPLOY_ID}" "${web_deploy_status}" "${web_deploy_commit}" "${RENDER_WORKER_DEPLOY_ID}" "${worker_deploy_status}" "${worker_deploy_commit}" "${DEPLOY_REF}" "${deployed_sha}" "${health_code}" "${ready_code}" "${started_at}" "${finished_at}" > "${evidence}"
           cat "${evidence}"
           if [ "${health_code}" != "200" ]; then
             echo "::error::GET /health returned ${health_code}; expected 200."

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -56,20 +56,22 @@ npm start
 The repo now includes [render.yaml](/Users/nijelhunt_1/workspace/Blueprint-WebApp/render.yaml) for the primary alpha deployment path.
 
 - Build command: `npm ci && npm run build`
-- Start command: `npm start`
+- Web start command: `npm start`
+- Independent worker start command: `npm run start:worker`
 - Health check: `/health/ready`
 - Render `autoDeploy` is disabled in `render.yaml`. GitHub Actions owns
   deploy-on-green through `.github/workflows/deploy.yml`.
 - The deploy workflow runs only after the full `CI` workflow succeeds on
   `main`. It calls Render's authenticated deploy API with the exact green
-  commit SHA, waits for that deploy to become live, then verifies
-  `/version.json`, `/health`, and `/health/ready`.
+  commit SHA for both services, waits for both deploy records to become live
+  at that SHA, then verifies `/version.json`, `/health`, and `/health/ready`.
 
 Render should hold all application secrets in the service environment, not in
 `render.yaml`. GitHub Actions holds the Render control-plane credential as the
-`RENDER_API_KEY` secret and the production service identifier as the
-`RENDER_SERVICE_ID` repository variable. If either is missing or invalid, the
-deploy job fails closed instead of allowing a red or unverified push to deploy.
+`RENDER_API_KEY` secret and the production service identifiers as the
+`RENDER_SERVICE_ID` and `RENDER_WORKER_SERVICE_ID` repository variables. If
+any is missing or invalid, the deploy job fails closed instead of deploying a
+partial control stack or allowing a red or unverified push to deploy.
 
 ## Required Environment Variables
 
@@ -218,6 +220,10 @@ Agent-side creative MCP note:
   - `TASK_EVALUATION_LAUNCH_URL=https://<pipeline-host>/api/live-pipeline/task-evaluation-launches`; optional when `ROBOT_EVAL_JOB_REQUEST_FORWARD_URL` is the canonical Pipeline `/job-requests` endpoint
   - the launch bridge always reuses `ROBOT_EVAL_JOB_REQUEST_FORWARD_TOKEN` and the fixed `blueprint-webapp` client identity; task-specific token overrides are not accepted
   - `TASK_EVALUATION_LAUNCH_FORWARD_REQUIRED=true`
+  - `TASK_EVALUATION_LAUNCH_STORE_TIMEOUT_MS=15000` bounds each launch-critical
+    Firestore operation; an ambiguous write returns `persistence_state=unknown`
+    and the admin UI recovers by polling the same launch ID rather than creating
+    a second authority record
   - `BLUEPRINT_TASK_EVALUATION_LAUNCH_FORWARD_WORKER_ENABLED=true` on the Render worker so a crash between the durable Firestore write and signed Pipeline POST is recovered
   - `TASK_EVALUATION_LAUNCH_FORWARD_MAX_ATTEMPTS=20` bounds intake-transport retries; these are idempotent queue deliveries and never authorize a paid GPU retry
   - `TASK_EVALUATION_LAUNCH_PROFILES_JSON` set to the exact descriptor catalog emitted by Pipeline's `publish_task_evaluation_launch_profiles.py`, or leave it empty so the server fetches and validates Pipeline's public `/api/live-pipeline/task-evaluation-launch-profiles` descriptor catalog; `TASK_EVALUATION_LAUNCH_PROFILES_URL` is an optional explicit catalog endpoint override

--- a/client/src/pages/AdminTaskEvaluationLaunches.tsx
+++ b/client/src/pages/AdminTaskEvaluationLaunches.tsx
@@ -18,6 +18,20 @@ type LaunchProfile = {
   claim_ceiling: string;
 };
 
+async function fetchWithTimeout(
+  input: RequestInfo | URL,
+  init: RequestInit = {},
+  timeoutMs = 20_000,
+) {
+  const controller = new AbortController();
+  const timeout = window.setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(input, { ...init, signal: controller.signal });
+  } finally {
+    window.clearTimeout(timeout);
+  }
+}
+
 export default function AdminTaskEvaluationLaunches() {
   const { currentUser } = useAuth();
   const [profiles, setProfiles] = useState<LaunchProfile[]>([]);
@@ -34,6 +48,7 @@ export default function AdminTaskEvaluationLaunches() {
   const [supervision, setSupervision] = useState<Record<string, any> | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  const [recoveringSubmission, setRecoveringSubmission] = useState(false);
 
   const selected = useMemo(
     () => profiles.find((profile) => `${profile.profile_id}:${profile.profile_digest}` === profileKey),
@@ -53,14 +68,14 @@ export default function AdminTaskEvaluationLaunches() {
 
   async function loadProfiles() {
     if (!currentUser) return;
-    const response = await fetch("/api/admin/task-evaluation-launches/profiles", {
+    const response = await fetchWithTimeout("/api/admin/task-evaluation-launches/profiles", {
       headers: await authHeaders(),
       credentials: "include",
     });
     if (!response.ok) throw new Error("Published Pipeline launch profiles are unavailable");
     const payload = await response.json();
     setProfiles(payload.profiles || []);
-    const supervisionResponse = await fetch(
+    const supervisionResponse = await fetchWithTimeout(
       "/api/admin/task-evaluation-launches/supervision",
       { headers: await authHeaders(), credentials: "include" },
     );
@@ -69,11 +84,21 @@ export default function AdminTaskEvaluationLaunches() {
 
   async function refreshStatus(id = launchId) {
     if (!currentUser || !id) return;
-    const response = await fetch(`/api/admin/task-evaluation-launches/${encodeURIComponent(id)}`, {
+    const response = await fetchWithTimeout(`/api/admin/task-evaluation-launches/${encodeURIComponent(id)}`, {
       headers: await authHeaders(),
       credentials: "include",
     });
-    if (response.ok) setStatus(await response.json());
+    if (response.ok) {
+      setStatus(await response.json());
+      setRecoveringSubmission(false);
+      setError(null);
+      return true;
+    }
+    if (response.status !== 404) {
+      const payload = await response.json().catch(() => ({}));
+      throw new Error(payload.error || "Task Evaluation launch status is unavailable");
+    }
+    return false;
   }
 
   useEffect(() => {
@@ -81,19 +106,23 @@ export default function AdminTaskEvaluationLaunches() {
   }, [currentUser]);
 
   useEffect(() => {
-    if (!launchId || !status || ["completed", "blocked", "dry_run_completed"].includes(status.state)) {
+    if (
+      !launchId
+      || (!status && !recoveringSubmission)
+      || ["completed", "blocked", "dry_run_completed"].includes(status?.state)
+    ) {
       return undefined;
     }
     const timer = window.setInterval(() => void refreshStatus(), 5000);
     return () => window.clearInterval(timer);
-  }, [launchId, status?.state, currentUser]);
+  }, [launchId, status?.state, currentUser, recoveringSubmission]);
 
   async function submit() {
     if (!selected) return;
     setSubmitting(true);
     setError(null);
     try {
-      const response = await fetch("/api/admin/task-evaluation-launches", {
+      const response = await fetchWithTimeout("/api/admin/task-evaluation-launches", {
         method: "POST",
         headers: await authHeaders(true),
         credentials: "include",
@@ -108,11 +137,24 @@ export default function AdminTaskEvaluationLaunches() {
         }),
       });
       const payload = await response.json();
+      if (!response.ok && payload.persistence_state === "unknown") {
+        setStatus(null);
+        setRecoveringSubmission(true);
+        setError("Launch persistence is still being resolved. Checking this exact launch ID; do not create a new launch.");
+        await refreshStatus(launchId).catch(() => false);
+        return;
+      }
       setStatus(payload);
       if (!response.ok) throw new Error(payload.error || payload.forward?.blocker || "Launch was blocked");
       await refreshStatus(launchId);
     } catch (reason) {
-      setError(reason instanceof Error ? reason.message : "Launch was blocked");
+      if (reason instanceof Error && reason.name === "AbortError") {
+        setRecoveringSubmission(true);
+        setError("Launch submission timed out while persistence may still be completing. Checking this exact launch ID; do not create a new launch.");
+        await refreshStatus(launchId).catch(() => false);
+      } else {
+        setError(reason instanceof Error ? reason.message : "Launch was blocked");
+      }
     } finally {
       setSubmitting(false);
     }
@@ -202,9 +244,13 @@ export default function AdminTaskEvaluationLaunches() {
                 There are no automatic paid retries.</span>
             </label>
             <button type="button" onClick={() => void submit()}
-              disabled={!canSubmit || submitting}
+              disabled={!canSubmit || submitting || recoveringSubmission}
               className="w-full bg-stone-950 px-5 py-3 font-medium text-white disabled:cursor-not-allowed disabled:opacity-40">
-              {submitting ? "Queuing immutable launch…" : "Authorize and queue launch"}
+              {submitting
+                ? "Queuing immutable launch…"
+                : recoveringSubmission
+                  ? "Checking durable launch…"
+                  : "Authorize and queue launch"}
             </button>
           </div>
 

--- a/docs/runbooks/ci-gated-deploy-2026-07-16.md
+++ b/docs/runbooks/ci-gated-deploy-2026-07-16.md
@@ -1,6 +1,7 @@
 # CI-Gated Render Deploy — Runbook (2026-07-16)
 
-Blueprint-WebApp has exactly one deploy owner: `.github/workflows/deploy.yml`.
+Blueprint-WebApp and its independent launch-forward worker have exactly one
+deploy owner: `.github/workflows/deploy.yml`.
 Render-native auto-deploy is off (`render.yaml` `autoDeploy: false`).
 
 > **RESOLVED 2026-07-21 — deployment ownership is singular.** PR #419 merged as
@@ -28,17 +29,19 @@ security task is separate from deployment-owner activation.
    verify, tests + worktree-mutation guard, e2e, build + build-output tests +
    isolated local smoke).
 3. Only if CI concludes `success` does the `Deploy (Render, CI-gated)`
-   workflow fire, POSTing Render's authenticated deploy API with the exact
-   `workflow_run.head_sha` as `commitId`.
-4. Render builds and serves that commit. `GET /version.json` on the live site
+   workflow fire, POSTing Render's authenticated deploy API for both the web
+   and worker services with the exact `workflow_run.head_sha` as `commitId`.
+4. Both Render deploy records must become live at that exact commit. Then
+   `GET /version.json` on the live site
    reports the deployed `git_sha` (written by `scripts/generate-build-info.mjs`
    at build time) — verify it matches the green SHA.
 
 Fail-closed properties:
 
 - A red CI run never triggers the deploy job.
-- A missing `RENDER_API_KEY` secret or invalid `RENDER_SERVICE_ID` variable
-  errors the deploy job loudly; it never silently skips or falls back.
+- A missing `RENDER_API_KEY` secret or invalid `RENDER_SERVICE_ID` or
+  `RENDER_WORKER_SERVICE_ID` variable errors the deploy job loudly; it never
+  silently skips the independent worker or falls back.
 - No push to a non-main branch can deploy.
 
 ## One-time activation steps (Render + GitHub)
@@ -47,8 +50,8 @@ Completed on 2026-07-21:
 
 1. In GitHub: repo → Settings → Secrets and variables → Actions, add the
    Render control-plane key as secret `RENDER_API_KEY`.
-2. Add the production Render service ID as repository variable
-   `RENDER_SERVICE_ID`.
+2. Add the production Render web and worker service IDs as repository
+   variables `RENDER_SERVICE_ID` and `RENDER_WORKER_SERVICE_ID`.
 3. Merge the API-workflow change and observe one exact-SHA deploy complete with
    a green `deploy-verification` artifact.
 4. In Render: Service → Settings → set **Auto-Deploy** to **Off**. The

--- a/render.required.env.example
+++ b/render.required.env.example
@@ -103,6 +103,9 @@ TASK_EVALUATION_RUN_FORWARD_CLIENT_ID=blueprint-webapp
 TASK_EVALUATION_LAUNCH_FORWARD_REQUIRED=true
 BLUEPRINT_TASK_EVALUATION_LAUNCH_FORWARD_WORKER_ENABLED=true
 TASK_EVALUATION_LAUNCH_FORWARD_MAX_ATTEMPTS=20
+# Bound launch-critical Firestore calls. On timeout the exact launch ID remains
+# the recovery key and provider mutation is not inferred.
+TASK_EVALUATION_LAUNCH_STORE_TIMEOUT_MS=15000
 # Optional immutable inline override. When empty, the server reads the validated
 # public descriptor catalog from the canonical Pipeline endpoint.
 TASK_EVALUATION_LAUNCH_PROFILES_JSON=[]

--- a/render.yaml
+++ b/render.yaml
@@ -1,9 +1,9 @@
 services:
   - type: web
-    name: blueprint-webapp
+    name: Blueprint-WebApp
     runtime: node
-    plan: starter
-    region: oregon
+    plan: free
+    region: virginia
     # Deploys are CI-gated: .github/workflows/deploy.yml triggers the Render
     # deploy hook only for an exact commit whose CI run is green on main.
     # Keeping Render-native auto-deploy off means a red or unreviewed push can
@@ -30,7 +30,7 @@ services:
     name: blueprint-webapp-worker
     runtime: node
     plan: starter
-    region: oregon
+    region: virginia
     autoDeploy: false
     buildCommand: npm ci && npm run build
     startCommand: npm run start:worker

--- a/server/routes/admin-task-evaluation-launches.ts
+++ b/server/routes/admin-task-evaluation-launches.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 
 import { dbAdmin as db } from "../../client/src/lib/firebaseAdmin";
+import { logger } from "../logger";
 import { requireAdminRole } from "../middleware/requireAdminRole";
 import { resolveAccessContext } from "../utils/access-control";
 import {
@@ -9,6 +10,10 @@ import {
   resolvePublishedLaunchProfiles,
   taskEvaluationLaunchInputSchema,
 } from "../utils/taskEvaluationLaunchContract";
+import {
+  taskEvaluationLaunchStoreErrorCode,
+  withTaskEvaluationLaunchStoreTimeout,
+} from "../utils/taskEvaluationLaunchStore";
 
 const router = Router();
 const COLLECTION = "taskEvaluationLaunches";
@@ -66,7 +71,7 @@ router.post("/", async (req, res) => {
   };
   let priorRecord: Record<string, any> | null;
   try {
-    priorRecord = await db.runTransaction(async (transaction): Promise<Record<string, any> | null> => {
+    priorRecord = await withTaskEvaluationLaunchStoreTimeout(db.runTransaction(async (transaction): Promise<Record<string, any> | null> => {
       const snapshot = await transaction.get(ref);
       if (snapshot.exists) {
         const existing = snapshot.data() as Record<string, any>;
@@ -88,7 +93,7 @@ router.post("/", async (req, res) => {
       }
       transaction.create(ref, initialRecord);
       return null;
-    });
+    }));
   } catch (error) {
     if (error instanceof Error && error.message === "immutable_launch_conflict") {
       return res.status(409).json({
@@ -96,7 +101,20 @@ router.post("/", async (req, res) => {
         code: "task_evaluation_launch_immutable_conflict",
       });
     }
-    return res.status(503).json({ error: "Task Evaluation launch store is unavailable" });
+    const code = taskEvaluationLaunchStoreErrorCode(error);
+    logger.error({
+      code,
+      launchId: parsed.data.launch_id,
+      runId: parsed.data.run_id,
+    }, "Task Evaluation launch authority persistence failed");
+    return res.status(503).json({
+      error: "Task Evaluation launch store is unavailable",
+      code,
+      launch_id: parsed.data.launch_id,
+      persistence_state: "unknown",
+      retryable: true,
+      provider_mutation_performed_inside_web_request: false,
+    });
   }
   const replayed = priorRecord !== null;
   const request = priorRecord
@@ -136,13 +154,28 @@ router.post("/", async (req, res) => {
       ? "queued_dispatch_blocked"
       : "queued_in_pipeline"
     : "forward_blocked";
-  await ref.set({
-    state,
-    forward: forwarded,
-    forward_attempt_count: priorAttempts + 1,
-    forwarded_at_iso: forwarded.status === "forwarded" ? new Date().toISOString() : null,
-    updated_at_iso: new Date().toISOString(),
-  }, { merge: true });
+  try {
+    await withTaskEvaluationLaunchStoreTimeout(ref.set({
+      state,
+      forward: forwarded,
+      forward_attempt_count: priorAttempts + 1,
+      forwarded_at_iso: forwarded.status === "forwarded" ? new Date().toISOString() : null,
+      updated_at_iso: new Date().toISOString(),
+    }, { merge: true }));
+  } catch (error) {
+    const code = taskEvaluationLaunchStoreErrorCode(error);
+    logger.error({ code, launchId: request.launch_id, runId: request.run_id },
+      "Task Evaluation launch forward receipt persistence failed");
+    return res.status(503).json({
+      error: "Task Evaluation launch forward receipt store is unavailable",
+      code,
+      launch_id: request.launch_id,
+      request_digest: request.request_digest,
+      persistence_state: "forward_receipt_unknown",
+      retryable: true,
+      provider_mutation_performed_inside_web_request: false,
+    });
+  }
   res.set("Cache-Control", "no-store");
   return res.status(forwarded.status === "forwarded" ? 202 : 503).json({
     schema_version: "task_evaluation_launch_web_receipt.v1",
@@ -158,7 +191,17 @@ router.post("/", async (req, res) => {
 
 router.get("/supervision", async (_req, res) => {
   if (!db) return res.status(503).json({ error: "Task Evaluation supervision store is unavailable" });
-  const snapshot = await db.collection("taskEvaluationLaunchSupervision").doc("latest").get();
+  let snapshot;
+  try {
+    snapshot = await withTaskEvaluationLaunchStoreTimeout(
+      db.collection("taskEvaluationLaunchSupervision").doc("latest").get(),
+    );
+  } catch (error) {
+    return res.status(503).json({
+      error: "Task Evaluation supervision store is unavailable",
+      code: taskEvaluationLaunchStoreErrorCode(error),
+    });
+  }
   res.set("Cache-Control", "no-store");
   return res.json(snapshot.exists ? snapshot.data() : {
     schema_version: "task_evaluation_launch_supervision_status.v1",
@@ -168,7 +211,20 @@ router.get("/supervision", async (_req, res) => {
 
 router.get("/:launchId", async (req, res) => {
   if (!db) return res.status(503).json({ error: "Task Evaluation launch store is unavailable" });
-  const snapshot = await db.collection(COLLECTION).doc(req.params.launchId).get();
+  let snapshot;
+  try {
+    snapshot = await withTaskEvaluationLaunchStoreTimeout(
+      db.collection(COLLECTION).doc(req.params.launchId).get(),
+    );
+  } catch (error) {
+    return res.status(503).json({
+      error: "Task Evaluation launch store is unavailable",
+      code: taskEvaluationLaunchStoreErrorCode(error),
+      launch_id: req.params.launchId,
+      persistence_state: "unknown",
+      retryable: true,
+    });
+  }
   if (!snapshot.exists) return res.status(404).json({ error: "Task Evaluation launch not found" });
   res.set("Cache-Control", "no-store");
   return res.json(snapshot.data());

--- a/server/routes/health.ts
+++ b/server/routes/health.ts
@@ -2,7 +2,9 @@ import { Router, Request, Response } from "express";
 import { logger } from "../logger";
 import { getHostedSessionLiveStoreStatus } from "../utils/hosted-session-live-store";
 import { buildLaunchReadinessSnapshot } from "../utils/launch-readiness";
+import { isLocalLaunchSmokeProfile } from "../utils/launch-readiness";
 import { maybeAlertOnLaunchReadinessTransition } from "../utils/ops-alerts";
+import { probeTaskEvaluationLaunchStore } from "../utils/taskEvaluationLaunchStore";
 
 const router = Router();
 
@@ -50,7 +52,38 @@ router.get("/health/live", (_req: Request, res: Response) => {
  */
 router.get("/health/ready", async (req: Request, res: Response) => {
   try {
-    const readiness = buildLaunchReadinessSnapshot();
+    const baseReadiness = buildLaunchReadinessSnapshot();
+    const launchStore = isLocalLaunchSmokeProfile()
+      ? { ready: true, code: "local_smoke", checked_at_iso: new Date().toISOString() }
+      : await probeTaskEvaluationLaunchStore();
+    const launchStoreCheck = {
+      required: !isLocalLaunchSmokeProfile(),
+      ready: launchStore.ready,
+      detail: launchStore.ready
+        ? "Task Evaluation launch Firestore is reachable."
+        : `Task Evaluation launch Firestore probe failed (${launchStore.code}).`,
+    };
+    const readiness = {
+      ...baseReadiness,
+      status: baseReadiness.status === "ready" && launchStore.ready
+        ? ("ready" as const)
+        : ("not_ready" as const),
+      checks: {
+        ...baseReadiness.checks,
+        taskEvaluationLaunchStore: launchStore.ready,
+      },
+      blockers: launchStoreCheck.required && !launchStoreCheck.ready
+        ? [...baseReadiness.blockers, `taskEvaluationLaunchStore: ${launchStoreCheck.detail}`]
+        : baseReadiness.blockers,
+      dependencies: {
+        ...baseReadiness.dependencies,
+        taskEvaluationLaunchStore: launchStore,
+        launchChecks: {
+          ...baseReadiness.dependencies.launchChecks,
+          taskEvaluationLaunchStore: launchStoreCheck,
+        },
+      },
+    };
     await maybeAlertOnLaunchReadinessTransition(readiness);
     const statusCode = readiness.status === "ready" ? 200 : 503;
 

--- a/server/tests/admin-task-evaluation-launches.test.ts
+++ b/server/tests/admin-task-evaluation-launches.test.ts
@@ -10,6 +10,7 @@ const realFetch = globalThis.fetch.bind(globalThis);
 
 const state = vi.hoisted(() => ({
   records: new Map<string, Record<string, any>>(),
+  hangTransaction: false,
 }));
 
 vi.mock("../../client/src/lib/firebaseAdmin", () => {
@@ -28,17 +29,20 @@ vi.mock("../../client/src/lib/firebaseAdmin", () => {
   return {
     dbAdmin: {
       collection: () => ({ doc: reference }),
-      runTransaction: async <T>(callback: (transaction: any) => Promise<T>) => callback({
-        get: async (ref: ReturnType<typeof reference>) => ref.get(),
-        create: (ref: ReturnType<typeof reference>, payload: Record<string, unknown>) => {
-          state.records.set(ref.id, structuredClone(payload));
-        },
-        set: (ref: ReturnType<typeof reference>, payload: Record<string, unknown>, options?: { merge?: boolean }) => {
-          state.records.set(ref.id, options?.merge
-            ? { ...(state.records.get(ref.id) || {}), ...structuredClone(payload) }
-            : structuredClone(payload));
-        },
-      }),
+      runTransaction: async <T>(callback: (transaction: any) => Promise<T>) => {
+        if (state.hangTransaction) return new Promise<T>(() => undefined);
+        return callback({
+          get: async (ref: ReturnType<typeof reference>) => ref.get(),
+          create: (ref: ReturnType<typeof reference>, payload: Record<string, unknown>) => {
+            state.records.set(ref.id, structuredClone(payload));
+          },
+          set: (ref: ReturnType<typeof reference>, payload: Record<string, unknown>, options?: { merge?: boolean }) => {
+            state.records.set(ref.id, options?.merge
+              ? { ...(state.records.get(ref.id) || {}), ...structuredClone(payload) }
+              : structuredClone(payload));
+          },
+        });
+      },
     },
   };
 });
@@ -136,6 +140,7 @@ async function startInternalServer(): Promise<{ server: Server; url: string }> {
 
 beforeEach(() => {
   state.records.clear();
+  state.hangTransaction = false;
   process.env.TASK_EVALUATION_LAUNCH_PROFILES_JSON = JSON.stringify([profile()]);
   process.env.TASK_EVALUATION_LAUNCH_URL = "https://pipeline.example/launches";
   process.env.ROBOT_EVAL_JOB_REQUEST_FORWARD_TOKEN = "forward-secret";
@@ -165,9 +170,38 @@ afterEach(() => {
   delete process.env.TASK_EVALUATION_LAUNCH_PROFILES_JSON;
   delete process.env.TASK_EVALUATION_LAUNCH_URL;
   delete process.env.ROBOT_EVAL_JOB_REQUEST_FORWARD_TOKEN;
+  delete process.env.TASK_EVALUATION_LAUNCH_STORE_TIMEOUT_MS;
 });
 
 describe("admin Task Evaluation launch route", () => {
+  it("fails closed with an unknown persistence state when Firestore stalls", async () => {
+    state.hangTransaction = true;
+    process.env.TASK_EVALUATION_LAUNCH_STORE_TIMEOUT_MS = "250";
+    const { server, url } = await startServer();
+    try {
+      const response = await fetch(url, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(launchInput()),
+      });
+      const body = await response.json();
+      expect(response.status).toBe(503);
+      expect(body).toMatchObject({
+        code: "task_evaluation_launch_store_timeout",
+        launch_id: "launch-001",
+        persistence_state: "unknown",
+        retryable: true,
+        provider_mutation_performed_inside_web_request: false,
+      });
+      expect(state.records.size).toBe(0);
+      expect(vi.mocked(fetch).mock.calls.filter(([target]) =>
+        String(target).startsWith("https://pipeline.example/"),
+      )).toHaveLength(0);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
   it("durably records authority before forwarding the exact published profile", async () => {
     const { server, url } = await startServer();
     try {

--- a/server/tests/render-deploy-ci-contract.test.ts
+++ b/server/tests/render-deploy-ci-contract.test.ts
@@ -26,12 +26,27 @@ describe("Render deploy-on-green contract", () => {
     expect(deployWorkflow).toContain("WORKFLOW_RUN_SHA: ${{ github.event.workflow_run.head_sha }}");
     expect(deployWorkflow).toContain("RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}");
     expect(deployWorkflow).toContain("RENDER_SERVICE_ID: ${{ vars.RENDER_SERVICE_ID }}");
+    expect(deployWorkflow).toContain(
+      "RENDER_WORKER_SERVICE_ID: ${{ vars.RENDER_WORKER_SERVICE_ID }}",
+    );
     expect(deployWorkflow).toContain("RENDER_API_KEY secret is not set");
-    expect(deployWorkflow).toContain("RENDER_SERVICE_ID Actions variable is missing or invalid");
-    expect(deployWorkflow).toContain("https://api.render.com/v1/services/${RENDER_SERVICE_ID}/deploys");
+    expect(deployWorkflow).toContain(
+      "for service_var in RENDER_SERVICE_ID RENDER_WORKER_SERVICE_ID",
+    );
+    expect(deployWorkflow).toContain(
+      "https://api.render.com/v1/services/${service_id}/deploys",
+    );
+    expect(deployWorkflow).toContain(
+      'trigger_deploy "${RENDER_SERVICE_ID}" web',
+    );
+    expect(deployWorkflow).toContain(
+      'trigger_deploy "${RENDER_WORKER_SERVICE_ID}" worker',
+    );
     expect(deployWorkflow).toContain("commitId");
     expect(deployWorkflow).toContain("${DEPLOY_REF}");
-    expect(deployWorkflow).toContain("render-deploy.json");
+    expect(deployWorkflow).toContain("render-${label}-deploy.json");
+    expect(deployWorkflow).toContain("web_render_commit");
+    expect(deployWorkflow).toContain("worker_render_commit");
     expect(deployWorkflow).toContain('"${BASE_URL}/version.json"');
     expect(deployWorkflow).toContain('"${BASE_URL}/health/ready"');
 
@@ -40,5 +55,6 @@ describe("Render deploy-on-green contract", () => {
     expect(deploymentDoc).toContain("full `CI` workflow succeeds");
     expect(deploymentDoc).toContain("RENDER_API_KEY");
     expect(deploymentDoc).toContain("RENDER_SERVICE_ID");
+    expect(deploymentDoc).toContain("RENDER_WORKER_SERVICE_ID");
   });
 });

--- a/server/tests/task-evaluation-launch-store.test.ts
+++ b/server/tests/task-evaluation-launch-store.test.ts
@@ -1,0 +1,60 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  probeTaskEvaluationLaunchStore,
+  resetTaskEvaluationLaunchStoreReadinessCacheForTests,
+  taskEvaluationLaunchStoreErrorCode,
+  withTaskEvaluationLaunchStoreTimeout,
+} from "../utils/taskEvaluationLaunchStore";
+
+afterEach(() => {
+  resetTaskEvaluationLaunchStoreReadinessCacheForTests();
+});
+
+describe("Task Evaluation launch store boundary", () => {
+  it("returns a typed timeout instead of waiting for the Firestore retry horizon", async () => {
+    await expect(withTaskEvaluationLaunchStoreTimeout(
+      new Promise(() => undefined),
+      10,
+    )).rejects.toMatchObject({ code: "task_evaluation_launch_store_timeout" });
+  });
+
+  it("normalizes provider errors without exposing raw Firestore messages", () => {
+    expect(taskEvaluationLaunchStoreErrorCode({ code: 7, message: "sensitive" }))
+      .toBe("task_evaluation_launch_store_permission_denied");
+    expect(taskEvaluationLaunchStoreErrorCode({ code: 8 }))
+      .toBe("task_evaluation_launch_store_resource_exhausted");
+    expect(taskEvaluationLaunchStoreErrorCode(new Error("unknown")))
+      .toBe("task_evaluation_launch_store_unavailable");
+  });
+
+  it("probes and caches a successful Firestore read", async () => {
+    let reads = 0;
+    const firestore = {
+      collection: () => ({
+        doc: () => ({
+          get: async () => {
+            reads += 1;
+            return { exists: false };
+          },
+        }),
+      }),
+    };
+    const first = await probeTaskEvaluationLaunchStore({
+      firestore: firestore as never,
+      timeoutMs: 250,
+      cacheMs: 1_000,
+      now: () => 1_000,
+    });
+    const second = await probeTaskEvaluationLaunchStore({
+      firestore: firestore as never,
+      timeoutMs: 250,
+      cacheMs: 1_000,
+      now: () => 1_100,
+    });
+    expect(first).toMatchObject({ ready: true, code: "ok" });
+    expect(second).toEqual(first);
+    expect(reads).toBe(1);
+  });
+});

--- a/server/utils/taskEvaluationLaunchForwardWorker.ts
+++ b/server/utils/taskEvaluationLaunchForwardWorker.ts
@@ -5,6 +5,7 @@ import {
   forwardTaskEvaluationLaunch,
 } from "./taskEvaluationLaunchContract";
 import { canonicalArtifactDigest } from "./taskCandidateContract";
+import { withTaskEvaluationLaunchStoreTimeout } from "./taskEvaluationLaunchStore";
 
 const COLLECTION = "taskEvaluationLaunches";
 
@@ -93,7 +94,9 @@ export async function processTaskEvaluationLaunchForwardQueue(limit = 10) {
   if (!db) return { status: "blocked", blocker: "firestore_unavailable", processed: 0 };
   const docs: FirebaseFirestore.QueryDocumentSnapshot[] = [];
   for (const state of ["forward_pending", "forward_blocked"] as const) {
-    const snapshot = await db.collection(COLLECTION).where("state", "==", state).limit(limit).get();
+    const snapshot = await withTaskEvaluationLaunchStoreTimeout(
+      db.collection(COLLECTION).where("state", "==", state).limit(limit).get(),
+    );
     docs.push(...snapshot.docs);
     if (docs.length >= limit) break;
   }
@@ -102,10 +105,12 @@ export async function processTaskEvaluationLaunchForwardQueue(limit = 10) {
     const record = doc.data() as Record<string, any>;
     const result = await forwardStoredTaskEvaluationLaunch(record);
     if (result.skipped) continue;
-    await doc.ref.set({
-      ...result,
-      updated_at_iso: new Date().toISOString(),
-    }, { merge: true });
+    await withTaskEvaluationLaunchStoreTimeout(
+      doc.ref.set({
+        ...result,
+        updated_at_iso: new Date().toISOString(),
+      }, { merge: true }),
+    );
     processed += 1;
   }
   return { status: "completed", processed };
@@ -133,4 +138,3 @@ export function startTaskEvaluationLaunchForwardWorker() {
     clearInterval(interval);
   };
 }
-

--- a/server/utils/taskEvaluationLaunchStore.ts
+++ b/server/utils/taskEvaluationLaunchStore.ts
@@ -1,0 +1,128 @@
+import { dbAdmin } from "../../client/src/lib/firebaseAdmin";
+
+const DEFAULT_TIMEOUT_MS = 15_000;
+const DEFAULT_READINESS_CACHE_MS = 60_000;
+
+export class TaskEvaluationLaunchStoreTimeoutError extends Error {
+  readonly code = "task_evaluation_launch_store_timeout";
+
+  constructor() {
+    super("Task Evaluation launch store operation timed out");
+    this.name = "TaskEvaluationLaunchStoreTimeoutError";
+  }
+}
+
+function boundedPositiveInteger(value: unknown, fallback: number, maximum: number) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return Math.min(maximum, Math.max(250, Math.floor(parsed)));
+}
+
+export function taskEvaluationLaunchStoreTimeoutMs() {
+  return boundedPositiveInteger(
+    process.env.TASK_EVALUATION_LAUNCH_STORE_TIMEOUT_MS,
+    DEFAULT_TIMEOUT_MS,
+    60_000,
+  );
+}
+
+export async function withTaskEvaluationLaunchStoreTimeout<T>(
+  operation: Promise<T>,
+  timeoutMs = taskEvaluationLaunchStoreTimeoutMs(),
+): Promise<T> {
+  let timeout: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      operation,
+      new Promise<T>((_resolve, reject) => {
+        timeout = setTimeout(() => reject(new TaskEvaluationLaunchStoreTimeoutError()), timeoutMs);
+        timeout.unref?.();
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
+export function taskEvaluationLaunchStoreErrorCode(error: unknown) {
+  if (error instanceof TaskEvaluationLaunchStoreTimeoutError) return error.code;
+  const raw = String(
+    error && typeof error === "object" && "code" in error
+      ? (error as { code?: unknown }).code
+      : "",
+  ).trim().toLowerCase();
+  if (raw.includes("permission-denied") || raw === "7") {
+    return "task_evaluation_launch_store_permission_denied";
+  }
+  if (raw.includes("failed-precondition") || raw === "9") {
+    return "task_evaluation_launch_store_failed_precondition";
+  }
+  if (raw.includes("resource-exhausted") || raw === "8") {
+    return "task_evaluation_launch_store_resource_exhausted";
+  }
+  if (raw.includes("unavailable") || raw === "14") {
+    return "task_evaluation_launch_store_dependency_unavailable";
+  }
+  return "task_evaluation_launch_store_unavailable";
+}
+
+export type TaskEvaluationLaunchStoreReadiness = {
+  ready: boolean;
+  code: "ok" | string;
+  checked_at_iso: string;
+};
+
+let cachedReadiness: { expiresAt: number; value: TaskEvaluationLaunchStoreReadiness } | null = null;
+let readinessInFlight: Promise<TaskEvaluationLaunchStoreReadiness> | null = null;
+
+export async function probeTaskEvaluationLaunchStore(options: {
+  firestore?: typeof dbAdmin;
+  timeoutMs?: number;
+  cacheMs?: number;
+  now?: () => number;
+} = {}): Promise<TaskEvaluationLaunchStoreReadiness> {
+  const firestore = options.firestore === undefined ? dbAdmin : options.firestore;
+  const now = options.now || Date.now;
+  const currentTime = now();
+  if (cachedReadiness && cachedReadiness.expiresAt > currentTime) return cachedReadiness.value;
+  if (readinessInFlight) return readinessInFlight;
+  if (!firestore) return {
+    ready: false,
+    code: "task_evaluation_launch_store_not_configured",
+    checked_at_iso: new Date(currentTime).toISOString(),
+  };
+
+  const cacheMs = boundedPositiveInteger(
+    options.cacheMs ?? process.env.TASK_EVALUATION_LAUNCH_STORE_READINESS_CACHE_MS,
+    DEFAULT_READINESS_CACHE_MS,
+    5 * 60_000,
+  );
+  readinessInFlight = (async () => {
+    let value: TaskEvaluationLaunchStoreReadiness;
+    try {
+      await withTaskEvaluationLaunchStoreTimeout(
+        firestore.collection("__blueprintHealth").doc("task-evaluation-launch-store").get(),
+        options.timeoutMs,
+      );
+      value = { ready: true, code: "ok", checked_at_iso: new Date(now()).toISOString() };
+    } catch (error) {
+      value = {
+        ready: false,
+        code: taskEvaluationLaunchStoreErrorCode(error),
+        checked_at_iso: new Date(now()).toISOString(),
+      };
+    }
+    cachedReadiness = { expiresAt: now() + cacheMs, value };
+    return value;
+  })();
+  try {
+    return await readinessInFlight;
+  } finally {
+    readinessInFlight = null;
+  }
+}
+
+export function resetTaskEvaluationLaunchStoreReadinessCacheForTests() {
+  cachedReadiness = null;
+  readinessInFlight = null;
+}


### PR DESCRIPTION
## Outcome

Makes website-triggered Task Evaluation launches durable across Firestore stalls and web process restarts, and promotes an independently deployed launch-forward worker alongside the web identity.

## Production defect covered

- bounds Firestore reads and writes and returns typed unknown persistence state instead of hanging
- recovers ambiguous browser submissions by polling the exact immutable launch identity
- exposes a live Firestore readiness probe
- bounds worker queue and receipt persistence operations
- deploys and verifies exact WebApp and worker commit identities
- records both Render deploy identities in the deploy receipt

## Verification

- npm run check
- focused launch route, store, worker, and deploy contract tests: 24 passed, then 5 worker/store tests after the final timeout change
- npm run build
- YAML parse
- bash scripts/graphify/run-webapp-architecture-pilot.sh --no-viz
- git diff --check

No provider mutation or paid GPU launch is performed by this change.