### PR TITLE
Add temporary Task Evaluation launch-lab access

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -230,7 +230,17 @@ Agent-side creative MCP note:
   - launch receipts and supervision callbacks use the same canonical
     `ROBOT_EVAL_JOB_REQUEST_FORWARD_TOKEN`; no separate launch callback secret
     is accepted
-  - authenticated admin/ops control surface: `/ops/task-evaluation-launches`
+  - normal authenticated admin/ops control surface: `/ops/task-evaluation-launches`
+  - temporary launch-lab mode may remove repeated Firebase sign-in for only this
+    route by setting `BLUEPRINT_TASK_EVALUATION_LAUNCH_LAB_ENABLED=true` and a
+    random, at-least-32-byte `BLUEPRINT_TASK_EVALUATION_LAUNCH_LAB_TOKEN` on the
+    Web service. Open the page once with the token in the URL fragment:
+    `/ops/task-evaluation-launches#launch-access=<token>`. The fragment is not
+    sent in HTTP requests and is cleared into tab-scoped session storage. This
+    bypass does not apply to any other admin route and does not bypass CSRF,
+    immutable profile selection, rights/spend authority, the canonical Pipeline
+    allocator, retry cap, watchdog, teardown, artifact, or provider-zero gates.
+    Unset both variables after the end-to-end launch path is stable.
 - `BLUEPRINT_REQUEST_REVIEW_TOKEN_SECRET`
 - Live robot-eval forwarding required for request acceptance:
   - `ROBOT_EVAL_JOB_REQUEST_FORWARD_URL`

--- a/client/src/app/routes.tsx
+++ b/client/src/app/routes.tsx
@@ -366,7 +366,9 @@ export const appRoutes: AppRoute[] = [
   { path: "/ops/evidence", layout: "protected", requireRoles: ADMIN_ROLES, component: AdminLeads },
   { path: "/ops/handoff", layout: "protected", requireRoles: ADMIN_ROLES, component: AdminLeads },
   { path: "/ops/spend", layout: "protected", requireRoles: ADMIN_ROLES, component: AdminCompanyMetrics },
-  { path: "/ops/task-evaluation-launches", layout: "protected", requireRoles: ADMIN_ROLES, component: AdminTaskEvaluationLaunches },
+  // Temporary launch-lab access is enforced server-side by a deployment-gated
+  // bearer capability; the page itself does not require Firebase sign-in.
+  { path: "/ops/task-evaluation-launches", layout: "public", component: AdminTaskEvaluationLaunches },
 
   // 404
   { layout: "public", component: NotFound },

--- a/client/src/lib/taskEvaluationLaunchLabAccess.test.ts
+++ b/client/src/lib/taskEvaluationLaunchLabAccess.test.ts
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  resolveTaskEvaluationLaunchLabToken,
+  TASK_EVALUATION_LAUNCH_LAB_HEADER,
+  withTaskEvaluationLaunchLabHeader,
+} from "./taskEvaluationLaunchLabAccess";
+
+describe("Task Evaluation launch-lab browser access", () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    window.history.replaceState({}, "", "/ops/task-evaluation-launches");
+  });
+
+  it("moves a fragment token into tab-scoped storage and clears the URL", () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/ops/task-evaluation-launches#launch-access=temporary-token",
+    );
+
+    expect(resolveTaskEvaluationLaunchLabToken()).toBe("temporary-token");
+    expect(window.location.hash).toBe("");
+    expect(resolveTaskEvaluationLaunchLabToken()).toBe("temporary-token");
+  });
+
+  it("adds the scoped header only when temporary access is present", () => {
+    expect(withTaskEvaluationLaunchLabHeader("token", { existing: "yes" })).toEqual({
+      existing: "yes",
+      [TASK_EVALUATION_LAUNCH_LAB_HEADER]: "token",
+    });
+    expect(withTaskEvaluationLaunchLabHeader("", { existing: "yes" })).toEqual({
+      existing: "yes",
+    });
+  });
+});
+

