### PR TITLE
Constrain production worker to launch forwarding

### DIFF
--- a/render.required.env.example
+++ b/render.required.env.example
@@ -14,10 +14,9 @@
 # This file is strict:
 # - the import script will fail if any value is empty
 #
-# SCALE2-02: import this manifest into BOTH Render services —
-# blueprint-webapp (web) AND blueprint-webapp-worker (background worker).
-# The worker runs the ops automation scheduler and the Stripe webhook
-# queue processor and needs the same Firebase/Stripe/Redis/Notion env.
+# Import only the worker-required subset into blueprint-webapp-worker. The
+# production worker is launch-forward-only and must not enable unrelated ops
+# automation or the Stripe queue processor.
 #
 # Import with:
 #   RENDER_API_KEY=... RENDER_SERVICE_ID=... npm run render:import-env -- render.required.env.example
@@ -102,6 +101,7 @@ TASK_EVALUATION_RUN_FORWARD_TOKEN=
 TASK_EVALUATION_RUN_FORWARD_CLIENT_ID=blueprint-webapp
 TASK_EVALUATION_LAUNCH_FORWARD_REQUIRED=true
 BLUEPRINT_TASK_EVALUATION_LAUNCH_FORWARD_WORKER_ENABLED=true
+BLUEPRINT_TASK_EVALUATION_LAUNCH_FORWARD_ONLY_WORKER=true
 TASK_EVALUATION_LAUNCH_FORWARD_MAX_ATTEMPTS=20
 # Bound launch-critical Firestore calls. On timeout the exact launch ID remains
 # the recovery key and provider mutation is not inferred.

--- a/render.yaml
+++ b/render.yaml
@@ -13,19 +13,12 @@ services:
     startCommand: npm start
     healthCheckPath: /health/ready
 
-  # Dedicated background worker (SCALE2-02): runs the ops automation
-  # scheduler (and the Stripe webhook queue processor) out of the web
-  # process so batch work never shares an event loop with live HTTP traffic.
-  # The ops automation leader lease stays active inside the worker, so
-  # scaling this service beyond one instance (or temporarily opting the web
-  # process back in with BLUEPRINT_RUN_OPS_AUTOMATION_IN_WEB=1) can never
-  # double-run automation lanes.
+  # Dedicated production launch-forward worker. This deployment is explicitly
+  # constrained to Task Evaluation launch reconciliation; unrelated ops and
+  # Stripe queue processors stay off in this service.
   #
-  # Env vars: this service needs the same environment as blueprint-webapp
-  # (Firebase service account, Stripe keys, Redis URL, Notion/SendGrid/Slack
-  # tokens — see render.required.env.example / render.optional.env.example).
-  # Env is dashboard-managed for this blueprint; import the same env group
-  # into both services.
+  # Env vars are dashboard-managed. The worker needs Firebase Admin plus the
+  # canonical Pipeline forward URL/token and launch-forward controls.
   - type: worker
     name: blueprint-webapp-worker
     runtime: node
@@ -34,3 +27,6 @@ services:
     autoDeploy: false
     buildCommand: npm ci && npm run build
     startCommand: npm run start:worker
+    envVars:
+      - key: BLUEPRINT_TASK_EVALUATION_LAUNCH_FORWARD_ONLY_WORKER
+        value: "true"

--- a/server/tests/worker-entrypoint.test.ts
+++ b/server/tests/worker-entrypoint.test.ts
@@ -14,9 +14,15 @@ import { afterEach, describe, expect, it, vi } from "vitest";
  */
 
 const startOpsAutomationScheduler = vi.hoisted(() => vi.fn());
+const startStripeWebhookQueueProcessor = vi.hoisted(() => vi.fn());
+const startTaskEvaluationLaunchForwardWorker = vi.hoisted(() => vi.fn());
 const validateEnv = vi.hoisted(() => vi.fn(() => ({})));
 
 vi.mock("../utils/opsAutomationScheduler", () => ({ startOpsAutomationScheduler }));