--- a/client/src/lib/taskEvaluationLaunchLabAccess.ts
+++ b/client/src/lib/taskEvaluationLaunchLabAccess.ts
@@ -1,0 +1,31 @@
+export const TASK_EVALUATION_LAUNCH_LAB_HEADER = "X-Blueprint-Launch-Lab-Token";
+const TOKEN_SESSION_KEY = "blueprint.task-evaluation-launch-lab-token";
+const TOKEN_FRAGMENT_KEY = "launch-access";
+
+export function resolveTaskEvaluationLaunchLabToken(): string {
+  if (typeof window === "undefined") return "";
+
+  const fragment = new URLSearchParams(window.location.hash.replace(/^#/, ""));
+  const fragmentToken = String(fragment.get(TOKEN_FRAGMENT_KEY) || "").trim();
+  if (fragmentToken) {
+    window.sessionStorage.setItem(TOKEN_SESSION_KEY, fragmentToken);
+    window.history.replaceState(
+      window.history.state,
+      "",
+      `${window.location.pathname}${window.location.search}`,
+    );
+    return fragmentToken;
+  }
+
+  return String(window.sessionStorage.getItem(TOKEN_SESSION_KEY) || "").trim();
+}
+
+export function withTaskEvaluationLaunchLabHeader(
+  token: string,
+  headers: Record<string, string>,
+): Record<string, string> {
+  return token
+    ? { ...headers, [TASK_EVALUATION_LAUNCH_LAB_HEADER]: token }
+    : headers;
+}
+

--- a/client/src/pages/AdminTaskEvaluationLaunches.tsx
+++ b/client/src/pages/AdminTaskEvaluationLaunches.tsx
@@ -4,6 +4,10 @@ import { AlertTriangle, CheckCircle2, RefreshCw, ShieldCheck } from "lucide-reac
 import { useAuth } from "@/contexts/AuthContext";
 import { withCsrfHeader } from "@/lib/csrf";
 import { withFirebaseAuthHeaders } from "@/lib/firebaseAuthHeaders";
+import {
+  resolveTaskEvaluationLaunchLabToken,
+  withTaskEvaluationLaunchLabHeader,
+} from "@/lib/taskEvaluationLaunchLabAccess";
 
 type LaunchProfile = {
   profile_id: string;
@@ -34,6 +38,7 @@ async function fetchWithTimeout(
 
 export default function AdminTaskEvaluationLaunches() {
   const { currentUser } = useAuth();
+  const [launchLabToken] = useState(resolveTaskEvaluationLaunchLabToken);
   const [profiles, setProfiles] = useState<LaunchProfile[]>([]);
   const [profileKey, setProfileKey] = useState("");
   const [launchId, setLaunchId] = useState("");
@@ -60,14 +65,17 @@ export default function AdminTaskEvaluationLaunches() {
   );
 
   async function authHeaders(json = false) {
-    return withFirebaseAuthHeaders(
+    const headers = await withFirebaseAuthHeaders(
       currentUser,
       await withCsrfHeader(json ? { "content-type": "application/json" } : {}),
     );
+    return withTaskEvaluationLaunchLabHeader(launchLabToken, headers);
   }
 
   async function loadProfiles() {
-    if (!currentUser) return;
+    if (!currentUser && !launchLabToken) {
+      throw new Error("Temporary launch access is missing. Reopen the private launch-lab link.");
+    }
     const response = await fetchWithTimeout("/api/admin/task-evaluation-launches/profiles", {
       headers: await authHeaders(),
       credentials: "include",
@@ -83,7 +91,7 @@ export default function AdminTaskEvaluationLaunches() {
   }
 
   async function refreshStatus(id = launchId) {
-    if (!currentUser || !id) return;
+    if ((!currentUser && !launchLabToken) || !id) return;
     const response = await fetchWithTimeout(`/api/admin/task-evaluation-launches/${encodeURIComponent(id)}`, {
       headers: await authHeaders(),
       credentials: "include",
@@ -103,7 +111,7 @@ export default function AdminTaskEvaluationLaunches() {
 
   useEffect(() => {
     void loadProfiles().catch((reason) => setError(String(reason)));
-  }, [currentUser]);
+  }, [currentUser, launchLabToken]);
 
   useEffect(() => {
     if (
@@ -115,7 +123,7 @@ export default function AdminTaskEvaluationLaunches() {
     }
     const timer = window.setInterval(() => void refreshStatus(), 5000);
     return () => window.clearInterval(timer);
-  }, [launchId, status?.state, currentUser, recoveringSubmission]);
+  }, [launchId, status?.state, currentUser, launchLabToken, recoveringSubmission]);
 
   async function submit() {
     if (!selected) return;
@@ -176,6 +184,11 @@ export default function AdminTaskEvaluationLaunches() {
             Authorize one immutable Pipeline profile. The website queues it; the canonical allocator,
             watchdog, reconciler, artifact retention, teardown, and provider-zero contracts own execution.
           </p>
+          {launchLabToken ? (
+            <p className="mt-3 text-sm font-medium text-emerald-800">
+              Temporary launch-lab access is active. Firebase sign-in is not required in this tab.
+            </p>
+          ) : null}
         </header>
 
         <section className="grid gap-3 md:grid-cols-4">

--- a/server/middleware/verifyTaskEvaluationLaunchAccess.ts
+++ b/server/middleware/verifyTaskEvaluationLaunchAccess.ts
@@ -1,0 +1,67 @@
+import { timingSafeEqual } from "node:crypto";
+import type { NextFunction, Request, Response } from "express";
+
+import verifyFirebaseToken from "./verifyFirebaseToken";
+
+const TOKEN_HEADER = "x-blueprint-launch-lab-token";
+const MIN_TOKEN_BYTES = 32;
+
+function enabled(value: string | undefined): boolean {
+  return ["1", "true", "yes", "on"].includes(String(value || "").trim().toLowerCase());
+}
+
+function tokensMatch(received: string, expected: string): boolean {
+  const receivedBytes = Buffer.from(received, "utf8");
+  const expectedBytes = Buffer.from(expected, "utf8");
+  return receivedBytes.length === expectedBytes.length
+    && timingSafeEqual(receivedBytes, expectedBytes);
+}
+
+/**
+ * Temporary, deployment-gated access for the single Task Evaluation launch
+ * surface. It replaces repeated Firebase sign-in while leaving CSRF, profile,
+ * rights, spend, allocator, retry, teardown, and provider-zero controls intact.
+ */
+export default async function verifyTaskEvaluationLaunchAccess(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  const expected = String(
+    process.env.BLUEPRINT_TASK_EVALUATION_LAUNCH_LAB_TOKEN || "",
+  ).trim();
+  const receivedHeader = req.headers[TOKEN_HEADER];
+  const received = typeof receivedHeader === "string" ? receivedHeader.trim() : "";
+  const launchLabEnabled = enabled(
+    process.env.BLUEPRINT_TASK_EVALUATION_LAUNCH_LAB_ENABLED,
+  );
+
+  if (
+    launchLabEnabled
+    && Buffer.byteLength(expected, "utf8") >= MIN_TOKEN_BYTES
+    && received
+    && tokensMatch(received, expected)
+  ) {
+    const now = Math.floor(Date.now() / 1000);
+    res.locals.firebaseUser = {
+      uid: "temporary-task-evaluation-launch-lab",
+      aud: "blueprint-task-evaluation-launch-lab",
+      auth_time: now,
+      exp: now + 300,
+      firebase: { identities: {}, sign_in_provider: "custom" },
+      iat: now,
+      iss: "blueprint-task-evaluation-launch-lab",
+      ops: true,
+      role: "ops",
+      roles: ["ops"],
+      sub: "temporary-task-evaluation-launch-lab",
+      temporaryLaunchLab: true,
+    };
+    res.set("Cache-Control", "no-store");
+    res.set("X-Blueprint-Launch-Lab-Mode", "temporary");
+    return next();
+  }
+
+  return verifyFirebaseToken(req, res, next);
+}
+

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -66,6 +66,7 @@ import clientRuntimeConfigAdminRouter, {
   clientRuntimeConfigPublicHandler,
 } from "./routes/client-runtime-config";
 import adminTaskEvaluationLaunchesRouter from "./routes/admin-task-evaluation-launches";
+import verifyTaskEvaluationLaunchAccess from "./middleware/verifyTaskEvaluationLaunchAccess";
 
 export function registerRoutes(app: Express) {
   app.use(appleAssociationRouter);
@@ -202,7 +203,7 @@ export function registerRoutes(app: Express) {
   app.use(
     "/api/admin/task-evaluation-launches",
     csrfProtection,
-    verifyFirebaseToken,
+    verifyTaskEvaluationLaunchAccess,
     adminTaskEvaluationLaunchesRouter,
   );
   app.use(

--- a/server/tests/task-evaluation-launch-access.test.ts
+++ b/server/tests/task-evaluation-launch-access.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment node
+import express from "express";
+import { createServer, type Server } from "node:http";
+import { afterEach, describe, expect, it } from "vitest";
+
+import verifyTaskEvaluationLaunchAccess from "../middleware/verifyTaskEvaluationLaunchAccess";
+
+const TOKEN = "temporary-launch-lab-token-0123456789abcdef";
+
+async function startServer(): Promise<{ server: Server; url: string }> {
+  const app = express();
+  app.use(verifyTaskEvaluationLaunchAccess);
+  app.get("/", (_req, res) => res.json({ user: res.locals.firebaseUser }));
+  const server = createServer(app);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("server address unavailable");
+  return { server, url: `http://127.0.0.1:${address.port}` };
+}
+
+afterEach(() => {
+  delete process.env.BLUEPRINT_TASK_EVALUATION_LAUNCH_LAB_ENABLED;
+  delete process.env.BLUEPRINT_TASK_EVALUATION_LAUNCH_LAB_TOKEN;
+});
+
+describe("temporary Task Evaluation launch-lab access", () => {
+  it("grants a scoped ops identity only for the exact configured token", async () => {
+    process.env.BLUEPRINT_TASK_EVALUATION_LAUNCH_LAB_ENABLED = "true";
+    process.env.BLUEPRINT_TASK_EVALUATION_LAUNCH_LAB_TOKEN = TOKEN;
+    const { server, url } = await startServer();
+    try {
+      const response = await fetch(url, {
+        headers: { "X-Blueprint-Launch-Lab-Token": TOKEN },
+      });
+      expect(response.status).toBe(200);
+      expect(response.headers.get("x-blueprint-launch-lab-mode")).toBe("temporary");
+      expect(await response.json()).toMatchObject({
+        user: {
+          uid: "temporary-task-evaluation-launch-lab",
+          ops: true,
+          roles: ["ops"],
+          temporaryLaunchLab: true,
+        },
+      });
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it.each([
+    ["disabled", false, TOKEN],
+    ["wrong token", true, `${TOKEN}-wrong`],
+    ["short configured token", true, "too-short"],
+  ])("fails back to normal Firebase auth when %s", async (_label, enabled, token) => {
+    process.env.BLUEPRINT_TASK_EVALUATION_LAUNCH_LAB_ENABLED = String(enabled);
+    process.env.BLUEPRINT_TASK_EVALUATION_LAUNCH_LAB_TOKEN =
+      token === "too-short" ? token : TOKEN;
+    const { server, url } = await startServer();
+    try {
+      const response = await fetch(url, {
+        headers: { "X-Blueprint-Launch-Lab-Token": token },
+      });
+      expect(response.status).toBe(401);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+});
+


### PR DESCRIPTION
## Outcome
Adds a temporary, deployment-gated private link for the Task Evaluation launch page so the launch flow can be repeated without Firebase sign-in during production qualification.

## Control boundary
- The browser moves the URL-fragment token into tab-scoped session storage and removes it from the address bar.
- Only `/api/admin/task-evaluation-launches` accepts the capability header.
- CSRF, immutable profile selection, rights/spend authority, canonical Pipeline allocator, retry caps, watchdog, teardown, artifact, and provider-zero gates remain unchanged.
- Normal Firebase authentication remains the fallback and the launch-lab mode is disabled unless two explicit production environment variables are set.

## Verification
- `npm exec vitest run server/tests/task-evaluation-launch-access.test.ts client/src/lib/taskEvaluationLaunchLabAccess.test.ts client/src/pages/AdminTaskEvaluationLaunches.test.tsx` (6 focused access tests passed; the optional page filename is absent from collection)
- `npm run check` (full TypeScript contract)
- `npm run build` (production bundle)
- `npm run graphify` with isolated graphifyy dependency (architecture graph completed; three documented pre-existing parser warnings)
- `git diff --check`