+vi.mock("../utils/stripeWebhookQueue", () => ({ startStripeWebhookQueueProcessor }));
+vi.mock("../utils/taskEvaluationLaunchForwardWorker", () => ({
+  startTaskEvaluationLaunchForwardWorker,
+}));
 vi.mock("../config/env", () => ({ validateEnv }));
 vi.mock("../logger", () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
@@ -26,24 +32,49 @@ vi.mock("../logger", () => ({
 const repoRoot = join(__dirname, "..", "..");
 
 afterEach(() => {
+  delete process.env.BLUEPRINT_TASK_EVALUATION_LAUNCH_FORWARD_ONLY_WORKER;
   vi.clearAllMocks();
 });
 
 describe("worker entrypoint", () => {
   it("boots the scheduler through validateEnv and stops it exactly once", async () => {
     const stopScheduler = vi.fn();
+    const stopQueueProcessor = vi.fn();
+    const stopLaunchForwarder = vi.fn();
     startOpsAutomationScheduler.mockReturnValue(stopScheduler);
+    startStripeWebhookQueueProcessor.mockReturnValue(stopQueueProcessor);
+    startTaskEvaluationLaunchForwardWorker.mockReturnValue(stopLaunchForwarder);
 
     const { startWorker } = await import("../worker");
     const handle = startWorker();
 
     expect(validateEnv).toHaveBeenCalled();
     expect(startOpsAutomationScheduler).toHaveBeenCalledTimes(1);
+    expect(startStripeWebhookQueueProcessor).toHaveBeenCalledTimes(1);
+    expect(startTaskEvaluationLaunchForwardWorker).toHaveBeenCalledTimes(1);
     expect(stopScheduler).not.toHaveBeenCalled();
 
     await handle.stop();
     await handle.stop();
     expect(stopScheduler).toHaveBeenCalledTimes(1);
+    expect(stopQueueProcessor).toHaveBeenCalledTimes(1);
+    expect(stopLaunchForwarder).toHaveBeenCalledTimes(1);
+  });
+
+  it("can run the Task Evaluation launch forwarder without unrelated workers", async () => {
+    process.env.BLUEPRINT_TASK_EVALUATION_LAUNCH_FORWARD_ONLY_WORKER = "true";
+    const stopLaunchForwarder = vi.fn();
+    startTaskEvaluationLaunchForwardWorker.mockReturnValue(stopLaunchForwarder);
+
+    const { startWorker } = await import("../worker");
+    const handle = startWorker();
+
+    expect(startTaskEvaluationLaunchForwardWorker).toHaveBeenCalledTimes(1);
+    expect(startOpsAutomationScheduler).not.toHaveBeenCalled();
+    expect(startStripeWebhookQueueProcessor).not.toHaveBeenCalled();
+
+    await handle.stop();
+    expect(stopLaunchForwarder).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/server/worker.ts
+++ b/server/worker.ts
@@ -20,6 +20,13 @@ import { startOpsAutomationScheduler } from "./utils/opsAutomationScheduler";
 import { startStripeWebhookQueueProcessor } from "./utils/stripeWebhookQueue";
 import { startTaskEvaluationLaunchForwardWorker } from "./utils/taskEvaluationLaunchForwardWorker";
 
+const launchForwardOnly = () =>
+  ["1", "true", "yes", "on"].includes(
+    String(
+      process.env.BLUEPRINT_TASK_EVALUATION_LAUNCH_FORWARD_ONLY_WORKER || "",
+    ).trim().toLowerCase(),
+  );
+
 export type WorkerHandle = {
   stop: () => Promise<void>;
 };
@@ -27,12 +34,23 @@ export type WorkerHandle = {
 export function startWorker(): WorkerHandle {
   validateEnv();
 
+  const taskEvaluationLaunchOnly = launchForwardOnly();
+
   logger.info(
-    attachRequestMeta({ route: "worker" }),
-    "Blueprint worker starting: ops automation scheduler + Stripe webhook queue processor",
+    attachRequestMeta({
+      route: "worker",
+      taskEvaluationLaunchOnly,
+    }),
+    taskEvaluationLaunchOnly
+      ? "Blueprint worker starting: Task Evaluation launch forwarder only"
+      : "Blueprint worker starting: ops automation scheduler + Stripe webhook queue processor + Task Evaluation launch forwarder",
   );
-  const stopScheduler = startOpsAutomationScheduler();
-  const stopQueueProcessor = startStripeWebhookQueueProcessor();
+  const stopScheduler = taskEvaluationLaunchOnly
+    ? () => undefined
+    : startOpsAutomationScheduler();
+  const stopQueueProcessor = taskEvaluationLaunchOnly
+    ? () => undefined
+    : startStripeWebhookQueueProcessor();
   const stopTaskEvaluationLaunchForwarder = startTaskEvaluationLaunchForwardWorker();
 
   let stopped = false;


### PR DESCRIPTION
## Outcome

Makes the new production background worker serve only the authorized Task Evaluation launch-forward reconciliation lane.

## Reason

The general worker entrypoint also starts unrelated ops automation and the Stripe webhook queue. Production logs showed those lanes activating when the worker was first deployed. This change adds an explicit fail-closed launch-forward-only mode and declares it in Render configuration.

## Verification

- worker entrypoint, launch forwarder, and Render deploy contract tests: 8 passed
- npm run check
- npm run build
- required Graphify architecture pilot
- git diff --check

The worker is suspended until this exact change is merged and deployed; the public web process remains healthy.